### PR TITLE
sof-skl_hda: remove volume setting in enable/disable sequences

### DIFF
--- a/ucm/sof-skl_hda_card/HiFi.conf
+++ b/ucm/sof-skl_hda_card/HiFi.conf
@@ -18,7 +18,6 @@ SectionDevice."Headphone" {
 
 	EnableSequence [
 		cdev "hw:sofsklhdacard"
-		cset "name='Headphone Playback Volume' 80"
 		cset "name='Headphone Playback Switch' on"
 	]
 
@@ -43,7 +42,6 @@ SectionDevice."Speaker" {
 	EnableSequence [
 		cdev "hw:sofsklhdacard"
 		cset "name='Speaker Playback Switch' on"
-		cset "name='Speaker Playback Volume' 80"
 	]
 
 	DisableSequence [
@@ -88,7 +86,6 @@ SectionDevice."Dmic" {
 
 	EnableSequence [
 		cdev "hw:sofsklhdacard"
-		cset "name='PGA10.0 10 Master Capture Volume' 75"
 	]
 
 	DisableSequence [


### PR DESCRIPTION
If the volume setting is defined in enable sequence you will
always get that exact volume when switching outputs in some
user space software like Pulseaudio. Pulseaudio will itself
keep track of the volume previously set.

Signed-off-by: Jaska Uimonen <jaska.uimonen@linux.intel.com>