### PR TITLE
sof-skl_hda: add device definition to speaker disable sequence

### DIFF
--- a/ucm/sof-skl_hda_card/HiFi.conf
+++ b/ucm/sof-skl_hda_card/HiFi.conf
@@ -45,6 +45,7 @@ SectionDevice."Speaker" {
 	]
 
 	DisableSequence [
+		cdev "hw:sofsklhdacard"
 		cset "name='Speaker Playback Switch' off"
 	]
 


### PR DESCRIPTION
For example Pulseaudio is not able to run the disable sequence
if the device is not defined. So add the definition.

Signed-off-by: Jaska Uimonen <jaska.uimonen@linux.intel.com>