### PR TITLE
[RFC] sof-skl_hda: change to use common HDMI codec driver

### DIFF
--- a/ucm/sof-skl_hda_card/HiFi.conf
+++ b/ucm/sof-skl_hda_card/HiFi.conf
@@ -112,20 +112,18 @@ SectionDevice."HDMI1" {
 
 	EnableSequence [
 		cdev "hw:sofsklhdacard"
-		cset "name='hif5-0 Jack Switch' on"
-		cset "name='Pin5-Port0 Mux' 1"
+		cset "name='IEC958 Playback Switch' on"
 	]
 
 	DisableSequence [
 		cdev "hw:sofsklhdacard"
-		cset "name='Pin5-Port0 Mux' 0"
-		cset "name='hif5-0 Jack Switch' off"
+		cset "name='IEC958 Playback Switch' off"
 	]
 
 	Value {
-		PlaybackPCM "hw:0,3"
+		PlaybackPCM "hw:sofsklhdacard,3"
 		PlaybackChannels "2"
-		JackControl "HDMI/DP, pcm=11 Jack"
+		JackControl "HDMI/DP,pcm=3 Jack"
 	}
 }
 
@@ -134,20 +132,18 @@ SectionDevice."HDMI2" {
 
 	EnableSequence [
 		cdev "hw:sofsklhdacard"
-		cset "name='hif6-0 Jack Switch' on"
-		cset "name='Pin6-Port0 Mux' 2"
+		cset "name='IEC958 Playback Switch',index=1 on"
 	]
 
 	DisableSequence [
 		cdev "hw:sofsklhdacard"
-		cset "name='Pin6-Port0 Mux' 0"
-		cset "name='hif6-0 Jack Switch' off"
+		cset "name='IEC958 Playback Switch',index=1 off"
 	]
 
 	Value {
-		PlaybackPCM "hw:0,4"
+		PlaybackPCM "hw:sofsklhdacard,4"
 		PlaybackChannels "2"
-		JackControl "HDMI/DP, pcm=12 Jack"
+		JackControl "HDMI/DP,pcm=4 Jack"
 	}
 }
 
@@ -156,20 +152,17 @@ SectionDevice."HDMI3" {
 
 	EnableSequence [
 		cdev "hw:sofsklhdacard"
-		cset "name='hif7-0 Jack Switch' on"
-		cset "name='Pin7-Port0 Mux' 3"
+		cset "name='IEC958 Playback Switch',index=2 on"
 	]
 
 	DisableSequence [
 		cdev "hw:sofsklhdacard"
-		cset "name='Pin7-Port0 Mux' 0"
-		cset "name='hif7-0 Jack Switch' off"
+		cset "name='IEC958 Playback Switch',index=2 off"
 	]
 
 	Value {
-		PlaybackPCM "hw:0,5"
+		PlaybackPCM "hw:sofsklhdacard,5"
 		PlaybackChannels "2"
-		JackControl "HDMI/DP, pcm=13 Jack"
+		JackControl "HDMI/DP,pcm=5 Jack"
 	}
 }
-


### PR DESCRIPTION
Here's a companion patch to the hda-hdmi kernel patchset on alsa-devel:
https://mailman.alsa-project.org/pipermail/alsa-devel/2019-October/157201.html

Modify UCM sequences to use user-space interface of the common
HDMI codec driver. Use of hdac-hdmi driver is no longer supported
by this UCM file.

To use this UCM file, kernel must be compiled with
SND_SOC_SOF_HDA_COMMON_HDMI_CODEC
