### PR TITLE
sof-skl_hda: fix headphone jack name

### DIFF
--- a/ucm/sof-skl_hda_card/HiFi.conf
+++ b/ucm/sof-skl_hda_card/HiFi.conf
@@ -34,7 +34,7 @@ SectionDevice."Headphone" {
 		JackName "sof-skl_hda_card Headphone"
 		JackType "gpio"
 		JackSwitch "12"
-		JackControl "Headphone Jack"
+		JackControl "Headphone Mic Jack"
 	}
 }
 


### PR DESCRIPTION
Change "Headphone Jack" to "Headphone Mic Jack".

Signed-off-by: Jaska Uimonen <jaska.uimonen@linux.intel.com>