### PR TITLE
broadwell-rt286: add support for hardware volume, conformance fixes

### DIFF
--- a/ucm2/broadwell-rt286/HiFi.conf
+++ b/ucm2/broadwell-rt286/HiFi.conf
@@ -1,45 +1,6 @@
 # Use case Configuration for Nexus 7
 # Adapted to Ubuntu Touch by David Henningsson <david.henningsson@canonical.com>
 
-SectionVerb {
-
-	# ALSA PCM
-	Value {
-		# ALSA PCM device for HiFi
-		PlaybackPCM "hw:${CardId}"
-		CapturePCM "hw:${CardId}"
-	}
-}
-
-SectionDevice."Headphones" {
-	Comment "Headphones playback"
-
-	ConflictingDevice [
-		"Speaker"
-	]
-
-	EnableSequence [
-		cset "name='Master Playback Volume' 30"
-		cset "name='HPO L Switch' on"
-		cset "name='HPO R Switch' on"
-		cset "name='Headphone Jack Switch' on"
-		cset "name='DAC0 Playback Volume' 100"
-	]
-
-	DisableSequence [
-		cset "name='Headphone Jack Switch' off"
-		cset "name='HPO L Switch' off"
-		cset "name='HPO R Switch' off"
-	]
-
-	Value {
-		PlaybackChannels "2"
-		JackDev "rt286-jack"
-		JackControl "Headphone Jack"
-		JackHWMute "Speaker"
-	}
-}
-
 SectionDevice."Speaker" {
 	Comment "Speaker playback"
 
@@ -48,8 +9,6 @@ SectionDevice."Speaker" {
 	]
 
 	EnableSequence [
-		cset "name='Master Playback Volume' 30"
-		cset "name='DAC0 Playback Volume' 127"
 		cset "name='SPO Switch' on"
 		cset "name='Speaker Playback Switch' on"
 		cset "name='Speaker Switch' on"
@@ -62,7 +21,66 @@ SectionDevice."Speaker" {
 	]
 
 	Value {
-		PlaybackChannels "2"
+		Priority 100
+		PlaybackPCM "hw:${CardId}"
+		PlaybackChannels 2
+		PlaybackMixerElem "DAC0"
+		PlaybackMasterElem "Master"
+	}
+}
+
+SectionDevice."Headphones" {
+	Comment "Headphones playback"
+
+	ConflictingDevice [
+		"Speaker"
+	]
+
+	EnableSequence [
+		cset "name='HPO L Switch' on"
+		cset "name='HPO R Switch' on"
+		cset "name='Headphone Jack Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Headphone Jack Switch' off"
+		cset "name='HPO L Switch' off"
+		cset "name='HPO R Switch' off"
+	]
+
+	Value {
+		Priority 200
+		PlaybackPCM "hw:${CardId}"
+		PlaybackChannels 2
+		PlaybackMixerElem "DAC0"
+		PlaybackMasterElem "Master"
+		JackDev "rt286-jack"
+		JackControl "Headphone Jack"
+		JackHWMute "Speaker"
+	}
+}
+
+SectionDevice."Mic" {
+	Comment "Microphone"
+
+	ConflictingDevice [
+		"Handset"
+	]
+
+	EnableSequence [
+		cset "name='ADC 0 Mux' 2"
+	]
+
+	DisableSequence [
+		cset "name='ADC0 Capture Switch' off"
+	]
+
+	Value {
+		Priority 100
+		CapturePCM "hw:${CardId}"
+		CaptureChannels "2"
+		CaptureMixerElem "Mic"
+		CaptureMasterElem "ADC0"
 	}
 }
 
@@ -70,14 +88,11 @@ SectionDevice."Handset" {
 	Comment "Handset Microphone"
 
 	ConflictingDevice [
-		"Mainmic"
+		"Mic"
 	]
 
 	EnableSequence [
-		cset "name='Mic Capture Volume' 28"
 		cset "name='ADC 0 Mux' 0"
-		cset "name='ADC0 Capture Switch' on"
-		cset "name='ADC0 Capture Volume' 127"
 		cset "name='AMIC Volume' 1"
 	]
 
@@ -86,32 +101,13 @@ SectionDevice."Handset" {
 	]
 
 	Value {
+		Priority 200
+		CapturePCM "hw:${CardId}"
 		CaptureChannels "2"
+		CaptureMixerElem "Mic"
+		CaptureMasterElem "ADC0"
 		JackDev "rt286-jack"
 		JackControl "Mic Jack"
-		JackHWMute "Mainmic"
-	}
-}
-
-SectionDevice."Mainmic" {
-	Comment "Main Microphone"
-
-	ConflictingDevice [
-		"Handset"
-	]
-
-	EnableSequence [
-		cset "name='Mic Capture Volume' 30"
-		cset "name='ADC 0 Mux' 2"
-		cset "name='ADC0 Capture Switch' on"
-		cset "name='ADC0 Capture Volume' 127"
-	]
-
-	DisableSequence [
-		cset "name='ADC0 Capture Switch' off"
-	]
-
-	Value {
-		CaptureChannels "2"
+		JackHWMute "Mic"
 	}
 }


### PR DESCRIPTION
This commit by @perexg fixes a regression on broadwell-rt286 which causes PulseAudio to abort on startup with:

`E: [pulseaudio] channelmap.c: Assertion 'pa_channels_valid(channels)' failed at pulse/channelmap.c:401, function pa_channel_map_init_extend(). Aborting.`