### PR TITLE
broadwell-rt286: more conformance and other fixes

### DIFF
--- a/ucm2/broadwell-rt286/HiFi.conf
+++ b/ucm2/broadwell-rt286/HiFi.conf
@@ -2,7 +2,7 @@
 # Adapted to Ubuntu Touch by David Henningsson <david.henningsson@canonical.com>
 
 SectionDevice."Speaker" {
-	Comment "Speaker playback"
+	Comment "Speakers"
 
 	ConflictingDevice [
 		"Headphones"
@@ -17,7 +17,7 @@ SectionDevice."Speaker" {
 	DisableSequence [
 		cset "name='Speaker Switch' off"
 		cset "name='Speaker Playback Switch' off"
-		cset "name='SPO Switch' 0"
+		cset "name='SPO Switch' off"
 	]
 
 	Value {
@@ -29,7 +29,7 @@ SectionDevice."Speaker" {
 }
 
 SectionDevice."Headphones" {
-	Comment "Headphones playback"
+	Comment "Headphones"
 
 	ConflictingDevice [
 		"Speaker"
@@ -54,35 +54,30 @@ SectionDevice."Headphones" {
 		PlaybackMasterElem "Master"
 		JackDev "rt286-jack"
 		JackControl "Headphone Jack"
-		JackHWMute "Speaker"
 	}
 }
 
 SectionDevice."Mic" {
-	Comment "Microphone"
+	Comment "Internal Microphone"
 
 	ConflictingDevice [
-		"Handset"
+		"Headset"
 	]
 
 	EnableSequence [
 		cset "name='ADC 0 Mux' 2"
 	]
 
-	DisableSequence [
-		cset "name='ADC0 Capture Switch' off"
-	]
-
 	Value {
 		CapturePriority 100
 		CapturePCM "hw:${CardId}"
-		CaptureMixerElem "Mic"
-		CaptureMasterElem "ADC0"
+		CaptureMixerElem "ADC0"
+		CaptureMasterElem "Mic"
 	}
 }
 
-SectionDevice."Handset" {
-	Comment "Handset Microphone"
+SectionDevice."Headset" {
+	Comment "Headset Microphone"
 
 	ConflictingDevice [
 		"Mic"
@@ -90,20 +85,19 @@ SectionDevice."Handset" {
 
 	EnableSequence [
 		cset "name='ADC 0 Mux' 0"
-		cset "name='AMIC Volume' 1"
+		cset "name='AMIC Volume' 3"
 	]
 
 	DisableSequence [
-		cset "name='ADC0 Capture Switch' off"
+		cset "name='AMIC Volume' 0"
 	]
 
 	Value {
 		CapturePriority 200
 		CapturePCM "hw:${CardId}"
-		CaptureMixerElem "Mic"
-		CaptureMasterElem "ADC0"
+		CaptureMixerElem "ADC0"
+		CaptureMasterElem "Mic"
 		JackDev "rt286-jack"
 		JackControl "Mic Jack"
-		JackHWMute "Mic"
 	}
 }


### PR DESCRIPTION
Remove JackHWMute, because the hardware does not forcibly shut off the internal speakers or microphone when the jack is in use.

The CaptureMixerElem and CaptureMasterElem devices were swapped. Do not manually set the "ADC0 Capture Switch" when disabling a capture device; it will be set automatically instead.

Correct "Handset" to "Headset". Apply maximum gain to the headset microphone ("AMIC Volume") when in use, based on testing.