### PR TITLE
sof-bdw-rt5677: initial port to UCM2

### DIFF
--- a/ucm2/sof-bdw-rt5677/HiFi.conf
+++ b/ucm2/sof-bdw-rt5677/HiFi.conf
@@ -1,0 +1,194 @@
+# Use case Configuration for sof-bdw-rt5677
+# command-line sequence to switch playback/capture
+# alsaucm -c sof-bdw-rt5677  set _verb HiFi
+# alsaucm -c sof-bdw-rt5677  set _verb HiFi set _enadev Headphones
+
+
+SectionVerb {
+
+	EnableSequence [
+
+		cset "name='PDM1 L Mux' STO1 DAC MIX"
+		cset "name='PDM1 R Mux' STO1 DAC MIX"
+
+		# Adjust Master Playback volume if needed
+		# cset "name='Master Playback Volume' 30"
+
+		cset "name='OUT1 Playback Switch' off"
+		cset "name='OUT2 Playback Switch' off"
+
+		cset "name='DAC1 Playback Volume' 175"
+		cset "name='DAC2 Playback Volume' 175"
+		cset "name='DAC12 SRC Mux' STO1 DAC MIX"
+
+		cset "name='Stereo DAC MIXL ST L Switch' off"
+		cset "name='Stereo DAC MIXL DAC1 L Switch' off"
+		cset "name='Stereo DAC MIXL DAC2 L Switch' off"
+		cset "name='Stereo DAC MIXL DAC1 R Switch' on"
+
+		cset "name='Stereo DAC MIXR ST R Switch' off"
+		cset "name='Stereo DAC MIXR DAC1 R Switch' off"
+		cset "name='Stereo DAC MIXR DAC2 R Switch' off"
+		cset "name='Stereo DAC MIXR DAC1 L Switch' on"
+
+		cset "name='DAC1 MIXL Stereo ADC Switch' off"
+		cset "name='DAC1 MIXL DAC1 Switch' on"
+
+		cset "name='DAC1 MIXR Stereo ADC Switch' off"
+		cset "name='DAC1 MIXR DAC1 Switch' on"
+
+		cset "name='DAC1 Mux' IF1 DAC 01"
+
+		cset "name='Stereo1 DMIC Mux' DMIC1"
+		cset "name='Stereo1 ADC2 Mux' DMIC"
+		cset "name='Stereo1 ADC1 Mux' ADC1/2"
+
+		cset "name='Sto1 ADC MIXL ADC1 Switch' off"
+		cset "name='Sto1 ADC MIXL ADC2 Switch' off"
+		cset "name='Sto1 ADC MIXL ADC2 Switch' on"
+
+		cset "name='Sto1 ADC MIXR ADC1 Switch' off"
+		cset "name='Sto1 ADC MIXR ADC2 Switch' off"
+		cset "name='Sto1 ADC MIXR ADC2 Switch' on"
+
+		cset "name='IF1 ADC1 Mux' STO1 ADC MIX"
+		cset "name='IF1 ADC1 Swap Mux' L/R"
+
+		# Adjust Mic Capture Volume if needed
+		# cset "name='Mic Capture Volume' 30"
+
+		cset "name='ADC1 Capture Switch' on"
+		cset "name='ADC1 Capture Volume' 31"
+		cset "name='STO1 ADC Boost Volume' 2"
+
+		cset "name='Headphone Switch' off"
+		cset "name='Speaker Switch' on"
+
+		cset "name='Remote DMICs Switch' on"
+		cset "name='Mono DMIC L Mux' DMIC1"
+		cset "name='Mono ADC2 L Mux' DMIC"
+		cset "name='Mono ADC MIXL ADC1 Switch' off"
+		cset "name='Mono ADC MIXL ADC2 Switch' on"
+		cset "name='VAD ADC Mux' MONO ADC MIX L"
+		cset "name='IB01 Mux' VAD ADC/DAC1 FS"
+		cset "name='IB01 Bypass Mux' Bypass"
+		cset "name='Mono ADC Boost Volume' 2"
+	]
+
+	DisableSequence [
+	]
+}
+
+SectionDevice."Speaker" {
+	Comment "Speakers"
+
+	ConflictingDevice [
+		"Headphones"
+	]
+
+	EnableSequence [
+	]
+
+	DisableSequence [
+	]
+
+	Value {
+		PlaybackPriority 100
+		PlaybackPCM "hw:${CardId}"
+	}
+}
+
+
+SectionDevice."Headphones" {
+	Comment "Headphones"
+
+	ConflictingDevice [
+		"Speaker"
+	]
+
+	EnableSequence [
+		cset "name='Speaker Switch' off"
+		cset "name='Stereo DAC MIXL DAC1 R Switch' off"
+		cset "name='Stereo DAC MIXR DAC1 L Switch' off"
+		cset "name='Stereo DAC MIXL DAC1 L Switch' on"
+		cset "name='Stereo DAC MIXR DAC1 R Switch' on"
+		cset "name='OUT1 Playback Switch' on"
+		cset "name='OUT2 Playback Switch' on"
+		cset "name='Headphone Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Headphone Switch' off"
+		cset "name='OUT1 Playback Switch' off"
+		cset "name='OUT2 Playback Switch' off"
+		cset "name='Stereo DAC MIXL DAC1 L Switch' off"
+		cset "name='Stereo DAC MIXR DAC1 R Switch' off"
+		cset "name='Stereo DAC MIXL DAC1 R Switch' on"
+		cset "name='Stereo DAC MIXR DAC1 L Switch' on"
+		cset "name='Speaker Switch' on"
+	]
+
+	Value {
+		PlaybackPriority 300
+		PlaybackPCM "hw:${CardId}"
+		JackControl "Headphone Jack"
+		JackHWMute "Speakers"
+	}
+}
+
+SectionDevice."Mic" {
+	Comment "Internal Microphone"
+
+	ConflictingDevice [
+		"Headset"
+	]
+
+	EnableSequence [
+	]
+
+	DisableSequence [
+	]
+
+	Value {
+		CapturePriority 100
+		CapturePCM "hw:${CardId}"
+	}
+}
+
+SectionDevice."Headset" {
+	Comment "Headset Microphone"
+
+	ConflictingDevice [
+		"Mic"
+	]
+
+	EnableSequence [
+		cset "name='Sto1 ADC MIXL ADC2 Switch' off"
+		cset "name='Sto1 ADC MIXR ADC2 Switch' off"
+		cset "name='Local DMICs Switch' off"
+
+		cset "name='IF1 ADC1 Swap Mux' L/L"
+
+		cset "name='Sto1 ADC MIXL ADC1 Switch' on"
+		cset "name='Sto1 ADC MIXR ADC1 Switch' on"
+		cset "name='Headset Mic Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Sto1 ADC MIXL ADC1 Switch' off"
+		cset "name='Sto1 ADC MIXR ADC1 Switch' off"
+		cset "name='Headset Mic Switch' off"
+
+		cset "name='IF1 ADC1 Swap Mux' L/R"
+
+		cset "name='Sto1 ADC MIXL ADC2 Switch' on"
+		cset "name='Sto1 ADC MIXR ADC2 Switch' on"
+		cset "name='Local DMICs Switch' on"
+	]
+
+	Value {
+		CapturePriority 300
+		CapturePCM "hw:${CardId}"
+		JackControl "Mic Jack"
+	}
+}

--- a/ucm2/sof-bdw-rt5677/sof-bdw-rt5677.conf
+++ b/ucm2/sof-bdw-rt5677/sof-bdw-rt5677.conf
@@ -1,0 +1,6 @@
+Syntax 2
+
+SectionUseCase."HiFi" {
+	File "HiFi.conf"
+	Comment "Default"
+}


### PR DESCRIPTION
Tested on Pixel 2015/SAMUS Chromebook.

Known limitations:
Left/Right confusion (probably a firmware issue)
PulseAudio does not switch capture devices on headset plug

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>