### PR TITLE
sof-hda-dsp: Support systems without integrated graphics audio

### DIFF
--- a/ucm2/sof-hda-dsp/Hdmi.conf
+++ b/ucm2/sof-hda-dsp/Hdmi.conf
@@ -1,55 +1,79 @@
 # Use case Configuration for sof-hda-dsp
 
-SectionDevice."HDMI1" {
-	Comment "HDMI1/DP1 Output"
+If.hdmi1 {
+	Condition {
+		Type ControlExists
+		Control "iface=CARD,name='HDMI/DP,pcm=3 Jack'"
+	}
+	True {
+		SectionDevice."HDMI1" {
+			Comment "HDMI1/DP1 Output"
 
-	EnableSequence [
-		cset "name='IEC958 Playback Switch' on"
-	]
+			EnableSequence [
+				cset "name='IEC958 Playback Switch' on"
+			]
 
-	DisableSequence [
-		cset "name='IEC958 Playback Switch' off"
-	]
+			DisableSequence [
+				cset "name='IEC958 Playback Switch' off"
+			]
 
-	Value {
-		PlaybackPriority 500
-		PlaybackPCM "hw:${CardId},3"
-		JackControl "HDMI/DP,pcm=3 Jack"
+			Value {
+				PlaybackPriority 500
+				PlaybackPCM "hw:${CardId},3"
+				JackControl "HDMI/DP,pcm=3 Jack"
+			}
+		}
 	}
 }
 
-SectionDevice."HDMI2" {
-	Comment "HDMI2/DP2 Output"
+If.hdmi2 {
+	Condition {
+		Type ControlExists
+		Control "iface=CARD,name='HDMI/DP,pcm=4 Jack'"
+	}
+	True {
+		SectionDevice."HDMI2" {
+			Comment "HDMI2/DP2 Output"
 
-	EnableSequence [
-		cset "name='IEC958 Playback Switch',index=1 on"
-	]
+			EnableSequence [
+				cset "name='IEC958 Playback Switch',index=1 on"
+			]
 
-	DisableSequence [
-		cset "name='IEC958 Playback Switch',index=1 off"
-	]
+			DisableSequence [
+				cset "name='IEC958 Playback Switch',index=1 off"
+			]
 
-	Value {
-		PlaybackPriority 600
-		PlaybackPCM "hw:${CardId},4"
-		JackControl "HDMI/DP,pcm=4 Jack"
+			Value {
+				PlaybackPriority 600
+				PlaybackPCM "hw:${CardId},4"
+				JackControl "HDMI/DP,pcm=4 Jack"
+			}
+		}
 	}
 }
 
-SectionDevice."HDMI3" {
-	Comment "HDMI3/DP3 Output"
+If.hdmi3 {
+	Condition {
+		Type ControlExists
+		Control "iface=CARD,name='HDMI/DP,pcm=5 Jack'"
+	}
+	True {
+		SectionDevice."HDMI3" {
+			Comment "HDMI3/DP3 Output"
 
-	EnableSequence [
-		cset "name='IEC958 Playback Switch',index=2 on"
-	]
+			EnableSequence [
+				cset "name='IEC958 Playback Switch',index=2 on"
+			]
 
-	DisableSequence [
-		cset "name='IEC958 Playback Switch',index=2 off"
-	]
+			DisableSequence [
+				cset "name='IEC958 Playback Switch',index=2 off"
+			]
 
-	Value {
-		PlaybackPriority 700
-		PlaybackPCM "hw:${CardId},5"
-		JackControl "HDMI/DP,pcm=5 Jack"
+			Value {
+				PlaybackPriority 700
+				PlaybackPCM "hw:${CardId},5"
+				JackControl "HDMI/DP,pcm=5 Jack"
+			}
+		}
 	}
 }


### PR DESCRIPTION
On systems where integrated graphics audio is not present
or is disabled, the HDMI PCM nodes are disabled. Add rules to
detect these systems by checking presence of HDMI jack controls
with UCM2 rules.

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>