### PR TITLE
sof-broadwell-rt286: use symlinks to reuse existing UCM

### DIFF
--- a/ucm2/broadwell-rt286/sof-broadwell-rt286.conf
+++ b/ucm2/broadwell-rt286/sof-broadwell-rt286.conf
@@ -1,0 +1,1 @@
+broadwell-rt286.conf

--- a/ucm2/sof-broadwell-rt286
+++ b/ucm2/sof-broadwell-rt286
@@ -1,0 +1,1 @@
+broadwell-rt286


### PR DESCRIPTION
There are no firmware-specific settings to it's fine to reuse the
legacy file as is.

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>