### PR TITLE
SOF support for Baytrail/CherryTrail

### DIFF
--- a/ucm2/SOF/HiFi.conf
+++ b/ucm2/SOF/HiFi.conf
@@ -1,0 +1,88 @@
+
+If.bytcht-rt5640 {
+	Condition {
+		Type String
+		Haystack "${CardName}"
+		Needle "bytcht rt5640"
+	}
+	True {
+		<bytcr-rt5640/HiFi.conf>
+	}
+}
+
+If.bytcht_rt5651 {
+	Condition {
+		Type String
+		Haystack "${CardName}"
+		Needle "bytcht rt5651"
+	}
+	True {
+		<bytcr-rt5651/HiFi.conf>
+	}
+}
+
+If.bytcht_cx2072x {
+	Condition {
+		Type String
+		Haystack "${CardName}"
+		Needle "bytcht cx2072x"
+	}
+	True {
+		<bytcht-cx2072x/HiFi.conf>
+	}
+}
+
+If.bytcht_es8316 {
+	Condition {
+		Type String
+		Haystack "${CardName}"
+		Needle "bytcht es8316"
+	}
+	True {
+		<bytcht-es8316/HiFi.conf>
+	}
+}
+
+If.bytcht_rt5672 {
+	Condition {
+		Type String
+		Haystack "${CardName}"
+		Needle "bytcht rt5672"
+	}
+	True {
+		<cht-bsw-rt5672/HiFi.conf>
+	}
+}
+
+If.bytcht_nau8824 {
+	Condition {
+		Type String
+		Haystack "${CardName}"
+		Needle "bytcht nau8824"
+	}
+	True {
+		<chtnau8824/HiFi.conf>
+	}
+}
+
+If.bytcht_rt5645 {
+	Condition {
+		Type String
+		Haystack "${CardName}"
+		Needle "bytcht rt5645"
+	}
+	True {
+		<chtrt5645/HiFi.conf>
+	}
+}
+
+If.bytcht_rt5650 {
+	Condition {
+		Type String
+		Haystack "${CardName}"
+		Needle "bytcht rt5650"
+	}
+	True {
+		<chtrt5650/HiFi.conf>
+	}
+}

--- a/ucm2/SOF/SOF.conf
+++ b/ucm2/SOF/SOF.conf
@@ -1,0 +1,6 @@
+Syntax 2
+
+SectionUseCase."HiFi" {
+	File "HiFi.conf"
+	Comment "Play HiFi quality Music"
+}

--- a/ucm2/bytcht-cx2072x/HiFi.conf
+++ b/ucm2/bytcht-cx2072x/HiFi.conf
@@ -1,13 +1,32 @@
 SectionVerb {
-	EnableSequence [
-		<platforms/bytcr/PlatformEnableSeq.conf>
-		<codecs/cx2072x/EnableSeq.conf>
-	]
 
-	DisableSequence [
-		<codecs/cx2072x/DisableSeq.conf>
-		<platforms/bytcr/PlatformDisableSeq.conf>
-	]
+	If.Controls {
+		Condition {
+			Type ControlExists
+			Control "name='media0_in Gain 0 Switch'"
+		}
+		True {
+			EnableSequence [
+				<platforms/bytcr/PlatformEnableSeq.conf>
+				<codecs/cx2072x/EnableSeq.conf>
+			]
+
+			DisableSequence [
+				<codecs/cx2072x/DisableSeq.conf>
+				<platforms/bytcr/PlatformDisableSeq.conf>
+			]
+		}
+		False {
+			EnableSequence [
+				<codecs/cx2072x/EnableSeq.conf>
+			]
+
+			DisableSequence [
+				<codecs/cx2072x/DisableSeq.conf>
+			]
+
+		}
+	}
 }
 
 <codecs/cx2072x/Speaker.conf>

--- a/ucm2/bytcht-es8316/HiFi.conf
+++ b/ucm2/bytcht-es8316/HiFi.conf
@@ -1,12 +1,26 @@
 SectionVerb {
-	EnableSequence [
-		<platforms/bytcr/PlatformEnableSeq.conf>
-		<codecs/es8316/EnableSeq.conf>
-	]
 
-	DisableSequence [
-		<platforms/bytcr/PlatformDisableSeq.conf>
-	]
+	If.Controls {
+		Condition {
+			Type ControlExists
+			Control "name='media0_in Gain 0 Switch'"
+		}
+		True {
+			EnableSequence [
+				<platforms/bytcr/PlatformEnableSeq.conf>
+				<codecs/es8316/EnableSeq.conf>
+			]
+
+			DisableSequence [
+				<platforms/bytcr/PlatformDisableSeq.conf>
+			]
+		}
+		False {
+			EnableSequence [
+				<codecs/es8316/EnableSeq.conf>
+			]
+		}
+	}
 }
 
 If.0 {

--- a/ucm2/bytcr-rt5640/HiFi.conf
+++ b/ucm2/bytcr-rt5640/HiFi.conf
@@ -2,14 +2,28 @@
 
 
 SectionVerb {
-	EnableSequence [
-		<platforms/bytcr/PlatformEnableSeq.conf>
-		<codecs/rt5640/EnableSeq.conf>
-	]
 
-	DisableSequence [
-		<platforms/bytcr/PlatformDisableSeq.conf>
-	]
+	If.Controls {
+		Condition {
+			Type ControlExists
+			Control "name='media0_in Gain 0 Switch'"
+		}
+		True {
+			EnableSequence [
+				<platforms/bytcr/PlatformEnableSeq.conf>
+				<codecs/rt5640/EnableSeq.conf>
+			]
+
+			DisableSequence [
+				<platforms/bytcr/PlatformDisableSeq.conf>
+			]
+		}
+		False {
+			EnableSequence [
+				<codecs/rt5640/EnableSeq.conf>
+			]
+		}
+	}
 }
 
 If.0 {

--- a/ucm2/bytcr-rt5651/HiFi.conf
+++ b/ucm2/bytcr-rt5651/HiFi.conf
@@ -2,14 +2,28 @@
 
 
 SectionVerb {
-	EnableSequence [
-		<platforms/bytcr/PlatformEnableSeq.conf>
-		<codecs/rt5651/EnableSeq.conf>
-	]
 
-	DisableSequence [
-		<platforms/bytcr/PlatformDisableSeq.conf>
-	]
+	If.Controls {
+		Condition {
+			Type ControlExists
+			Control "name='media0_in Gain 0 Switch'"
+		}
+		True {
+			EnableSequence [
+				<platforms/bytcr/PlatformEnableSeq.conf>
+				<codecs/rt5651/EnableSeq.conf>
+			]
+
+			DisableSequence [
+				<platforms/bytcr/PlatformDisableSeq.conf>
+			]
+		}
+		False {
+			EnableSequence [
+				<codecs/rt5651/EnableSeq.conf>
+			]
+		}
+	}
 }
 
 If.0 {

--- a/ucm2/cht-bsw-rt5672/HiFi-stereo-dmic2.conf
+++ b/ucm2/cht-bsw-rt5672/HiFi-stereo-dmic2.conf
@@ -1,14 +1,28 @@
 # Adapted from https://github.com/plbossart/UCM/tree/master/cht-bsw-rt5672
 
 SectionVerb {
-	EnableSequence [
-		<platforms/bytcr/PlatformEnableSeq.conf>
-		<codecs/rt5672/EnableSeq.conf>
-	]
 
-	DisableSequence [
-		<platforms/bytcr/PlatformDisableSeq.conf>
-	]
+	If.Controls {
+		Condition {
+			Type ControlExists
+			Control "name='media0_in Gain 0 Switch'"
+		}
+		True {
+			EnableSequence [
+				<platforms/bytcr/PlatformEnableSeq.conf>
+				<codecs/rt5672/EnableSeq.conf>
+			]
+
+			DisableSequence [
+				<platforms/bytcr/PlatformDisableSeq.conf>
+			]
+		}
+		False {
+			EnableSequence [
+				<codecs/rt5672/EnableSeq.conf>
+			]
+		}
+	}
 }
 
 <codecs/rt5672/Speaker.conf>

--- a/ucm2/cht-bsw-rt5672/HiFi.conf
+++ b/ucm2/cht-bsw-rt5672/HiFi.conf
@@ -1,14 +1,28 @@
 # Adapted from https://github.com/plbossart/UCM/tree/master/cht-bsw-rt5672
 
 SectionVerb {
-	EnableSequence [
-		<platforms/bytcr/PlatformEnableSeq.conf>
-		<codecs/rt5672/EnableSeq.conf>
-	]
 
-	DisableSequence [
-		<platforms/bytcr/PlatformDisableSeq.conf>
-	]
+	If.Controls {
+		Condition {
+			Type ControlExists
+			Control "name='media0_in Gain 0 Switch'"
+		}
+		True {
+			EnableSequence [
+				<platforms/bytcr/PlatformEnableSeq.conf>
+				<codecs/rt5672/EnableSeq.conf>
+			]
+
+			DisableSequence [
+				<platforms/bytcr/PlatformDisableSeq.conf>
+			]
+		}
+		False {
+			EnableSequence [
+				<codecs/rt5672/EnableSeq.conf>
+			]
+		}
+	}
 }
 
 <codecs/rt5672/Speaker.conf>

--- a/ucm2/chtnau8824/HiFi-mono.conf
+++ b/ucm2/chtnau8824/HiFi-mono.conf
@@ -5,14 +5,27 @@ SectionVerb {
 		TQ "HiFi"
 	}
 
-	EnableSequence [
-		<platforms/bytcr/PlatformEnableSeq.conf>
-		<codecs/nau8824/EnableSeq.conf>
-	]
+	If.Controls {
+		Condition {
+			Type ControlExists
+			Control "name='media0_in Gain 0 Switch'"
+		}
+		True {
+			EnableSequence [
+				<platforms/bytcr/PlatformEnableSeq.conf>
+				<codecs/nau8824/EnableSeq.conf>
+			]
 
-	DisableSequence [
-		<platforms/bytcr/PlatformDisableSeq.conf>
-	]
+			DisableSequence [
+				<platforms/bytcr/PlatformDisableSeq.conf>
+			]
+		}
+		False {
+			EnableSequence [
+				<codecs/nau8824/EnableSeq.conf>
+			]
+		}
+	}
 }
 
 <codecs/nau8824/MonoSpeaker.conf>

--- a/ucm2/chtnau8824/HiFi.conf
+++ b/ucm2/chtnau8824/HiFi.conf
@@ -1,14 +1,28 @@
-
 SectionVerb {
-	EnableSequence [
-		<platforms/bytcr/PlatformEnableSeq.conf>
-		<codecs/nau8824/EnableSeq.conf>
-	]
 
-	DisableSequence [
-		<platforms/bytcr/PlatformDisableSeq.conf>
-	]
+	If.Controls {
+		Condition {
+			Type ControlExists
+			Control "name='media0_in Gain 0 Switch'"
+		}
+		True {
+			EnableSequence [
+				<platforms/bytcr/PlatformEnableSeq.conf>
+				<codecs/nau8824/EnableSeq.conf>
+			]
+
+			DisableSequence [
+				<platforms/bytcr/PlatformDisableSeq.conf>
+			]
+		}
+		False {
+			EnableSequence [
+				<codecs/nau8824/EnableSeq.conf>
+			]
+		}
+	}
 }
+
 
 <codecs/nau8824/Speaker.conf>
 <codecs/nau8824/HeadPhones.conf>

--- a/ucm2/chtrt5645/HiFi-dmic1.conf
+++ b/ucm2/chtrt5645/HiFi-dmic1.conf
@@ -4,21 +4,46 @@ SectionVerb {
 		TQ "HiFi"
 	}
 
-	EnableSequence [
-		<platforms/bytcr/PlatformEnableSeq.conf>
-		<codecs/rt5645/EnableSeq.conf>
+	If.Controls {
+		Condition {
+			Type ControlExists
+			Control "name='media0_in Gain 0 Switch'"
+		}
+		True {
+			EnableSequence [
+				<platforms/bytcr/PlatformEnableSeq.conf>
+				<codecs/rt5645/EnableSeq.conf>
 
-		cset "name='Stereo1 ADC1 Mux' 1"
-		cset "name='I2S2 Func Switch' on"
-		# 3/12 the headphone mic tends to be quite loud
-		cset "name='IN1 Boost' 3"
-		# 8/8 the internal analog mic tends to be quite soft
-		cset "name='IN2 Boost' 8"
-	]
+				cset "name='Stereo1 ADC1 Mux' 1"
+				cset "name='I2S2 Func Switch' on"
+				# 3/12 the headphone mic tends to be quite loud
+				cset "name='IN1 Boost' 3"
+				# 8/8 the internal analog mic tends to be quite soft
+				cset "name='IN2 Boost' 8"
+			]
 
-	DisableSequence [
-		<codecs/rt5645/DisableSeq.conf>
-	]
+			DisableSequence [
+				<platforms/bytcr/PlatformDisableSeq.conf>
+				<codecs/rt5645/DisableSeq.conf>
+			]
+		}
+		False {
+			EnableSequence [
+				<codecs/rt5645/EnableSeq.conf>
+
+				cset "name='Stereo1 ADC1 Mux' 1"
+				cset "name='I2S2 Func Switch' on"
+				# 3/12 the headphone mic tends to be quite loud
+				cset "name='IN1 Boost' 3"
+				# 8/8 the internal analog mic tends to be quite soft
+				cset "name='IN2 Boost' 8"
+			]
+
+			DisableSequence [
+				<codecs/rt5645/DisableSeq.conf>
+			]
+		}
+	}
 }
 
 SectionDevice."Speaker" {

--- a/ucm2/chtrt5645/HiFi-dmic2.conf
+++ b/ucm2/chtrt5645/HiFi-dmic2.conf
@@ -4,21 +4,46 @@ SectionVerb {
 		TQ "HiFi"
 	}
 
-	EnableSequence [
-		<platforms/bytcr/PlatformEnableSeq.conf>
-		<codecs/rt5645/EnableSeq.conf>
+	If.Controls {
+		Condition {
+			Type ControlExists
+			Control "name='media0_in Gain 0 Switch'"
+		}
+		True {
+			EnableSequence [
+				<platforms/bytcr/PlatformEnableSeq.conf>
+				<codecs/rt5645/EnableSeq.conf>
 
-		cset "name='Stereo1 ADC1 Mux' 1"
-		cset "name='I2S2 Func Switch' on"
-		# 3/12 the headphone mic tends to be quite loud
-		cset "name='IN1 Boost' 3"
-		# 8/8 the internal analog mic tends to be quite soft
-		cset "name='IN2 Boost' 8"
-	]
+				cset "name='Stereo1 ADC1 Mux' 1"
+				cset "name='I2S2 Func Switch' on"
+				# 3/12 the headphone mic tends to be quite loud
+				cset "name='IN1 Boost' 3"
+				# 8/8 the internal analog mic tends to be quite soft
+				cset "name='IN2 Boost' 8"
+			]
 
-	DisableSequence [
-		<codecs/rt5645/DisableSeq.conf>
-	]
+			DisableSequence [
+				<platforms/bytcr/PlatformDisableSeq.conf>
+				<codecs/rt5645/DisableSeq.conf>
+			]
+		}
+		False {
+			EnableSequence [
+				<codecs/rt5645/EnableSeq.conf>
+
+				cset "name='Stereo1 ADC1 Mux' 1"
+				cset "name='I2S2 Func Switch' on"
+				# 3/12 the headphone mic tends to be quite loud
+				cset "name='IN1 Boost' 3"
+				# 8/8 the internal analog mic tends to be quite soft
+				cset "name='IN2 Boost' 8"
+			]
+
+			DisableSequence [
+				<codecs/rt5645/DisableSeq.conf>
+			]
+		}
+	}
 }
 
 SectionDevice."Speaker" {

--- a/ucm2/chtrt5645/HiFi-mono-speaker-analog-mic.conf
+++ b/ucm2/chtrt5645/HiFi-mono-speaker-analog-mic.conf
@@ -4,21 +4,46 @@ SectionVerb {
 		TQ "HiFi"
 	}
 
-	EnableSequence [
-		<platforms/bytcr/PlatformEnableSeq.conf>
-		<codecs/rt5645/EnableSeq.conf>
+	If.Controls {
+		Condition {
+			Type ControlExists
+			Control "name='media0_in Gain 0 Switch'"
+		}
+		True {
+			EnableSequence [
+				<platforms/bytcr/PlatformEnableSeq.conf>
+				<codecs/rt5645/EnableSeq.conf>
 
-		cset "name='Stereo1 ADC1 Mux' 1"
-		cset "name='I2S2 Func Switch' on"
-		# 3/12 the headphone mic tends to be quite loud
-		cset "name='IN1 Boost' 3"
-		# 8/8 the internal analog mic tends to be quite soft
-		cset "name='IN2 Boost' 8"
-	]
+				cset "name='Stereo1 ADC1 Mux' 1"
+				cset "name='I2S2 Func Switch' on"
+				# 3/12 the headphone mic tends to be quite loud
+				cset "name='IN1 Boost' 3"
+				# 8/8 the internal analog mic tends to be quite soft
+				cset "name='IN2 Boost' 8"
+			]
 
-	DisableSequence [
-		<codecs/rt5645/DisableSeq.conf>
-	]
+			DisableSequence [
+				<platforms/bytcr/PlatformDisableSeq.conf>
+				<codecs/rt5645/DisableSeq.conf>
+			]
+		}
+		False {
+			EnableSequence [
+				<codecs/rt5645/EnableSeq.conf>
+
+				cset "name='Stereo1 ADC1 Mux' 1"
+				cset "name='I2S2 Func Switch' on"
+				# 3/12 the headphone mic tends to be quite loud
+				cset "name='IN1 Boost' 3"
+				# 8/8 the internal analog mic tends to be quite soft
+				cset "name='IN2 Boost' 8"
+			]
+
+			DisableSequence [
+				<codecs/rt5645/DisableSeq.conf>
+			]
+		}
+	}
 }
 
 SectionDevice."Speaker" {

--- a/ucm2/chtrt5645/HiFi.conf
+++ b/ucm2/chtrt5645/HiFi.conf
@@ -4,21 +4,46 @@ SectionVerb {
 		TQ "HiFi"
 	}
 
-	EnableSequence [
-		<platforms/bytcr/PlatformEnableSeq.conf>
-		<codecs/rt5645/EnableSeq.conf>
+	If.Controls {
+		Condition {
+			Type ControlExists
+			Control "name='media0_in Gain 0 Switch'"
+		}
+		True {
+			EnableSequence [
+				<platforms/bytcr/PlatformEnableSeq.conf>
+				<codecs/rt5645/EnableSeq.conf>
 
-		cset "name='Stereo1 ADC1 Mux' 1"
-		cset "name='I2S2 Func Switch' on"
-		# 3/12 the headphone mic tends to be quite loud
-		cset "name='IN1 Boost' 3"
-		# 8/8 the internal analog mic tends to be quite soft
-		cset "name='IN2 Boost' 8"
-	]
+				cset "name='Stereo1 ADC1 Mux' 1"
+				cset "name='I2S2 Func Switch' on"
+				# 3/12 the headphone mic tends to be quite loud
+				cset "name='IN1 Boost' 3"
+				# 8/8 the internal analog mic tends to be quite soft
+				cset "name='IN2 Boost' 8"
+			]
 
-	DisableSequence [
-		<codecs/rt5645/DisableSeq.conf>
-	]
+			DisableSequence [
+				<platforms/bytcr/PlatformDisableSeq.conf>
+				<codecs/rt5645/DisableSeq.conf>
+			]
+		}
+		False {
+			EnableSequence [
+				<codecs/rt5645/EnableSeq.conf>
+
+				cset "name='Stereo1 ADC1 Mux' 1"
+				cset "name='I2S2 Func Switch' on"
+				# 3/12 the headphone mic tends to be quite loud
+				cset "name='IN1 Boost' 3"
+				# 8/8 the internal analog mic tends to be quite soft
+				cset "name='IN2 Boost' 8"
+			]
+
+			DisableSequence [
+				<codecs/rt5645/DisableSeq.conf>
+			]
+		}
+	}
 }
 
 SectionDevice."Speaker" {

--- a/ucm2/chtrt5650/HiFi.conf
+++ b/ucm2/chtrt5650/HiFi.conf
@@ -5,20 +5,45 @@ SectionVerb {
 		TQ "HiFi"
 	}
 
-	EnableSequence [
-		<platforms/bytcr/PlatformEnableSeq.conf>
-		<codecs/rt5645/EnableSeq.conf>
+	If.Controls {
+		Condition {
+			Type ControlExists
+			Control "name='media0_in Gain 0 Switch'"
+		}
+		True {
+			EnableSequence [
+				<platforms/bytcr/PlatformEnableSeq.conf>
+				<codecs/rt5645/EnableSeq.conf>
 
-		cset "name='Speaker HWEQ' 1,164,237,135,1,165,0,0,1,166,237,135,1,167,0,0,1,192,30,196,1,193,0,0,1,194,30,196,1,195,0,0,1,196,31,180,1,197,0,75,1,198,31,180,1,199,31,180,1,200,0,75,1,201,31,180,0,177,51,224"
-		cset "name='DAC1 Playback Volume' 77,77"
-		cset "name='Speaker ClassD Playback Volume' 4"
-		cset "name='I2S2 Func Switch' off"
-		cset "name='RT5650 IF1 ADC Mux' 0"
-	]
+				cset "name='Speaker HWEQ' 1,164,237,135,1,165,0,0,1,166,237,135,1,167,0,0,1,192,30,196,1,193,0,0,1,194,30,196,1,195,0,0,1,196,31,180,1,197,0,75,1,198,31,180,1,199,31,180,1,200,0,75,1,201,31,180,0,177,51,224"
+				cset "name='DAC1 Playback Volume' 77,77"
+				cset "name='Speaker ClassD Playback Volume' 4"
+				cset "name='I2S2 Func Switch' off"
+				cset "name='RT5650 IF1 ADC Mux' 0"
+			]
 
-	DisableSequence [
-		<codecs/rt5645/DisableSeq.conf>
-	]
+			DisableSequence [
+				<platforms/bytcr/PlatformDisableSeq.conf>
+				<codecs/rt5645/DisableSeq.conf>
+			]
+		}
+		False {
+			EnableSequence [
+				<codecs/rt5645/EnableSeq.conf>
+
+				cset "name='Speaker HWEQ' 1,164,237,135,1,165,0,0,1,166,237,135,1,167,0,0,1,192,30,196,1,193,0,0,1,194,30,196,1,195,0,0,1,196,31,180,1,197,0,75,1,198,31,180,1,199,31,180,1,200,0,75,1,201,31,180,0,177,51,224"
+				cset "name='DAC1 Playback Volume' 77,77"
+				cset "name='Speaker ClassD Playback Volume' 4"
+				cset "name='I2S2 Func Switch' off"
+				cset "name='RT5650 IF1 ADC Mux' 0"
+			]
+
+			DisableSequence [
+				<codecs/rt5645/DisableSeq.conf>
+			]
+		}
+	}
+
 }
 
 SectionDevice."Speaker" {

--- a/ucm2/chtrt5650/chtrt5650.conf
+++ b/ucm2/chtrt5650/chtrt5650.conf
@@ -1,3 +1,5 @@
+Syntax 2
+
 Comment "Intel SoC Audio Device"
 SectionUseCase."HiFi" {
 	File "HiFi.conf"


### PR DESCRIPTION
Add symlink and simple test to reuse legacy settings as is.

tested on Baytrail/Asus T100TA only with SOF and legacy drivers, all other platforms are just based on same changes.

sof-bytcr-rt5640 is here:
 http://alsa-project.org/db/?f=6f8be0520e2bbda94cb744ce66232174feec03d4

UCM validator seems to have problems with the conditional statement?