### PR TITLE
sof-hda-dsp: Reverse order and priority of headset and headphone mic

### DIFF
--- a/ucm2/sof-hda-dsp/HiFi.conf
+++ b/ucm2/sof-hda-dsp/HiFi.conf
@@ -87,6 +87,19 @@ If.monomic {
 	}
 	After.SectionDevice "Mic1"
 	True {
+		SectionDevice."Headset" {
+			Comment "Headset Mono Microphone"
+
+			EnableSequence [
+				cset "name='Input Source' Headset Mic"
+			]
+
+			Value {
+				CapturePriority 200
+				<sof-hda-dsp/HDA-Capture-value.conf>
+				JackControl "Headphone Mic Jack"
+			}
+		}
 		SectionDevice."Mic2" {
 			Comment "Headphones Stereo Microphone"
 
@@ -96,20 +109,6 @@ If.monomic {
 
 			EnableSequence [
 				cset "name='Input Source' 'Headphone Mic'"
-			]
-
-			Value {
-				CapturePriority 200
-				<sof-hda-dsp/HDA-Capture-value.conf>
-				JackControl "Headphone Mic Jack"
-			}
-		}
-
-		SectionDevice."Headset" {
-			Comment "Headset Mono Microphone"
-
-			EnableSequence [
-				cset "name='Input Source' Headset Mic"
 			]
 
 			Value {


### PR DESCRIPTION
Headset mic is the analog input source in 99% of the cases compared to
headphone mic, so change it's priority higher.

Jaska Uimonen <jaska.uimonen@linux.intel.com>