### PR TITLE
sof-hda-dsp: fix speaker on ThinkPad X1C7

### DIFF
--- a/ucm2/sof-hda-dsp/HiFi.conf
+++ b/ucm2/sof-hda-dsp/HiFi.conf
@@ -49,7 +49,8 @@ SectionDevice."Speaker" {
 		}
 		True {
 			EnableSequence [
-				cset "name='Speaker Playback Switch' on"
+				cset "name='Speaker Playback Switch' off"
+				cset "name='Speaker Playback Volume' 100%"
 				cset "name='Bass Speaker Playback Switch' on"
 			]
 
@@ -60,7 +61,8 @@ SectionDevice."Speaker" {
 		}
 		False {
 			EnableSequence [
-				cset "name='Speaker Playback Switch' on"
+				cset "name='Speaker Playback Switch' off"
+				cset "name='Speaker Playback Volume' 100%"
 			]
 
 			DisableSequence [
@@ -72,10 +74,9 @@ SectionDevice."Speaker" {
 	Value {
 		PlaybackPriority 100
 		PlaybackPCM "hw:${CardId}"
-		PlaybackMixerElem "Speaker"
 		PlaybackMasterElem "Master"
-		PlaybackVolume "Speaker Playback Volume"
-		PlaybackSwitch "Speaker Playback Switch"
+		PlaybackVolume "Master Playback Volume"
+		PlaybackSwitch "Master Playback Switch"
 	}
 }
 


### PR DESCRIPTION
With the current ucm2 profile at `sof-hda-dsp/HiFi.conf`, built-in speakers on the ThinkPad X1 Carbon Gen 7 sounds muffled/tinny. Muting 'Speaker' and setting 'Speaker' volume to 100 in `alsamixer` fixes this issue.

I applied these fixes in the ucm2 profile, so they don't have to be applied manually.