### PR TITLE
Add initial support for Realtek ALC1220 TRX40 motherboards

### DIFF
--- a/ucm2/USB-Audio/Realtek-ALC1220-VB-Desktop-HiFi.conf
+++ b/ucm2/USB-Audio/Realtek-ALC1220-VB-Desktop-HiFi.conf
@@ -1,0 +1,60 @@
+SectionDevice."Speaker" {
+        Comment "Speakers"
+        Value {
+               PlaybackChannels 8
+               PlaybackPriority 100
+               PlaybackPCM "hw:${CardId},0"
+               JackControl "Speaker Jack"
+               PlaybackMixerElem "Speaker"
+        }
+}
+
+SectionDevice."Headphones" {
+        Comment "Front Headphones"
+        Value {
+                PlaybackPriority 300
+                PlaybackPCM "hw:${CardId},1"
+                JackControl "Front Headphone Jack"
+                PlaybackMixerElem "Front Headphone"
+        }
+}
+
+SectionDevice."SPDIF" {
+        Comment "S/PDIF Out"
+        Value {
+                PlaybackPriority 200
+                PlaybackPCM "hw:${CardId},2"
+                PlaybackMixerElem "IEC958"
+        }
+}
+
+SectionDevice."Line" {
+        Comment "Line In"
+        Value {
+                CapturePriority 100
+                CapturePCM "hw:${CardId},0"
+                JackControl "Line Jack"
+                CaptureMixerElem "Line"
+        }
+}
+
+SectionDevice."Mic1" {
+        Comment "Microphone"
+        Value {
+                CapturePriority 200
+                CapturePCM "hw:${CardId},1"
+                JackControl "Mic Jack"
+                CaptureMixerElem "Mic"
+        }
+}
+
+SectionDevice."Mic2" {
+        Comment "Front Microphone"
+        Value {
+                CapturePriority 300
+                CapturePCM "hw:${CardId},2"
+                JackControl "Front Mic Jack"
+                CaptureMixerElem "Front Mic"
+        }
+}
+

--- a/ucm2/USB-Audio/Realtek-ALC1220-VB-Desktop.conf
+++ b/ucm2/USB-Audio/Realtek-ALC1220-VB-Desktop.conf
@@ -1,0 +1,6 @@
+Syntax 2
+Comment "USB-audio on Realtek ALC1220-VB desktop"
+SectionUseCase."HiFi" {
+	File "Realtek-ALC1220-VB-Desktop-HiFi.conf"
+	Comment "Default Alsa Profile"
+}


### PR DESCRIPTION
Tested with TRX40 Designare but should work on most TRX40 motherboards
Tested with pulseaudio 13.99.1 (from fedora 31 package)
Tested with kernel 5.7.0-rc3

The following are the notes of the testing and implementation

* Back speaker works in 5.1 mode, however
  pulseaudio doesn't know how to handle mixer controls with
  8 channels, thus 'PlaybackMixerElem' is for now commented out
  This profile at least makes pulseaudio to set volume on this mixer
  element to 100% when it boots
  7.1 mode doesn't work due to lack of jack retasking in the kernel

  Also pulseaudio refuses to set any postive volume on subwoofer on unknown grounds,
  even though on the kernel level it works.

* SPDIF is not tested physically yet. The SPDIF mute mixer control is recognised by
  pulseaudio correctly

* PlaybackPrioriry/CapturePriority seems to have no effect to pulseaudio,
  it doesn't autoswitch inputs when jacks are insterted. You need to switch manually

* When all capture inputs are disconnected, pulseaudio thinks that the UCM2 profile
  is invalid and doesn't use it by default. It can be forced to use it by selecting
  it in the pavucontrol. Or you can for now comment out one of 'JackControl' statements,
  to make it think that one of the jacks is always plugged in.

* Front mic is alway working in mic mode due to lack of jack retasting as well.

* PulseAudio doesn't take advantage of EnableSequence/DisableSequence fully.
  It just enables all the devices regardless of the jack status, and it will disable
  them only when you swith the device profile to Off

* The default volume on capture devices is set to 59% which roughtly repesents
  0 dB amplification according to alsamixer

Signed-off-by: Maxim Levitsky <maximlevitsky@gmail.com>