### PR TITLE
ucm2: Add profile for Chromebook Asus C300

### DIFF
--- a/ucm2/chtmax98090/GOOGLE-Quawks-1.0.conf
+++ b/ucm2/chtmax98090/GOOGLE-Quawks-1.0.conf
@@ -1,0 +1,6 @@
+Syntax 2
+Comment "ASUS C300 built-in audio"
+SectionUseCase."HiFi" {
+	File "HiFi-Quawks.conf"
+	Comment "Default"
+}

--- a/ucm2/chtmax98090/HiFi-Quawks.conf
+++ b/ucm2/chtmax98090/HiFi-Quawks.conf
@@ -1,0 +1,18 @@
+SectionVerb {
+	Value {
+		TQ "HiFi"
+	}
+
+	EnableSequence [
+		<platforms/bytcr/PlatformEnableSeq.conf>
+		<codecs/max98090/EnableSeq.conf>
+		# volume values modified
+		cset "name='Headphone Volume' 25"
+		cset "name='Speaker Volume' 32"
+	]
+}
+
+<codecs/max98090/Headphones.conf>
+<codecs/max98090/Speaker.conf>
+<codecs/max98090/InternalMic.conf>
+<codecs/max98090/HeadsetMic.conf>

--- a/ucm2/codecs/max98090/EnableSeq.conf
+++ b/ucm2/codecs/max98090/EnableSeq.conf
@@ -1,0 +1,25 @@
+cset "name='Left Speaker Mixer Left DAC Switch' on"
+cset "name='Right Speaker Mixer Right DAC Switch' on"
+cset "name='Digital EQ 3 Band Switch' off"
+cset "name='Digital EQ 5 Band Switch' off"
+cset "name='Digital EQ 7 Band Switch' off"
+cset "name='Biquad Switch' off"
+cset "name='Filter Mode' Music"
+cset "name='ADC Oversampling Rate' 0"
+
+cset "name='DMIC Mux' DMIC"
+cset "name='MIC2 Mux' IN34"
+cset "name='MIC2 Volume' 10"
+cset "name='MIC2 Boost Volume' 0"
+
+cset "name='ADCR Boost Volume' 4"
+cset "name='ADCL Boost Volume' 4"
+cset "name='ADCR Volume' 11"
+cset "name='ADCL Volume' 11"
+
+cset "name='Headphone Volume' 10"
+cset "name='Speaker Volume' 10"
+
+cset "name='Speaker Left Mixer Volume' 3"
+cset "name='Speaker Right Mixer Volume' 3"
+cset "name='Playback Path DC Blocking' on"

--- a/ucm2/codecs/max98090/Headphones.conf
+++ b/ucm2/codecs/max98090/Headphones.conf
@@ -1,0 +1,25 @@
+SectionDevice."Headphones" {
+	Comment "Headphones"
+
+	Value {
+		PlaybackPriority 200
+		PlaybackPCM "hw:${CardId}"
+		JackControl "Headphone Jack"
+	}
+
+	ConflictingDevice [
+		"Speaker"
+	]
+
+	EnableSequence [
+		cset "name='Headphone Left Switch' on"
+		cset "name='Headphone Right Switch' on"
+		cset "name='Headphone Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Headphone Left Switch' off"
+		cset "name='Headphone Right Switch' off"
+		cset "name='Headphone Switch' off"
+	]
+}

--- a/ucm2/codecs/max98090/HeadsetMic.conf
+++ b/ucm2/codecs/max98090/HeadsetMic.conf
@@ -1,0 +1,32 @@
+# Headset Microphone via MIC2
+SectionDevice."Headset" {
+	Comment "Headset Microphone"
+
+	Value {
+		CapturePriority 200
+		CapturePCM "hw:${CardId}"
+		JackControl "Headset Mic Jack"
+	}
+
+	ConflictingDevice [
+		"Mic"
+	]
+
+	EnableSequence [
+		cset "name='Headset Mic Switch' on"
+		cset "name='DMIC Mux' ADC"
+		cset "name='Record Path DC Blocking' on"
+
+		cset "name='Left ADC Mixer MIC2 Switch' on"
+		cset "name='Right ADC Mixer MIC2 Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Headset Mic Switch' off"
+		cset "name='DMIC Mux' DMIC"
+		cset "name='Record Path DC Blocking' off"
+
+		cset "name='Left ADC Mixer MIC2 Switch' off"
+		cset "name='Right ADC Mixer MIC2 Switch' off"
+	]
+}

--- a/ucm2/codecs/max98090/InternalMic.conf
+++ b/ucm2/codecs/max98090/InternalMic.conf
@@ -1,0 +1,25 @@
+# internal microphone via DMIC
+SectionDevice."Mic" {
+	Comment "Internal Microphone"
+
+	 Value {
+		CapturePriority 100
+		CapturePCM "hw:${CardId}"
+	}
+
+	ConflictingDevice [
+		"Mic"
+	]
+
+	EnableSequence [
+		cset "name='Int Mic Switch' on"
+		cset "name='DMIC Mux' DMIC"
+		cset "name='Record Path DC Blocking' off"
+	]
+
+	DisableSequence [
+		cset "name='Int Mic Switch' off"
+		cset "name='DMIC Mux' ADC"
+		cset "name='Record Path DC Blocking' on"
+	]
+}

--- a/ucm2/codecs/max98090/Speaker.conf
+++ b/ucm2/codecs/max98090/Speaker.conf
@@ -1,0 +1,24 @@
+SectionDevice."Speaker" {
+	Comment "Speaker"
+
+	Value {
+		PlaybackPriority 100
+		PlaybackPCM "hw:${CardId}"
+	}
+
+	ConflictingDevice [
+		"Headphones"
+	]
+
+	EnableSequence [
+		cset "name='Speaker Left Switch' on"
+		cset "name='Speaker Right Switch' on"
+		cset "name='Ext Spk Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Speaker Left Switch' off"
+		cset "name='Speaker Right Switch' off"
+		cset "name='Ext Spk Switch' off"
+	]
+}


### PR DESCRIPTION
ASUS Chromebook C300 alias Google QUAWKS is an Intel Baytrail platform
with max98090 codec.  This patch adds the basic UCM snippet for the
max98090 codec and HiFi.conf for this model.

Note that MIC2 is used for the headset mic.  If another model with
this codec uses a different ADC port, we'd need to create another
profile snippet and rename the device.

BugLink: https://apibugzilla.suse.com/show_bug.cgi?id=1171492
Signed-off-by: Takashi Iwai <tiwai@suse.de>