### PR TITLE
ucm2: chtmax98090: add generic HiFi.conf and SOF support

### DIFF
--- a/ucm2/SOF/HiFi.conf
+++ b/ucm2/SOF/HiFi.conf
@@ -86,3 +86,14 @@ If.bytcht_rt5650 {
 		<chtrt5650/HiFi.conf>
 	}
 }
+
+If.bytcht_max98090 {
+	Condition {
+		Type String
+		Haystack "${CardName}"
+		Needle "bytcht max98090"
+	}
+	True {
+		<chtmax98090/HiFi.conf>
+	}
+}

--- a/ucm2/chtmax98090/HiFi.conf
+++ b/ucm2/chtmax98090/HiFi.conf
@@ -1,0 +1,26 @@
+SectionVerb {
+	Value {
+		TQ "HiFi"
+	}
+
+	If.platform {
+		Condition {
+			Type ControlExists
+			Control "name='media0_in Gain 0 Switch'"
+		}
+		True {
+			EnableSequence [
+				<platforms/bytcr/PlatformEnableSeq.conf>
+			]
+		}
+	}
+
+	EnableSequence [
+		<codecs/max98090/EnableSeq.conf>
+	]
+}
+
+<codecs/max98090/Headphones.conf>
+<codecs/max98090/Speaker.conf>
+<codecs/max98090/InternalMic.conf>
+<codecs/max98090/HeadsetMic.conf>


### PR DESCRIPTION
Tested on Cyan Chromebook with both SOF and SST drivers.

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>