### PR TITLE
sof-hda-dsp: don't fail if Auto-Mute control is not present

### DIFF
--- a/ucm2/sof-hda-dsp/HiFi.conf
+++ b/ucm2/sof-hda-dsp/HiFi.conf
@@ -1,9 +1,17 @@
 # Use case Configuration for sof-hda-dsp
 
 SectionVerb {
-	EnableSequence [
-		cset "name='Auto-Mute Mode' 'Disabled'"
-	]
+	If.automute {
+		Condition {
+			Type ControlExists
+			Control "name='Auto-Mute Mode'"
+		}
+		True {
+			EnableSequence [
+				cset "name='Auto-Mute Mode' 'Disabled'"
+			]
+		}
+	}
 }
 
 SectionDevice."Headphones" {


### PR DESCRIPTION
The "Auto-Mute Mode" control is not present in all HDA codecs.
The generic SOF HDA UCM file should be robust enough to handle
these cases as well.

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>