### PR TITLE
sof-hda-dsp: make Headphone Playback Switch conditional

### DIFF
--- a/ucm2/sof-hda-dsp/HiFi.conf
+++ b/ucm2/sof-hda-dsp/HiFi.conf
@@ -9,13 +9,20 @@ SectionVerb {
 SectionDevice."Headphones" {
 	Comment "Headphones"
 
-	EnableSequence [
-		cset "name='Headphone Playback Switch' on"
-	]
-
-	DisableSequence [
-		cset "name='Headphone Playback Switch' off"
-	]
+	If.headphone_switch {
+		Condition {
+			Type ControlExists
+			Control "name='Headphone Playback Switch'"
+		}
+		True {
+			EnableSequence [
+				cset "name='Headphone Playback Switch' on"
+			]
+			DisableSequence [
+				cset "name='Headphone Playback Switch' off"
+			]
+		}
+	}
 
 	Value {
 		PlaybackPriority 200


### PR DESCRIPTION
The Headphone Playback Switch control is not present in all
HDA codecs. Allow the Headphones definition to work also on
such systems.

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>