### PR TITLE
sof-hda-dsp: add initial kcontrol values

### DIFF
--- a/ucm2/sof-hda-dsp/sof-hda-dsp.conf
+++ b/ucm2/sof-hda-dsp/sof-hda-dsp.conf
@@ -4,3 +4,24 @@ SectionUseCase."HiFi" {
 	File "HiFi.conf"
 	Comment "Play HiFi quality Music"
 }
+
+# the kcontrols initial values, which will be set by `alsactl init`
+
+BootSequence [
+	cset "name='Master Playback Volume' 80"
+	cset "name='Headphone Playback Volume' 80"
+	cset "name='Speaker Playback Volume' 80"
+	cset "name='Auto-Mute Mode' off"
+]
+
+If.Dmic0 {
+	Condition {
+		Type ControlExists
+		Control "name='Dmic0 Capture Volume'"
+	}
+	True {
+		BootSequence [
+			cset "name='Dmic0 Capture Volume' 70"
+		]
+	}
+}


### PR DESCRIPTION
This patch adds the initial values of sof-hda-dsp card.

Signed-off-by: Libin Yang <libin.yang@intel.com>