### PR TITLE
sof-soundwire: initial UCM2 version

### DIFF
--- a/ucm2/codecs/rt5682/init.conf
+++ b/ucm2/codecs/rt5682/init.conf
@@ -1,0 +1,24 @@
+# RT5682 specific volume control settings
+If.RT5682init {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "hs:rt5682"
+	}
+	True {
+		BootSequence [
+			cset "name='rt5682 Stereo1 DAC MIXL DAC L1 Switch' 1"
+			cset "name='rt5682 Stereo1 DAC MIXR DAC R1 Switch' 1"
+			cset "name='rt5682 DAC L Mux' 1"
+			cset "name='rt5682 DAC R Mux' 1"
+			cset "name='rt5682 IF1 01 ADC Swap Mux' 2"
+			cset "name='rt5682 CBJ Boost Volume' 3"
+			cset "name='rt5682 Stereo1 ADC L Mux' 0"
+			cset "name='rt5682 Stereo1 ADC R Mux' 0"
+			cset "name='rt5682 Stereo1 ADC L1 Mux' 1"
+			cset "name='rt5682 Stereo1 ADC R1 Mux' 1"
+			cset "name='rt5682 Stereo1 ADC MIXL ADC2 Switch' 0"
+			cset "name='rt5682 Stereo1 ADC MIXR ADC2 Switch' 0"
+		]
+	}
+}

--- a/ucm2/codecs/rt700/init.conf
+++ b/ucm2/codecs/rt700/init.conf
@@ -1,0 +1,17 @@
+# RT700 specific volume control settings
+If.rt700init {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "hs:rt700"
+	}
+	True {
+		BootSequence [
+			cset "name='DAC Front Playback Volume' 87"
+			cset "name='HPO Mux' 'Front'"
+			cset "name='ADC 09 Capture Volume' 63"
+			cset "name='ADC 22 Mux' 'MIC2'"
+			cset "name='AMIC Volume' 1"
+		]
+	}
+}

--- a/ucm2/codecs/rt711/init.conf
+++ b/ucm2/codecs/rt711/init.conf
@@ -1,0 +1,17 @@
+# RT711 specific volume control settings
+If.rt711init {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "hs:rt711"
+	}
+	True {
+		BootSequence [
+			cset "name='rt711 DAC Surr Playback Volume' 87"
+			cset "name='rt711 ADC 08 Capture Volume' 63"
+			cset "name='rt711 ADC 23 Mux' 'MIC2'"
+			cset "name='rt711 ADC 08 Capture Switch' 1"
+			cset "name='rt711 AMIC Volume' 1"
+		]
+	}
+}

--- a/ucm2/codecs/rt715/init.conf
+++ b/ucm2/codecs/rt715/init.conf
@@ -1,0 +1,19 @@
+# RT715 specific volume control settings
+If.RT715init {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "mic:rt715"
+	}
+	True {
+		BootSequence [
+			cset "name='rt715 DMIC3 Boost' 2"
+			cset "name='rt715 DMIC4 Boost' 2"
+			cset "name='rt715 ADC 24 Mux' 3"
+			cset "name='rt715 ADC 25 Mux' 4"
+			cset "name='rt715 ADC 27 Capture Switch' 1"
+			cset "name='rt715 ADC 07 Capture Switch' 1"
+
+		]
+	}
+}

--- a/ucm2/sof-soundwire/Hdmi.conf
+++ b/ucm2/sof-soundwire/Hdmi.conf
@@ -1,0 +1,79 @@
+# Use case Configuration for sof-soundwire card
+
+If.hdmi1 {
+	Condition {
+		Type ControlExists
+		Control "iface=CARD,name='HDMI/DP,pcm=5 Jack'"
+	}
+	True {
+		SectionDevice."HDMI1" {
+			Comment "HDMI1/DP1 Output"
+
+			EnableSequence [
+				cset "name='IEC958 Playback Switch' on"
+			]
+
+			DisableSequence [
+				cset "name='IEC958 Playback Switch' off"
+			]
+
+			Value {
+				PlaybackPriority 500
+				PlaybackPCM "hw:${CardId},5"
+				JackControl "HDMI/DP,pcm=5 Jack"
+			}
+		}
+	}
+}
+
+If.hdmi2 {
+	Condition {
+		Type ControlExists
+		Control "iface=CARD,name='HDMI/DP,pcm=6 Jack'"
+	}
+	True {
+		SectionDevice."HDMI2" {
+			Comment "HDMI2/DP2 Output"
+
+			EnableSequence [
+				cset "name='IEC958 Playback Switch',index=1 on"
+			]
+
+			DisableSequence [
+				cset "name='IEC958 Playback Switch',index=1 off"
+			]
+
+			Value {
+				PlaybackPriority 600
+				PlaybackPCM "hw:${CardId},6"
+				JackControl "HDMI/DP,pcm=6 Jack"
+			}
+		}
+	}
+}
+
+If.hdmi3 {
+	Condition {
+		Type ControlExists
+		Control "iface=CARD,name='HDMI/DP,pcm=7 Jack'"
+	}
+	True {
+		SectionDevice."HDMI3" {
+			Comment "HDMI3/DP3 Output"
+
+			EnableSequence [
+				cset "name='IEC958 Playback Switch',index=2 on"
+			]
+
+			DisableSequence [
+				cset "name='IEC958 Playback Switch',index=2 off"
+			]
+
+			Value {
+				PlaybackPriority 700
+				PlaybackPCM "hw:${CardId},7"
+				JackControl "HDMI/DP,pcm=7 Jack"
+			}
+		}
+	}
+}

--- a/ucm2/sof-soundwire/HiFi.conf
+++ b/ucm2/sof-soundwire/HiFi.conf
@@ -1,0 +1,8 @@
+# Use case Configuration for sof-soundwire card
+
+<sof-soundwire/RT700.conf>
+<sof-soundwire/RT711.conf>
+<sof-soundwire/RT5682.conf>
+<sof-soundwire/RT1308.conf>
+<sof-soundwire/RT715.conf>
+<sof-soundwire/Hdmi.conf>

--- a/ucm2/sof-soundwire/RT1308-1.conf
+++ b/ucm2/sof-soundwire/RT1308-1.conf
@@ -1,0 +1,23 @@
+# Use case Configuration for sof-soundwire card
+
+SectionDevice."Speaker" {
+	Comment	"Speaker"
+
+	EnableSequence [
+		cset "name='rt1308-1 DAC L Switch' 1"
+		cset "name='rt1308-1 DAC R Switch' 1"
+		cset "name='Speaker Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='rt1308-1 DAC L Switch' 0"
+		cset "name='rt1308-1 DAC R Switch' 0"
+		cset "name='Speaker Switch' off"
+	]
+
+	Value {
+	      PlaybackPriority 100
+	      PlaybackPCM "hw:${CardId},2"
+	      PlaybackChannels "2"
+	}
+}

--- a/ucm2/sof-soundwire/RT1308-2.conf
+++ b/ucm2/sof-soundwire/RT1308-2.conf
@@ -1,0 +1,30 @@
+# Use case Configuration for sof-soundwire card
+
+SectionDevice."Speaker" {
+	Comment	"Speaker"
+
+	EnableSequence [
+		cset "name='rt1308-1 RX Channel Select' LL"
+		cset "name='rt1308-2 RX Channel Select' RR"
+
+		cset "name='rt1308-1 DAC L Switch' 1"
+		cset "name='rt1308-1 DAC R Switch' 1"
+		cset "name='rt1308-2 DAC L Switch' 1"
+		cset "name='rt1308-2 DAC R Switch' 1"
+		cset "name='Speaker Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='rt1308-1 DAC L Switch' 0"
+		cset "name='rt1308-1 DAC R Switch' 0"
+		cset "name='rt1308-2 DAC L Switch' 0"
+		cset "name='rt1308-2 DAC R Switch' 0"
+		cset "name='Speaker Switch' off"
+	]
+
+	Value {
+	      PlaybackPriority 100
+	      PlaybackPCM "hw:${CardId},2"
+	      PlaybackChannels "2"
+	}
+}

--- a/ucm2/sof-soundwire/RT1308.conf
+++ b/ucm2/sof-soundwire/RT1308.conf
@@ -1,0 +1,30 @@
+# Use case Configuration for sof-soundwire card
+# alsaucm -c sof-soundwire  set _verb HiFi set _enadev Speaker
+
+If.RT1308 {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "spk:rt1308"
+	}
+	True {
+
+		If.2ch {
+			Condition {
+				Type String
+				Haystack "${CardComponents}"
+				Needle "cfg-spk:2"
+			}
+			True {
+
+<sof-soundwire/RT1308-1.conf>
+
+			}
+			False {
+
+<sof-soundwire/RT1308-2.conf>
+
+			}
+		}
+	}
+}

--- a/ucm2/sof-soundwire/RT5682.conf
+++ b/ucm2/sof-soundwire/RT5682.conf
@@ -1,0 +1,62 @@
+# Use case Configuration for sof-soundwire card
+
+If.RT5682 {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+        	Needle "hs:rt5682" 
+	}
+	True {
+
+		SectionDevice."Headphones" {
+			Comment	"Headphones"
+
+			EnableSequence [
+				cset "name='Headphone Switch' on"
+				cset "name='rt5682 HPOL Playback Switch' 1"
+				cset "name='rt5682 HPOR Playback Switch' 1"
+			]
+
+			DisableSequence [
+				cset "name='rt5682 HPOL Playback Switch' 0"
+				cset "name='rt5682 HPOR Playback Switch' 0"
+				cset "name='Headphone Switch' off"
+
+			]
+
+			Value {
+			      PlaybackPriority 200
+			      PlaybackPCM "hw:${CardId},0"
+			      PlaybackChannels "2"
+			      JackControl "Headphone Jack"
+			}
+		}
+
+		SectionDevice."Headset" {
+			Comment "Headset Microphone"
+
+			EnableSequence [
+				cset "name='Headset Mic Switch' on"
+				cset "name='rt5682 STO1 ADC Capture Switch' 1"
+				cset "name='rt5682 RECMIX1L CBJ Switch' 1"
+				cset "name='rt5682 Stereo1 ADC MIXL ADC1 Switch' 1"
+				cset "name='rt5682 Stereo1 ADC MIXR ADC1 Switch' 1"
+			]
+
+			DisableSequence [
+				cset "name='rt5682 STO1 ADC Capture Switch' 0"
+				cset "name='rt5682 RECMIX1L CBJ Switch' 0"
+				cset "name='rt5682 Stereo1 ADC MIXL ADC1 Switch' 0"
+				cset "name='rt5682 Stereo1 ADC MIXR ADC1 Switch' 0"
+				cset "name='Headset Mic Switch' off"
+			]
+
+			Value {
+				CapturePriority 200
+			     	CapturePCM "hw:${CardId},1"
+			      	CaptureChannels "2"
+			      	JackControl "Headset Mic Jack"
+			}
+		}
+	}
+}

--- a/ucm2/sof-soundwire/RT700.conf
+++ b/ucm2/sof-soundwire/RT700.conf
@@ -1,0 +1,75 @@
+# Use case Configuration for sof-soundwire card
+
+If.RT700 {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+        	Needle "hs:rt700" 
+	}
+	True {
+
+		SectionDevice."Headphones" {
+			Comment	"Headphones"
+
+			ConflictingDevice [
+				"Speaker"
+			]
+
+			EnableSequence [
+				cset "name='Headphones Switch' on"
+			]
+
+			DisableSequence [
+				cset "name='Headphones Switch' off"
+			]
+
+			Value {
+			      PlaybackPriority 200
+			      PlaybackPCM "hw:${CardId},0"
+			      PlaybackChannels "2"
+			      JackControl "Headphone Jack"
+			}
+		}
+
+		SectionDevice."Speaker" {
+			Comment	"Speaker"
+			
+			ConflictingDevice [
+				"Headphones"
+			]
+
+			EnableSequence [
+				cset "name='Speaker Switch' on"
+			]
+
+			DisableSequence [
+				cset "name='Speaker Switch' off"
+			]
+
+			Value {
+			      PlaybackPriority 100
+			      PlaybackPCM "hw:${CardId},0"
+			      PlaybackChannels "2"
+			}
+		}
+
+		SectionDevice."Headset" {
+			Comment "Headset Microphone"
+
+			EnableSequence [
+				cset "name='ADC 09 Capture Switch' 1"
+			]
+
+			DisableSequence [
+				cset "name='ADC 09 Capture Switch' 0"
+			]
+
+			Value {
+				CapturePriority 200
+			     	CapturePCM "hw:${CardId},1"
+			      	CaptureChannels "2"
+			      	JackControl "Headset Mic Jack"
+			}
+		}
+	}
+}

--- a/ucm2/sof-soundwire/RT711.conf
+++ b/ucm2/sof-soundwire/RT711.conf
@@ -1,0 +1,51 @@
+# Use case Configuration for sof-soundwire card
+
+If.RT711 {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+        	Needle "hs:rt711" 
+	}
+	True {
+
+		SectionDevice."Headphones" {
+			Comment	"Headphones"
+
+			EnableSequence [
+				cset "name='Headphone Switch' on"
+			]
+
+			DisableSequence [
+				cset "name='Headphone Switch' off"
+			]
+
+			Value {
+			      PlaybackPriority 200
+			      PlaybackPCM "hw:${CardId},0"
+			      PlaybackChannels "2"
+			      JackControl "Headphone Jack"
+			}
+		}
+
+		SectionDevice."Headset" {
+			Comment "Headset Microphone"
+
+			EnableSequence [
+				cset "name='PGA2.0 2 Master Capture Switch' 1"
+			]
+
+			DisableSequence [
+				cset "name='PGA2.0 2 Master Capture Switch' 0"
+			]
+
+			Value {
+				CapturePriority 200
+			     	CapturePCM "hw:${CardId},1"
+			      	CaptureChannels "2"
+			      	JackControl "Headset Mic Jack"
+				CaptureSwitch "PGA2.0 2 Master Capture Switch"
+				CaptureVolume "PGA2.0 2 Master Capture Volume"
+			}
+		}
+	}
+}

--- a/ucm2/sof-soundwire/RT715.conf
+++ b/ucm2/sof-soundwire/RT715.conf
@@ -1,0 +1,31 @@
+# Use case Configuration for sof-soundwire card
+
+If.RT715 {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+        	Needle "mic:rt715"
+	}
+	True {
+
+		SectionDevice."Mic" {
+			Comment	"SoundWire microphones"
+
+			EnableSequence [
+				cset "name='PGA5.0 5 Master Capture Switch' 1"
+			]
+
+			DisableSequence [
+				cset "name='PGA5.0 5 Master Capture Switch' 0"
+			]
+
+			Value {
+			      CapturePriority 100
+			      CapturePCM "hw:${CardId},4"
+			      CaptureChannels "2"
+			      CaptureSwitch "PGA5.0 5 Master Capture Switch"
+			      CaptureVolume "PGA5.0 5 Master Capture Volume"
+			}
+		}
+	}
+}

--- a/ucm2/sof-soundwire/sof-soundwire.conf
+++ b/ucm2/sof-soundwire/sof-soundwire.conf
@@ -1,0 +1,11 @@
+Syntax 2
+
+SectionUseCase."HiFi" {
+	File "HiFi.conf"
+	Comment "Play HiFi quality Music"
+}
+
+<codecs/rt5682/init.conf>
+<codecs/rt700/init.conf>
+<codecs/rt711/init.conf>
+<codecs/rt715/init.conf>


### PR DESCRIPTION
Add support for sof-soundwire driver, with conditional inclusion of
sections for RT700, RT711, RT5682, RT1308, RT715.

Required test files for the ucm-validation are provided at https://github.com/alsa-project/alsa-tests/pull/10

Signed-off-by: Libin Yang <libin.yang@linux.intel.com>
Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>