### PR TITLE
Sof hda dsp fixup

### DIFF
--- a/ucm2/sof-hda-dsp/Hdmi.conf
+++ b/ucm2/sof-hda-dsp/Hdmi.conf
@@ -8,7 +8,7 @@ If.hdmi1 {
 			HdmiPCM 3
 			HdmiPrio 500
 		}
-		Include.hdmi1.File "/codec/hda/hdmi.conf"
+		Include.hdmi1.File "/codecs/hda/hdmi.conf"
 	}
 }
 
@@ -20,7 +20,7 @@ If.hdmi2 {
 			HdmiPCM 4
 			HdmiPrio 600
 		}
-		Include.hdmi2.File "/codec/hda/hdmi.conf"
+		Include.hdmi2.File "/codecs/hda/hdmi.conf"
 	}
 }
 
@@ -32,6 +32,6 @@ If.hdmi3 {
 			HdmiPCM 5
 			HdmiPrio 700
 		}
-		Include.hdmi3.File "/codec/hda/hdmi.conf"
+		Include.hdmi3.File "/codecs/hda/hdmi.conf"
 	}
 }

--- a/ucm2/sof-hda-dsp/HiFi.conf
+++ b/ucm2/sof-hda-dsp/HiFi.conf
@@ -43,4 +43,4 @@ SectionDevice."Mic1" {
 	}
 }
 
-<HDA-Intel/Hdmi.conf>
+<sof-hda-dsp/Hdmi.conf>


### PR DESCRIPTION
This PR does such fixup:
fixup typo "codec" => "codecs"
sof-hda-dsp should include sof-hda-dsp/Hdmi.conf not HDA-Intel/Hdmi.conf