### PR TITLE
ucm2: Add config for Rockchip/rk3399-gru-sound

### DIFF
--- a/ucm2/ASUS Google Nexus 7 ALC5642/ASUS Google Nexus 7 ALC5642.conf
+++ b/ucm2/ASUS Google Nexus 7 ALC5642/ASUS Google Nexus 7 ALC5642.conf
@@ -1,0 +1,8 @@
+# Use case Configuration for ASUS Google Nexus 7 (2012)
+
+Syntax 2
+
+SectionUseCase."HiFi" {
+	File "HiFi.conf"
+	Comment "Play HiFi quality Music"
+}

--- a/ucm2/ASUS Google Nexus 7 ALC5642/HiFi.conf
+++ b/ucm2/ASUS Google Nexus 7 ALC5642/HiFi.conf
@@ -1,0 +1,105 @@
+# Use case Configuration for ASUS Google Nexus 7 (2012)
+# Based on codecs/rt5640/*
+
+SectionVerb {
+	EnableSequence [
+		# RT5640 Output Configuration
+		cset "name='Speaker Playback Volume' 15"
+		cset "name='HP Playback Volume' 10"
+		cset "name='DAC1 Playback Volume' 175"
+
+		# RT5640 Output Routing
+		cset "name='OUT MIXL DAC L1 Switch' on"
+		cset "name='OUT MIXR DAC R1 Switch' on"
+		cset "name='SDI select' 0"
+		cset "name='DAI select' 0"
+		cset "name='DAC2 Playback Switch' on"
+		cset "name='DIG MIXL DAC L2 Switch' on"
+		cset "name='DAC MIXL INF1 Switch' on"
+		cset "name='DAC MIXR INF1 Switch' on"
+ 		cset "name='Stereo DAC MIXL DAC L1 Switch' on"
+ 		cset "name='Stereo DAC MIXR DAC R1 Switch' on"
+		cset "name='Stereo DAC MIXL DAC L2 Switch' on"
+ 		cset "name='Stereo DAC MIXR DAC R2 Switch' on"
+
+		# RT5640 Speakers Routing
+		cset "name='SPK MIXL DAC L1 Switch' on"
+		cset "name='SPK MIXR DAC R1 Switch' on"
+		cset "name='SPOL MIX SPKVOL L Switch' on"
+		cset "name='SPOR MIX SPKVOL R Switch' on"
+		cset "name='SPOL MIX SPKVOL R Switch' off"
+		cset "name='Speaker Channel Switch' on"
+
+		# NVIDIA Tegra RT5640 Speakers Switch
+		cset "name='Speakers Switch' on"
+
+		# RT5640 Headphones Routing
+ 		cset "name='HPO MIX HPVOL Switch' on"
+		cset "name='HP Channel Switch' on"
+
+		# RT5640 Input Configuration
+		cset "name='ADC Capture Volume' 110"
+		cset "name='ADC Boost Gain' 1"
+
+		# RT5640 Microphone Routing
+		cset "name='Stereo ADC1 Mux' ADC"
+		cset "name='Stereo ADC2 Mux' DMIC1"
+		cset "name='Stereo ADC MIXL ADC2 Switch' on"
+		cset "name='Stereo ADC MIXR ADC2 Switch' on"
+		cset "name='ADC Capture Switch' on"
+	]
+}
+
+SectionDevice."Speakers" {
+	Comment "Speakers"
+
+	ConflictingDevice [
+		"Headphones"
+	]
+
+	EnableSequence [
+		cset "name='HP L Playback Switch' off"
+		cset "name='HP R Playback Switch' off"
+		cset "name='Speaker L Playback Switch' on"
+		cset "name='Speaker R Playback Switch' on"
+	]
+
+	Value {
+		PlaybackPCM "hw:${CardId}"
+		PlaybackMixerElem "Speaker"
+		PlaybackMasterElem "DAC1"
+	}
+}
+
+SectionDevice."Headphones" {
+	Comment "Headphones"
+
+	ConflictingDevice [
+		"Speakers"
+	]
+
+	EnableSequence [
+		cset "name='Speaker L Playback Switch' off"
+		cset "name='Speaker R Playback Switch' off"
+		cset "name='HP L Playback Switch' on"
+		cset "name='HP R Playback Switch' on"
+	]
+
+	Value {
+		PlaybackPCM "hw:${CardId}"
+		PlaybackMixerElem "HP"
+		PlaybackMasterElem "DAC1"
+
+		# NVIDIA Tegra GPIO RT5640 Headphones Jack
+		JackControl "Headphones Jack"
+	}
+}
+
+SectionDevice."DigitalMics" {
+	Comment "Internal Microphone"
+
+	Value {
+		CapturePCM "hw:${CardId}"
+		CaptureMixerElem "ADC"
+	}
+}

--- a/ucm2/Acer Iconia Tab A500 WM8903/Acer Iconia Tab A500 WM8903.conf
+++ b/ucm2/Acer Iconia Tab A500 WM8903/Acer Iconia Tab A500 WM8903.conf
@@ -1,0 +1,8 @@
+# Use case Configuration for Acer Iconia Tab A500
+
+Syntax 2
+
+SectionUseCase."HiFi" {
+	File "HiFi.conf"
+	Comment "Play HiFi quality Music"
+}

--- a/ucm2/Acer Iconia Tab A500 WM8903/HiFi.conf
+++ b/ucm2/Acer Iconia Tab A500 WM8903/HiFi.conf
@@ -1,0 +1,112 @@
+# Use case Configuration for Acer Iconia Tab A500
+
+SectionVerb {
+	EnableSequence [
+		# WM8903 Output Configuration
+		cset "name='Digital Playback Volume' 80"
+		cset "name='Headphone Volume' 42"
+		cset "name='Line Out Volume' 42"
+		cset "name='DAC Boost Volume' 0"
+
+		# WM8903 Output Routing
+		cset "name='Left Output Mixer DACL Switch' on"
+		cset "name='Left Output Mixer DACR Switch' off"
+		cset "name='Right Output Mixer DACL Switch' off"
+		cset "name='Right Output Mixer DACR Switch' on"
+		cset "name='Int Spk Switch' on"
+
+		# WM8903 Input Configuration
+		cset "name='Digital Capture Volume' 120"
+		cset "name='DRC Compressor Threshold Volume' 124"
+		cset "name='DRC Compressor Slope R0' 1"
+		cset "name='DRC Compressor Slope R1' 1"
+		cset "name='DRC Maximum Gain Volume' 1"
+		cset "name='DRC Minimum Gain Volume' 0"
+		cset "name='DRC Volume' 13"
+
+		# WM8903 Input Routing
+		cset "name='Left Input PGA Switch' on"
+		cset "name='Right Input PGA Switch' on"
+		cset "name='Int Mic Switch' on"
+	]
+}
+
+SectionDevice."Speakers" {
+	Comment "Speakers"
+
+	ConflictingDevice [
+		"Headphones"
+	]
+
+	EnableSequence [
+		cset "name='Headphone Switch' off"
+		cset "name='Line Out Switch' on"
+	]
+
+	Value {
+		PlaybackPCM "hw:${CardId}"
+		PlaybackMixerElem "Line Out"
+	}
+}
+
+SectionDevice."Headphones" {
+	Comment "Headphones"
+
+	ConflictingDevice [
+		"Speakers"
+	]
+
+	EnableSequence [
+		cset "name='Line Out Switch' off"
+		cset "name='Headphone Switch' on"
+	]
+
+	Value {
+		PlaybackPCM "hw:${CardId}"
+		PlaybackMixerElem "Headphone"
+		JackControl "Headphone Jack"
+	}
+}
+
+SectionDevice."InternalMic" {
+	Comment "Internal Microphone"
+
+	ConflictingDevice [
+		"HeadsetMic"
+	]
+
+	EnableSequence [
+		cset "name='Left Input PGA Volume' 31"
+		cset "name='Right Input PGA Volume' 31"
+		cset "name='Left Input Inverting Mux' IN1L"
+		cset "name='Right Input Inverting Mux' IN1R"
+		cset "name='DRC Switch' on"
+	]
+
+	Value {
+		CapturePCM "hw:${CardId}"
+		CaptureMixerElem "Digital"
+	}
+}
+
+SectionDevice."HeadsetMic" {
+	Comment "Headset Microphone"
+
+	ConflictingDevice [
+		"InternalMic"
+	]
+
+	EnableSequence [
+		cset "name='Left Input PGA Volume' 25"
+		cset "name='Right Input PGA Volume' 25"
+		cset "name='Left Input Inverting Mux' IN2L"
+		cset "name='Right Input Inverting Mux' IN2R"
+		cset "name='DRC Switch' off"
+	]
+
+	Value {
+		CapturePCM "hw:${CardId}"
+		CaptureMixerElem "Digital"
+		JackControl "Mic Jack"
+	}
+}

--- a/ucm2/README.md
+++ b/ucm2/README.md
@@ -12,7 +12,12 @@ configurations. They contain files included from other UCMs.
 
 UCM master configuration path lookup is defined in the top level
 ucm.conf file. This file allows custom directory layout. The new
-ucm2 layout is based on the driver name.
+ucm2 layout is based on the kernel module driver name with the
+ALSA driver name fallback.
+
+The lookup configuration:
+
+  https://git.alsa-project.org/?p=alsa-ucm-conf.git;a=blob;f=ucm2/ucm.conf
 
 Example paths:
 
@@ -21,8 +26,15 @@ Example paths:
 - TwoCardsMix/TwoCardsMix.conf
 -- virtual UCM from two soundcards
 
-Note: For the driver configurations, use always the real driver name
-not the ucm card name configuration paths!
+Note: For the driver configurations, use always the real kernel driver
+name or the ALSA driver name - not the ucm card name configuration paths!
+
+The kernel driver name is obtained using sysfs like (last
+part of the path is used from the symlink):
+
+````
+  /sys/class/sound/card0/device/driver
+````
 
 The driver name can be obtained using procfs like:
 

--- a/ucm2/Rockchip/rk3399-gru-sound/HiFi.conf
+++ b/ucm2/Rockchip/rk3399-gru-sound/HiFi.conf
@@ -1,0 +1,129 @@
+SectionVerb {
+	Value {
+		MinBufferLevel "512"
+	}
+
+	EnableSequence [
+		cset "name='Stereo1 DMIC Mux' DMIC1"
+		cset "name='Sto1 ADC MIXL DMIC Switch' on"
+		cset "name='Sto1 ADC MIXR DMIC Switch' on"
+
+		cset "name='Mixer Out FilterL DACL Switch' on"
+		cset "name='Mixer Out FilterR DACR Switch' on"
+		cset "name='Playback Digital Switch' on"
+		cset "name='Headphone Switch' on"
+
+		cset "name='Mixin Volume' 11"
+		cset "name='Mixin Switch' on"
+		cset "name='Mixer In Mic Switch' on"
+		cset "name='Out DAIL Mux' ADC"
+		cset "name='Out DAIR Mux' ADC"
+		cset "name='ADC1 Capture Volume' 51"
+		cset "name='Mic Volume' 6"
+		cset "name='Capture Digital Switch' on"
+		cset "name='Mic Switch' on"
+
+		cset "name='Speakers Switch' off"
+		cset "name='Int Mic Switch' off"
+		cset "name='Headphones Switch' off"
+		cset "name='Headset Mic Switch' off"
+	]
+}
+
+SectionDevice."Speaker" {
+	Comment "Speaker"
+
+	Value {
+		PlaybackPriority 100
+		PlaybackPCM "hw:${CardId},0"
+		PlaybackMixerElem "Speakers"
+		PlaybackRate "48000"
+	}
+
+	EnableSequence [
+		cset "name='Speakers Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Speakers Switch' off"
+	]
+
+	ConflictingDevice [
+		"Headphones"
+	]
+}
+
+SectionDevice."Mic" {
+	Comment "Internal Microphone"
+
+	Value {
+		CapturePriority 100
+		CapturePCM "hw:${CardId},1"
+		CaptureMixerElem "ADC1"
+		CaptureRate "48000"
+	}
+
+	EnableSequence [
+		cset "name='Int Mic Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Int Mic Switch' off"
+	]
+
+	ConflictingDevice [
+		"Headset"
+	]
+}
+
+SectionDevice."Headphones" {
+	Comment "Headphones"
+
+	Value {
+		PlaybackPriority 200
+		PlaybackPCM "hw:${CardId},2"
+		PlaybackMixerElem "Headphone"
+		JackControl "Headphones Jack"
+		PlaybackRate "48000"
+	}
+
+	EnableSequence [
+		cset "name='Headphones Switch' on"
+		cset "name='DAC Soft Mute Switch' off"
+		cset "name='Headphone Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Headphone Switch' off"
+		cset "name='DAC Soft Mute Switch' on"
+		cset "name='Headphones Switch' off"
+	]
+
+	ConflictingDevice [
+		"Speaker"
+	]
+}
+
+SectionDevice."Headset" {
+	Comment "Headset Microphone"
+
+	Value {
+		CapturePriority 200
+		CapturePCM "hw:${CardId},2"
+		CaptureMixerElem "Mic"
+		JackControl "Headset Mic Jack"
+		CaptureRate "48000"
+	}
+
+	EnableSequence [
+		cset "name='Headset Mic Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Headset Mic Switch' off"
+	]
+
+	ConflictingDevice [
+		"Mic"
+	]
+}

--- a/ucm2/Rockchip/rk3399-gru-sound/rk3399-gru-sound.conf
+++ b/ucm2/Rockchip/rk3399-gru-sound/rk3399-gru-sound.conf
@@ -1,0 +1,8 @@
+Syntax 2
+
+Comment "Rockchip Gru card"
+
+SectionUseCase."HiFi" {
+	File "/Rockchip/rk3399-gru-sound/HiFi.conf"
+	Comment "Default"
+}

--- a/ucm2/module/rk3399-gru-sound.conf
+++ b/ucm2/module/rk3399-gru-sound.conf
@@ -1,0 +1,1 @@
+../Rockchip/rk3399-gru-sound/rk3399-gru-sound.conf


### PR DESCRIPTION
This is the internal card for a number of ChromeOS devices based on the Gru board. Config is taken from ChromeOS sources [1] and modified to mostly look like Rockchip/max98090. Tested on a Samsung Chromebook Plus (rk3399-gru-kevin) running Linux 5.7+.

[1] https://chromium.googlesource.com/chromiumos/overlays/board-overlays/+/75cf7da335c11469956c84ddfa4e2ca73b268441/overlay-kevin/chromeos-base/chromeos-bsp-kevin/files/audio-config/ucm-config/rk3399-gru-sound

Signed-off-by: Alper Nebi Yasak \<alpernebiyasak@gmail.com\>

---

I've tested this on a Debian installation (with alsa-lib version 1.2.2) meaning I had to put the two files to /usr/share/alsa/ucm2/rk3399-gru-sound/ instead of .../Rockchip/rk3399-gru-sound, so I hope the latter is a correct path for them with later versions.

All four devices work, but I couldn't get the Speaker/Headphones to play different things or the Mic/Headset to record simultaneously, so I marked those pairs as "ConflictingDevice"s. Without that, e.g. I see all devices in pulseaudio, but when I play two different audio files to Speaker/Headphones sinks I hear an alternating mix of both files on both devices; and both Mic/Headset sources end up recording only from the headset microphone in an alternating way. 

Pulseaudio doesn't recognize the headset jack, but acpi_listen does report "jack/headphone HEADPHONE plug" events. I'll look into this more, my best guess now is that the kernel doesn't expose the jack in a way it should.

I also uploaded the alsa-info.sh output to cardinfo database:
http://alsa-project.org/db/?f=9b4102975fa9c0f109af6ad687c856c620d76909