### PR TITLE
Remove cset value quotation

### DIFF
--- a/ucm2/HDA-Intel/HiFi-analog.conf
+++ b/ucm2/HDA-Intel/HiFi-analog.conf
@@ -95,7 +95,7 @@ If.monomic {
 			]
 
 			EnableSequence [
-				cset "name='Input Source' 'Headphone Mic'"
+				cset "name='Input Source' Headphone Mic"
 			]
 
 			Value {
@@ -109,7 +109,7 @@ If.monomic {
 			Comment "Headset Mono Microphone"
 
 			EnableSequence [
-				cset "name='Input Source' 'Headset Mic'"
+				cset "name='Input Source' Headset Mic"
 			]
 
 			Value {

--- a/ucm2/codecs/cx2072x/HeadsetMic.conf
+++ b/ucm2/codecs/cx2072x/HeadsetMic.conf
@@ -7,7 +7,7 @@ SectionDevice."Headset" {
 
 	EnableSequence [
 		cset "name='Headset Mic Switch' on"
-		cset "name='ADC1 Mux' 'PortD Switch'"
+		cset "name='ADC1 Mux' PortD Switch"
 		cset "name='PortD In En Switch' on"
 	]
 

--- a/ucm2/codecs/cx2072x/InternalMic.conf
+++ b/ucm2/codecs/cx2072x/InternalMic.conf
@@ -7,7 +7,7 @@ SectionDevice."Mic" {
 
 	EnableSequence [
 		cset "name='Int Mic Switch' on"
-		cset "name='ADC1 Mux' 'PortC Switch'"
+		cset "name='ADC1 Mux' PortC Switch"
 		cset "name='PortC In En Switch' on"
 	]
 

--- a/ucm2/codecs/rt700/init.conf
+++ b/ucm2/codecs/rt700/init.conf
@@ -2,8 +2,8 @@
 
 BootSequence [
 	cset "name='DAC Front Playback Volume' 87"
-	cset "name='HPO Mux' 'Front'"
+	cset "name='HPO Mux' Front"
 	cset "name='ADC 09 Capture Volume' 63"
-	cset "name='ADC 22 Mux' 'MIC2'"
+	cset "name='ADC 22 Mux' MIC2"
 	cset "name='AMIC Volume' 1"
 ]

--- a/ucm2/codecs/rt711/init.conf
+++ b/ucm2/codecs/rt711/init.conf
@@ -3,7 +3,7 @@
 BootSequence [
 	cset "name='rt711 DAC Surr Playback Volume' 87"
 	cset "name='rt711 ADC 08 Capture Volume' 63"
-	cset "name='rt711 ADC 23 Mux' 'MIC2'"
+	cset "name='rt711 ADC 23 Mux' MIC2"
 	cset "name='rt711 ADC 08 Capture Switch' 1"
 	cset "name='rt711 AMIC Volume' 1"
 ]


### PR DESCRIPTION
This patchset removes the quotation marks of the cset values in the ucm2 config files.
In ucm2 files, the cset values should not use quotation marks. Otherwise, the cset won't work. 