### PR TITLE
amd/renoir/acp: use the machine driver's name for top-level's conf

### DIFF
--- a/ucm2/HDA-Intel/HiFi.conf
+++ b/ucm2/HDA-Intel/HiFi.conf
@@ -9,24 +9,25 @@ If.analog {
 		Type ControlExists
 		Control "name='Master Playback Switch'"
 	}
-	True.Include.analog.File "/HDA-Intel/HiFi-analog.conf"
+	True {
+		Include.analog.File "/HDA-Intel/HiFi-analog.conf"
+		If.acp {
+			Condition {
+				Type String
+				Empty "${var:AcpCardId}"
+			}
+			True {
+				RenameDevice."Mic1" "Mic"
+			}
+			False.Include.acp {
+				Before.SectionDevice "Mic1"
+				File "/HDA-Intel/HiFi-acp.conf"
+			}
+		}
+	}
 }
 
 If.hdmi {
 	Condition { Type String Empty "" }
 	True.Include.hdmi.File "/HDA-Intel/Hdmi.conf"
-}
-
-If.acp {
-	Condition {
-		Type String
-		Empty "${var:AcpCardId}"
-	}
-	True {
-		RenameDevice."Mic1" "Mic"
-	}
-	False.Include.acp {
-		Before.SectionDevice "Mic1"
-		File "/HDA-Intel/HiFi-acp.conf"
-	}
 }


### PR DESCRIPTION
On the machines with amd renoir audio, the /sys/class/sound/card2/
device/driver links to /sys/bus/platform/drivers/acp_pdm_mach.

Signed-off-by: Hui Wang <hui.wang@canonical.com>