### PR TITLE
Add support for Lenovo ThinkStation P620 Main Audio

### DIFF
--- a/ucm2/USB-Audio/Lenovo-ThinkStation-P620-Main-HiFi.conf
+++ b/ucm2/USB-Audio/Lenovo-ThinkStation-P620-Main-HiFi.conf
@@ -1,0 +1,29 @@
+SectionDevice."Headphones" {
+	Comment "Headphones"
+
+	Value {
+		PlaybackPriority 200
+		PlaybackPCM "hw:${CardId},1"
+		JackControl "Headphone - Output Jack"
+	}
+}
+
+SectionDevice."Mic" {
+	Comment "Mic"
+
+	Value {
+		CapturePriority 200
+		CapturePCM "hw:${CardId}"
+		JackControl "Mic - Input Jack"
+	}
+}
+
+SectionDevice."Speaker" {
+	Comment "Speaker"
+
+	Value {
+		PlaybackPriority 100
+		PlaybackPCM "hw:${CardId}"
+		JackControl "Speaker - Output Jack"
+	}
+}

--- a/ucm2/USB-Audio/Lenovo-ThinkStation-P620-Main.conf
+++ b/ucm2/USB-Audio/Lenovo-ThinkStation-P620-Main.conf
@@ -1,0 +1,6 @@
+Syntax 2
+Comment "USB-audio on Lenovo ThinkStation P620 Main Audio"
+SectionUseCase."HiFi" {
+	Comment "Default"
+	File "Lenovo-ThinkStation-P620-Main-HiFi.conf"
+}


### PR DESCRIPTION
This add support for internal speaker and front headset.

We need two separate configs to let PulseAudio understands they are two
different profiles, so the headset's port availability won't affect
speaker's profile availability.