### PR TITLE
Correct conflicting mic in max98090

### DIFF
--- a/ucm2/codecs/max98090/InternalMic.conf
+++ b/ucm2/codecs/max98090/InternalMic.conf
@@ -8,7 +8,7 @@ SectionDevice."Mic" {
 	}
 
 	ConflictingDevice [
-		"Mic"
+		"Headset"
 	]
 
 	EnableSequence [


### PR DESCRIPTION
'mic' was conflicting 'mic' instead of 'headset', thus preventing correct configuration regarding microphones.

With this corrected, introducing a headset enables 'headset' mic and disables internal 'mic', whereas releasing the headset disables 'headset' mic and enables internal 'mic'