### PR TITLE
HDA-Intel: HiFi-dual: Fix the Rear Mic's Jack name

### DIFF
--- a/ucm2/HDA-Intel/HiFi-dual.conf
+++ b/ucm2/HDA-Intel/HiFi-dual.conf
@@ -96,7 +96,7 @@ SectionDevice."Mic2" {
 		CapturePriority 300
 		CapturePCM "hw:${CardId}"
 		JackHWMute "Line2"
-		JackControl "Mic Jack"
+		JackControl "Rear Mic Jack"
 	}
 
 	ConflictingDevice [


### PR DESCRIPTION
On the LENOVO P520 (dual codecs machine), the Jack name of Rear Mic is
"Rear Mic Jack" instead of "Mic Jack".

Below is picked from alsa-info.txt on the LENOVO p520 machine:
	control.18 {
		iface CARD
		name 'Rear Mic Jack'
		value true
		comment {
			access read
			type BOOLEAN
			count 1
		}
	}

Signed-off-by: Hui Wang <hui.wang@canonical.com>