### PR TITLE
USB-Audio: Dell-WD15-Dock: make input and output volume adjustable

### DIFF
--- a/ucm2/USB-Audio/Dell-WD15-Dock-HiFi.conf
+++ b/ucm2/USB-Audio/Dell-WD15-Dock-HiFi.conf
@@ -4,6 +4,18 @@ SectionDevice."Headphones" {
 	Value {
 		PlaybackPriority 100
 		PlaybackPCM "hw:${CardId}"
+
+		If.Headphone_ctl {
+			Condition {
+				Type ControlExists
+				Control "name='Headphone Playback Switch'"
+			}
+			True {
+				PlaybackMixerElem "Headphone"
+				PlaybackVolume "Headphone Playback Volume"
+				PlaybackSwitch "Headphone Playback Switch"
+			}
+		}
 	}
 }
 
@@ -13,6 +25,18 @@ SectionDevice."Line" {
 	Value {
 		PlaybackPriority 200
 		PlaybackPCM "hw:${CardId},1"
+
+		If.Line_ctl {
+			Condition {
+				Type ControlExists
+				Control "name='Line Playback Switch'"
+			}
+			True {
+				PlaybackMixerElem "Line"
+				PlaybackVolume "Line Playback Volume"
+				PlaybackSwitch "Line Playback Switch"
+			}
+		}
 	}
 }
 
@@ -22,5 +46,17 @@ SectionDevice."Mic" {
 	Value {
 		CapturePriority 100
 		CapturePCM "hw:${CardId}"
+
+		If.Mic_trl {
+			Condition {
+				Type ControlExists
+				Control "name='Mic Capture Switch'"
+			}
+			True {
+				CaptureMixerElem "Mic"
+				CaptureVolume "Mic Capture Volume"
+				CaptureSwitch "Mic Capture Switch"
+			}
+		}
 	}
 }


### PR DESCRIPTION
Recently we found the input volume is too low for some specific
headset-mic, even we adjust the input volume to max from PA, we still
can't record the sound from that headset-mic. That is because we
change the input or output volume from PA, but the mixer's volume
is not changed, only PA's soft-volume is changed.

Checking the amixer controls for this sound card, it supports
MixerElem, Volume and Switch, So adding them in the ucm.

Signed-off-by: Hui Wang <hui.wang@canonical.com>