### PR TITLE
ucm2: USB-Audio: Add support for Lenovo ThinkStation P620 Rear Audio

### DIFF
--- a/ucm2/USB-Audio/Lenovo-ThinkStation-P620-Rear-HiFi.conf
+++ b/ucm2/USB-Audio/Lenovo-ThinkStation-P620-Rear-HiFi.conf
@@ -1,0 +1,29 @@
+SectionDevice."Line" {
+	Comment "Line In"
+
+	Value {
+		CapturePriority 100
+		CapturePCM "hw:${CardId}"
+		JackControl "Line - Input Jack"
+	}
+}
+
+SectionDevice."Mic" {
+	Comment "Mic"
+
+	Value {
+		CapturePriority 200
+		CapturePCM "hw:${CardId},1"
+		JackControl "Mic - Input Jack"
+	}
+}
+
+SectionDevice."Speaker" {
+	Comment "Speaker"
+
+	Value {
+		PlaybackPriority 100
+		PlaybackPCM "hw:${CardId}"
+		JackControl "Speaker - Output Jack"
+	}
+}

--- a/ucm2/USB-Audio/Lenovo-ThinkStation-P620-Rear.conf
+++ b/ucm2/USB-Audio/Lenovo-ThinkStation-P620-Rear.conf
@@ -1,0 +1,6 @@
+Syntax 2
+Comment "USB-audio on Lenovo ThinkStation P620 Rear Audio"
+SectionUseCase."HiFi" {
+	Comment "Default"
+	File "Lenovo-ThinkStation-P620-Rear-HiFi.conf"
+}


### PR DESCRIPTION
Add proper PCM assignment to Lenovo ThinkStation P620 Rear Audio.

Signed-off-by: Kai-Heng Feng <kai.heng.feng@canonical.com>