### PR TITLE
ucm2: USB-Audio: Add CaptureMixerElem for Lenovo ThinkStation P620

### DIFF
--- a/ucm2/USB-Audio/Lenovo-ThinkStation-P620-Main-HiFi.conf
+++ b/ucm2/USB-Audio/Lenovo-ThinkStation-P620-Main-HiFi.conf
@@ -15,6 +15,7 @@ SectionDevice."Mic" {
 		CapturePriority 200
 		CapturePCM "hw:${CardId}"
 		JackControl "Mic - Input Jack"
+		CaptureMixerElem "Mic"
 	}
 }
 

--- a/ucm2/USB-Audio/Lenovo-ThinkStation-P620-Rear-HiFi.conf
+++ b/ucm2/USB-Audio/Lenovo-ThinkStation-P620-Rear-HiFi.conf
@@ -5,6 +5,7 @@ SectionDevice."Line" {
 		CapturePriority 100
 		CapturePCM "hw:${CardId}"
 		JackControl "Line - Input Jack"
+		CaptureMixerElem "Line"
 	}
 }
 
@@ -15,6 +16,7 @@ SectionDevice."Mic" {
 		CapturePriority 200
 		CapturePCM "hw:${CardId},1"
 		JackControl "Mic - Input Jack"
+		CaptureMixerElem "Mic"
 	}
 }
 


### PR DESCRIPTION
The Switch and Volume mixer start to work after device firmware update.
Add MixerElem to support them.

Signed-off-by: Kai-Heng Feng <kai.heng.feng@canonical.com>