### PR TITLE
bdw-rt5677: add SOF support

### DIFF
--- a/ucm2/SOF/HiFi.conf
+++ b/ucm2/SOF/HiFi.conf
@@ -87,3 +87,12 @@ If.bdw_rt286 {
 	}
 	True.Include.main.File "/broadwell-rt286/HiFi.conf"
 }
+
+If.bdw_rt5677 {
+	Condition {
+		Type String
+		Haystack "${CardName}"
+		Needle "sof-bdw rt5677"
+	}
+	True.Include.main.File "/bdw-rt5677/HiFi.conf"
+}


### PR DESCRIPTION
I believe this is the mechanism intended in 898602208888da63d758ff3c293b5ad2ec6e6c19.