### PR TITLE
Fix muted output and low ouput/input volume on a Dell Latitude 3410

### DIFF
--- a/ucm2/sof-hda-dsp/sof-hda-dsp.conf
+++ b/ucm2/sof-hda-dsp/sof-hda-dsp.conf
@@ -23,7 +23,8 @@ If.master {
 		Control "name='Master Playback Volume'"
 	}
 	True.BootSequence [
-		cset "name='Master Playback Volume' 60%"
+		cset "name='Master Playback Volume' 92%"
+		cset "name='Master Playback Switch' on"
 	]
 }
 
@@ -33,7 +34,7 @@ If.speaker {
 		Control "name='Speaker Playback Volume'"
 	}
 	True.BootSequence [
-		cset "name='Speaker Playback Volume' 60%"
+		cset "name='Speaker Playback Volume' 92%"
 	]
 }
 
@@ -43,7 +44,7 @@ If.headphone {
 		Control "name='Headphone Playback Volume'"
 	}
 	True.BootSequence [
-		cset "name='Headphone Playback Volume' 60%"
+		cset "name='Headphone Playback Volume' 92%"
 	]
 }
 
@@ -53,6 +54,6 @@ If.Dmic0 {
 		Control "name='Dmic0 Capture Volume'"
 	}
 	True.BootSequence [
-		cset "name='Dmic0 Capture Volume' 70%"
+		cset "name='Dmic0 Capture Volume' 92%"
 	]
 }


### PR DESCRIPTION
Using following environment on a Dell Latitude 3410 results in muted master channel and low output/input volume:

 - alsa-libs 1.2.4
 - alsa-ucm-conf 1.2.4
 - alsa-topology-conf 1.2.4
 - alsa-utils 1.2.4
 - kernel 5.9.1 -> with commit 3dca35e applied on top of it 
 - sof-bin v1.6

The propused changes fixes the problem for me. I don't know why but the given values are not 1:1 mapped to levels in alsamixer, please see attached iamges for alsamixer levels before and after the change, the alsamixer levels where captured after running "alsactl init":

before:
![before](https://user-images.githubusercontent.com/15876551/96853514-bf0f5f80-145a-11eb-9c7f-751834a56491.png)

after:
![after](https://user-images.githubusercontent.com/15876551/96853530-c46caa00-145a-11eb-9057-5399382d195d.png)