### PR TITLE
Fix initsetting

### DIFF
--- a/ucm2/HDA-Intel/init.conf
+++ b/ucm2/HDA-Intel/init.conf
@@ -14,7 +14,7 @@ If.master {
 		Control "name='Master Playback Volume'"
 	}
 	True.BootSequence [
-		cset "name='Master Playback Volume' 60%"
+		cset "name='Master Playback Volume' 90%"
 		cset "name='Master Playback Switch' on"
 	]
 }
@@ -25,7 +25,7 @@ If.speaker {
 		Control "name='Speaker Playback Volume'"
 	}
 	True.BootSequence [
-		cset "name='Speaker Playback Volume' 60%"
+		cset "name='Speaker Playback Volume' 90%"
 	]
 }
 

--- a/ucm2/HDA-Intel/init.conf
+++ b/ucm2/HDA-Intel/init.conf
@@ -15,6 +15,7 @@ If.master {
 	}
 	True.BootSequence [
 		cset "name='Master Playback Volume' 60%"
+		cset "name='Master Playback Switch' on"
 	]
 }
 

--- a/ucm2/sof-hda-dsp/sof-hda-dsp.conf
+++ b/ucm2/sof-hda-dsp/sof-hda-dsp.conf
@@ -23,7 +23,7 @@ If.master {
 		Control "name='Master Playback Volume'"
 	}
 	True.BootSequence [
-		cset "name='Master Playback Volume' 60%"
+		cset "name='Master Playback Volume' 90%"
 		cset "name='Master Playback Switch' on"
 	]
 }
@@ -34,7 +34,7 @@ If.speaker {
 		Control "name='Speaker Playback Volume'"
 	}
 	True.BootSequence [
-		cset "name='Speaker Playback Volume' 60%"
+		cset "name='Speaker Playback Volume' 90%"
 	]
 }
 

--- a/ucm2/sof-hda-dsp/sof-hda-dsp.conf
+++ b/ucm2/sof-hda-dsp/sof-hda-dsp.conf
@@ -24,6 +24,7 @@ If.master {
 	}
 	True.BootSequence [
 		cset "name='Master Playback Volume' 60%"
+		cset "name='Master Playback Switch' on"
 	]
 }
 


### PR DESCRIPTION
This issue was found when we prepared ubuntu 20.10. When users install the OS to a machine with HDA codec and use sof driver, the audio output is muted after installation. And even we set the master playback switch to on, the output volume from speaker is too low.

This issue could be easily reproduced by:
sudo rm /var/lib/asla/*
rm ~/.config/pulse/* (optional)
sudo /usr/sbin/alsactl -E HOME=/run/alsa -E XDG_RUNTIME_DIR=/run/alsa/runtime restore
