### PR TITLE
ucm2:sof-soundwire: Add Support For Dell Privacy Mic Mute LED Control

### DIFF
--- a/ucm2/sof-soundwire/rt715.conf
+++ b/ucm2/sof-soundwire/rt715.conf
@@ -5,10 +5,12 @@ SectionDevice."Mic" {
 
 	EnableSequence [
 		cset "name='PGA5.0 5 Master Capture Switch' 1"
+		cset "name='rt715 Micmute Led Mode' On"
 	]
 
 	DisableSequence [
 		cset "name='PGA5.0 5 Master Capture Switch' 0"
+		cset "name='rt715 Micmute Led Mode' Off"
 	]
 
 	Value {


### PR DESCRIPTION
Dell is going to add internal microphone mute led control for Dell privacy system,
which has hardware level protection for audio privacy, when mic mute
state is changed, the ucm2 will help to switch the Mic Mute LED state.

Signed-off-by: perry_yuan <perry_yuan@dell.com>