### PR TITLE
Sm8250 v1

### DIFF
--- a/ucm2/codecs/lpass/va-macro/DMIC0DisableSeq.conf
+++ b/ucm2/codecs/lpass/va-macro/DMIC0DisableSeq.conf
@@ -1,0 +1,5 @@
+DisableSequence [
+	cset "name='VA DMIC MUX0' ZERO"
+	cset "name='VA_DEC0 Volume' 0"
+	cset "name='VA_AIF1_CAP Mixer DEC0' 0"
+]

--- a/ucm2/codecs/lpass/va-macro/DMIC0EnableSeq.conf
+++ b/ucm2/codecs/lpass/va-macro/DMIC0EnableSeq.conf
@@ -1,0 +1,5 @@
+EnableSequence [
+	cset "name='VA DMIC MUX0' DMIC0"
+	cset "name='VA_AIF1_CAP Mixer DEC0' 1"
+	cset "name='VA_DEC0 Volume' 100"
+]

--- a/ucm2/codecs/lpass/wsa-macro/SpeakerDisableSeq.conf
+++ b/ucm2/codecs/lpass/wsa-macro/SpeakerDisableSeq.conf
@@ -1,0 +1,10 @@
+DisableSequence [
+	cset "name='WSA_RX0 Digital Volume' 0"
+	cset "name='WSA_RX1 Digital Volume' 0"
+	cset "name='WSA_COMP1 Switch' 0"
+	cset "name='WSA_COMP2 Switch' 0"
+	cset "name='WSA_RX0 INP0' ZERO"
+	cset "name='WSA_RX1 INP0' ZERO"
+	cset "name='WSA RX0 MUX' ZERO"
+	cset "name='WSA RX1 MUX' ZERO"
+]

--- a/ucm2/codecs/lpass/wsa-macro/SpeakerEnableSeq.conf
+++ b/ucm2/codecs/lpass/wsa-macro/SpeakerEnableSeq.conf
@@ -1,0 +1,10 @@
+EnableSequence [
+	cset "name='WSA RX0 MUX' AIF1_PB"
+	cset "name='WSA RX1 MUX' AIF1_PB"
+	cset "name='WSA_RX0 INP0' RX0"
+	cset "name='WSA_RX1 INP0' RX1"
+	cset "name='WSA_COMP1 Switch' 1"
+	cset "name='WSA_COMP2 Switch' 1"
+	cset "name='WSA_RX0 Digital Volume' 68"
+	cset "name='WSA_RX1 Digital Volume' 68"
+]

--- a/ucm2/sm8250/HDMI.conf
+++ b/ucm2/sm8250/HDMI.conf
@@ -1,0 +1,26 @@
+# Use case configuration for RB5 board.
+# Author: Srinivas Kandagatla <srinivas.kandagatla@linaro.org>
+
+SectionVerb {
+	EnableSequence [
+		cset "name='TERT_MI2S_RX Audio Mixer MultiMedia1' 1"
+	]
+
+	DisableSequence [
+		cset "name='TERT_MI2S_RX Audio Mixer MultiMedia1' 0"
+	]
+
+	Value {
+		TQ "HiFi"
+	}
+}
+
+SectionDevice."HDMI" {
+	#Name "HDMI"
+	Comment "HDMI Digital Stereo Output"
+
+	Value {
+		PlaybackPCM "hw:${CardId}"
+		PlaybackPriority 200
+	}
+}

--- a/ucm2/sm8250/HiFi.conf
+++ b/ucm2/sm8250/HiFi.conf
@@ -1,0 +1,46 @@
+# Use case configuration for Qualcomm RB5.
+# Author: Srinivas Kandagatla <srinivas.kandagatla@linaro.org>
+
+SectionVerb {
+
+	EnableSequence [
+		cset "name='WSA_CODEC_DMA_RX_0 Audio Mixer MultiMedia2' 1"
+		cset "name='MultiMedia3 Mixer VA_CODEC_DMA_TX_0' 1"
+	]
+
+	Include.wsae.File "/codecs/wsa881x/DefaultEnableSeq.conf"
+
+	DisableSequence [
+		cset "name='WSA_CODEC_DMA_RX_0 Audio Mixer MultiMedia2' 0"
+		cset "name='MultiMedia3 Mixer VA_CODEC_DMA_TX_0' 0"
+	]
+
+	Value {
+		TQ "HiFi"
+	}
+}
+
+SectionDevice."Speaker" {
+	Comment "Speaker playback"
+
+	Include.lpasswsae.File "/codecs/lpass/wsa-macro/SpeakerEnableSeq.conf"
+	Include.wsae.File "/codecs/wsa881x/SpeakerEnableSeq.conf"
+	Include.wsad.File "/codecs/wsa881x/SpeakerDisableSeq.conf"
+	Include.lpasswsad.File "/codecs/lpass/wsa-macro/SpeakerDisableSeq.conf"
+
+	Value {
+		PlaybackPriority 100
+		PlaybackPCM "hw:${CardId},1"
+	}
+}
+
+SectionDevice."Mic" {
+	Comment "Mic"
+	Include.lpassvad.File "/codecs/lpass/va-macro/DMIC0EnableSeq.conf"
+	Include.lpassvad.File "/codecs/lpass/va-macro/DMIC0DisableSeq.conf"
+
+	Value {
+		CapturePriority 100
+		CapturePCM "hw:${CardId},2"
+	}
+}

--- a/ucm2/sm8250/Qualcomm-RB5-WSA8815-Speakers-DMIC0.conf
+++ b/ucm2/sm8250/Qualcomm-RB5-WSA8815-Speakers-DMIC0.conf
@@ -1,0 +1,11 @@
+Syntax 3
+
+SectionUseCase."HiFi" {
+	File "/Qualcomm/sm8250/HiFi.conf"
+	Comment "HiFi quality Music."
+}
+
+SectionUseCase."HDMI" {
+	File "/Qualcomm/sm8250/HDMI.conf"
+	Comment "HDMI output."
+}


### PR DESCRIPTION
This patchset adds support to The Qualcomm Robotics RB5 Platform Audio ports.
RB5 has 2 WSA881X smart speakers attached via Soundwire, HDMI and a DMIC0 on the board.
All the audio related patches are merged in ASoC tree.

Also to note that the driver name and long card names are fixed properly on all new and old machine drivers so that we can organise the ucm2 directories correctly. That is the reason for moving sm8250 out of Qualcomm folder.
Thanks,
srini