### PR TITLE
rt715: init: setup ADC07 to a proper volume

### DIFF
--- a/ucm2/codecs/rt715/init.conf
+++ b/ucm2/codecs/rt715/init.conf
@@ -7,4 +7,5 @@ BootSequence [
 	cset "name='rt715 ADC 25 Mux' 4"
 	cset "name='rt715 ADC 27 Capture Switch' 1"
 	cset "name='rt715 ADC 07 Capture Switch' 1"
+	cset "name='rt715 ADC 07 Capture Volume' 58"
 ]


### PR DESCRIPTION
This patch initiates 'rt715 ADC 07 Capture Volume' to a proper volume.

Signed-off-by: Libin Yang <libin.yang@intel.com>