### PR TITLE
ucm2: sof-soundwire - add support for new main capture switch and main capture volume control

### DIFF
--- a/ucm2/sof-soundwire/rt715.conf
+++ b/ucm2/sof-soundwire/rt715.conf
@@ -1,20 +1,54 @@
 # Use case Configuration for sof-soundwire card
+#
+Syntax 3
+Define.KernelModulePath "class/leds/privacy\:\:micmute"
+Define.MicMute "$${sys:$KernelModulePath}"
 
-SectionDevice."Mic" {
-	Comment	"SoundWire microphones"
+If.driver {
+	Condition {
+		Type String
+		Empty "${var:MicMute}"
+	}
 
-	EnableSequence [
-		cset "name='PGA5.0 5 Master Capture Switch' 1"
-	]
+	True {
+		SectionDevice."Mic" {
+			Comment	"SoundWire microphones"
 
-	DisableSequence [
-		cset "name='PGA5.0 5 Master Capture Switch' 0"
-	]
+			EnableSequence [
+				cset "name='PGA5.0 5 Master Capture Switch' 1"
+			]
 
-	Value {
-	      CapturePriority 100
-	      CapturePCM "hw:${CardId},4"
-	      CaptureSwitch "PGA5.0 5 Master Capture Switch"
-	      CaptureVolume "PGA5.0 5 Master Capture Volume"
+			DisableSequence [
+				cset "name='PGA5.0 5 Master Capture Switch' 0"
+			]
+
+			Value {
+			      CapturePriority 100
+			      CapturePCM "hw:${CardId},4"
+			      CaptureSwitch "PGA5.0 5 Master Capture Switch"
+			      CaptureVolume "PGA5.0 5 Master Capture Volume"
+			}
+		}
+	}
+	False {
+		SectionDevice."Mic" {
+			Comment	"SoundWire microphones"
+
+			EnableSequence [
+				cset "name='rt715 Main Capture Switch' 1"
+			]
+
+			DisableSequence [
+				cset "name='rt715 Main Capture Switch' 0"
+			]
+
+			Value {
+			      CapturePriority 100
+			      CapturePCM "hw:${CardId},4"
+			      CaptureSwitch "rt715 Main Capture Switch"
+			      CaptureVolume "rt715 Main Capture Volume"
+			}
+		}
 	}
 }
+


### PR DESCRIPTION
This patch was added for its new main capture switch and main capture
volume control which combine the ADC 07 / ADC 27 Capture and Volume
switch ,the new mute switch and volume control will be handled by codec
rt715`s driver mute/volume kcontrol instead of PGA5.

BugLink: https://github.com/thesofproject/linux/issues/2544
Signed-off-by: Perry Yuan <perry_yuan@dell.com>