### PR TITLE
chtrt5645: Enable Internal MIC of ECS EF20EA

### DIFF
--- a/ucm2/chtrt5645/HiFi.conf
+++ b/ucm2/chtrt5645/HiFi.conf
@@ -18,7 +18,7 @@ If.cfg-dmic2 {
 	Condition {
 		Type RegexMatch
 		String "${CardLongName}"
-		Regex "(LENOVO.*LenovoMIIX320|MEDION.*Wingman)"
+		Regex "(LENOVO.*LenovoMIIX320|MEDION.*Wingman|Standard-EF20EA-1.0)"
 	}
 	True {
 		Define.AnalogMic ""


### PR DESCRIPTION
* Add a card long name "Standard-EF20EA-1.0" match chtrt5645 enabling the internal DMIC.
* ~~Create HdmiLpeAudio folder and copy & modify HDMI.conf from HDA-Intel for the devices using HdmiLpeAudio as the HDMI audio driver.~~