### PR TITLE
USB-Audio/ALC1220: Bump analog Speaker priority over S/PDIF

### DIFF
--- a/ucm2/USB-Audio/Realtek-ALC1220-VB-Desktop-HiFi.conf
+++ b/ucm2/USB-Audio/Realtek-ALC1220-VB-Desktop-HiFi.conf
@@ -1,14 +1,3 @@
-SectionDevice."Speaker" {
-	Comment "Speakers"
-	Value {
-	       PlaybackChannels 8
-	       PlaybackPriority 100
-	       PlaybackPCM "hw:${CardId}"
-	       JackControl "Speaker Jack"
-	       PlaybackMixerElem "Speaker"
-	}
-}
-
 SectionDevice."Headphones" {
 	Comment "Front Headphones"
 	Value {
@@ -19,10 +8,21 @@ SectionDevice."Headphones" {
 	}
 }
 
+SectionDevice."Speaker" {
+	Comment "Speakers"
+	Value {
+		PlaybackChannels 8
+		PlaybackPriority 200
+		PlaybackPCM "hw:${CardId}"
+		JackControl "Speaker Jack"
+		PlaybackMixerElem "Speaker"
+	}
+}
+
 SectionDevice."SPDIF" {
 	Comment "S/PDIF Out"
 	Value {
-		PlaybackPriority 200
+		PlaybackPriority 100
 		PlaybackPCM "hw:${CardId},2"
 		PlaybackMixerElem "IEC958"
 	}


### PR DESCRIPTION
Suggestion from https://github.com/alsa-project/alsa-ucm-conf/pull/25#issuecomment-760141633

The `S/PDIF` port does not have any jack sensing, and with a priority higher than the `Speakers` it will always be selected by default instead of the `Speakers` even if unplugged.

Swapping the priorities around allows analog `Speakers` to be selected first, _if_ they are plugged in. Otherwise `S/PDIF` is used.

The sections are reordered to adhere to this priority, including some indentation fixes.