### PR TITLE
chtnau8824: Add support for using the SOF driver

### DIFF
--- a/ucm2/chtnau8824/HiFi.conf
+++ b/ucm2/chtnau8824/HiFi.conf
@@ -1,6 +1,7 @@
 Define.Speaker "Speaker"
 Define.Mic "InternalMic"
 Define.SST "yes"
+Define.RightOutputChannel 1
 
 If.Controls {
 	Condition {
@@ -9,6 +10,7 @@ If.Controls {
 	}
 	False {
 		Define.SST ""
+		Define.RightOutputChannel 0
 	}
 }
 

--- a/ucm2/codecs/nau8824/EnableSeq.conf
+++ b/ucm2/codecs/nau8824/EnableSeq.conf
@@ -1,7 +1,7 @@
 EnableSequence [
 	# Playback TDM configuration
 	cset "name='DACL Channel Source' 0"
-	cset "name='DACR Channel Source' 1"
+	cset "name='DACR Channel Source' ${var:RightOutputChannel}"
 	# Input Configuration
 	cset "name='DMIC1 Enable Switch' off"
 	cset "name='DMIC2 Enable Switch' off"


### PR DESCRIPTION
The old (and currently the default) SST driver uses TDM 4 slots 24 bit
as wire format to the codec. Where as the new SOF driver uses standard
I2S 2 channel 24 bit.

Normally this should not impact the UCM settings, but on the NAU8824
the "DAC Right Channel Source" mixer setting must be set to 1 when
using TDM 4 slots and to 0 when using I2S 2 channel mode.

Getting this wrong (in either case) results in the right channel not
outputting any sound.

This commit introduces a RightOutputChannel variable which gets
set to 0/1 depending on the driver and then uses that for the
"DAC Right Channel Source" mixer setting so that we do the right
thing depending on the driver.

This has been tested on the following devices:

Medion E2215T:    Stereo speakers, analog mic
Medion E2228T:    Stereo speakers, stereo digital mics
Cube iWork 8 Air: Mono speaker, analog mic
