### PR TITLE
SOF SoundWire: Improve dmic detection

### DIFF
--- a/ucm2/sof-soundwire/dmic.conf
+++ b/ucm2/sof-soundwire/dmic.conf
@@ -1,0 +1,21 @@
+SectionDevice."Mic" {
+	Comment "Digital Microphone"
+
+	Value {
+		CapturePriority 100
+		CapturePCM "hw:${CardId},3"
+		If.chn {
+			Condition {
+				Type RegexMatch
+				Regex "[34]"
+				String "${var:Mics1}"
+			}
+			True {
+				CaptureChannels 4
+			}
+		}
+		CaptureMixerElem "Dmic0"
+		CaptureVolume "Dmic0 Capture Volume"
+		CaptureSwitch "Dmic0 Capture Switch"
+	}
+}

--- a/ucm2/sof-soundwire/sof-soundwire.conf
+++ b/ucm2/sof-soundwire/sof-soundwire.conf
@@ -11,6 +11,7 @@ Define {
 	SpeakerAmps1 "0"
 	HeadsetCodec1 ""
 	MicCodec1 ""
+	Mics1 "0"
 }
 
 DefineRegex {
@@ -32,6 +33,10 @@ DefineRegex {
 	}
 	MicCodec {
 		Regex " mic:([a-z0-9]+)"
+		String "${CardComponents}"
+	}
+	Mics {
+		Regex " cfg-mics:([1-9][0-9]*)"
 		String "${CardComponents}"
 	}
 }


### PR DESCRIPTION
DMIC support seems incomplete for HDaudio (not handling all possibilities for cfg-dmics) and missing completely for SoundWire.

This is an untested draft just to get UCM3 feedback from @perexg and tests from @aigilea on an HP Spectre x360 device.

Edit: adding @kv2019i @RanderWang @bardliao and @libinyang for reviews.