### PR TITLE
Extend card search paths

### DIFF
--- a/ucm2/module/snd_soc_sdm845
+++ b/ucm2/module/snd_soc_sdm845
@@ -1,0 +1,1 @@
+../Qualcomm/sdm845

--- a/ucm2/ucm.conf
+++ b/ucm2/ucm.conf
@@ -53,6 +53,10 @@ If.driver {
 			False {
 				Define.KernelModulePath "class/sound/card${CardNumber}/device/driver/module"
 				Define.KernelModule "$${sys:$KernelModulePath}"
+				UseCasePath.modulelongname {
+					Directory "module/${var:KernelModule}"
+					File "${CardLongName}.conf"
+				}
 				UseCasePath.module {
 					Directory "module"
 					File "${var:KernelModule}.conf"


### PR DESCRIPTION
On Qualcomm platforms is is typical for a single kernel module to support several sound cards. Add support for using `ucm2/module/${KernelModule}/${CardLongName}.conf` as a use case config file.

See https://github.com/alsa-project/alsa-ucm-conf/pull/70 for the reference.