### PR TITLE
sof-soundwire: use the ${find-device} lookup for the dmic device

### DIFF
--- a/ucm2/sof-soundwire/dmic.conf
+++ b/ucm2/sof-soundwire/dmic.conf
@@ -3,7 +3,7 @@ SectionDevice."Mic" {
 
 	Value {
 		CapturePriority 100
-		CapturePCM "hw:${CardId},3"
+		CapturePCM "hw:${CardId},${find-device:type=pcm,stream=capture,field=id,regex='DMIC '}"
 		If.chn {
 			Condition {
 				Type RegexMatch

--- a/ucm2/sof-soundwire/sof-soundwire.conf
+++ b/ucm2/sof-soundwire/sof-soundwire.conf
@@ -1,4 +1,4 @@
-Syntax 3
+Syntax 4
 
 SectionUseCase."HiFi" {
 	File "HiFi.conf"


### PR DESCRIPTION
The PCM device number for the internal digital microphone is not fixed.
