### PR TITLE
Extend use case search paths to use kernel driver name

### DIFF
--- a/ucm2/driver/qcom-apq8016-sbc.conf
+++ b/ucm2/driver/qcom-apq8016-sbc.conf
@@ -1,0 +1,1 @@
+../Qualcomm/apq8016-sbc/apq8016-sbc.conf

--- a/ucm2/ucm.conf
+++ b/ucm2/ucm.conf
@@ -15,6 +15,7 @@ Syntax 3
 
 Define.V1 ""		# non-empty string to enable ucm v1 paths
 Define.V2Module yes	# empty string to disable
+Define.V2Driver	yes	# empty string to disable
 Define.V2Name yes	# empty string to disable
 
 If.driver {
@@ -56,6 +57,24 @@ If.driver {
 				UseCasePath.module {
 					Directory "module"
 					File "${var:KernelModule}.conf"
+				}
+			}
+		}
+		If.V2Driver {
+			Condition {
+				Type String
+				Empty "${var:V2Driver}"
+			}
+			False {
+				Define.KernelDriverPath "class/sound/card${CardNumber}/device/driver"
+				Define.KernelDriver "$${sys:$KernelDriverPath}"
+				UseCasePath.kerneldriverlongname {
+					Directory "driver/${var:KernelDriver}"
+					File "${CardLongName}.conf"
+				}
+				UseCasePath.kerneldriver {
+					Directory "driver"
+					File "${var:KernelDriver}.conf"
 				}
 			}
 		}


### PR DESCRIPTION
This is a companion (or replacement) for #76 . This adds lookup for the use case search path using the in-kernel driver name. This allows easy lookup both for the setups which have the sound card/platform driver built as a module or builtin into the kernel.