### PR TITLE
ucm2/conf.d: add symlinks for Qualcomm cards

### DIFF
--- a/ucm2/conf.d/DB410c/DB410c.conf
+++ b/ucm2/conf.d/DB410c/DB410c.conf
@@ -1,0 +1,1 @@
+../../Qualcomm/apq8016-sbc/apq8016-sbc.conf

--- a/ucm2/conf.d/DB820c/DB820c.conf
+++ b/ucm2/conf.d/DB820c/DB820c.conf
@@ -1,0 +1,1 @@
+../../Qualcomm/apq8096/apq8096.conf

--- a/ucm2/conf.d/sdm845/DB845c.conf
+++ b/ucm2/conf.d/sdm845/DB845c.conf
@@ -1,0 +1,1 @@
+../../Qualcomm/sdm845/sdm845.conf


### PR DESCRIPTION
Add ucm2/conf.d symlinks for all defined Qualcomm sound cards.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>