### PR TITLE
broadwell-rt286, bdw-rt5677: Fix inconsistency in card detection

### DIFF
--- a/ucm2/SOF/HiFi.conf
+++ b/ucm2/SOF/HiFi.conf
@@ -92,7 +92,7 @@ If.bdw_rt286 {
 	Condition {
 		Type String
 		Haystack "${CardName}"
-		Needle "sof-bdw rt286"
+		Needle "bdw rt286"
 	}
 	True.Include.main.File "/broadwell-rt286/HiFi.conf"
 }
@@ -101,7 +101,7 @@ If.bdw_rt5677 {
 	Condition {
 		Type String
 		Haystack "${CardName}"
-		Needle "sof-bdw rt5677"
+		Needle "bdw rt5677"
 	}
 	True.Include.main.File "/bdw-rt5677/HiFi.conf"
 }

--- a/ucm2/bdw-rt5677/HiFi.conf
+++ b/ucm2/bdw-rt5677/HiFi.conf
@@ -1,4 +1,4 @@
-# Use case Configuration for sof-bdw-rt5677
+# Use case Configuration for bdw-rt5677
 # command-line sequence to switch playback/capture
 # alsaucm -c bdw-rt5677  set _verb HiFi
 # alsaucm -c bdw-rt5677  set _verb HiFi set _enadev Headphones

--- a/ucm2/broadwell-rt286/HiFi.conf
+++ b/ucm2/broadwell-rt286/HiFi.conf
@@ -1,5 +1,4 @@
-# Use case Configuration for Nexus 7
-# Adapted to Ubuntu Touch by David Henningsson <david.henningsson@canonical.com>
+# Use case Configuration for broadwell-rt286
 
 SectionDevice."Speaker" {
 	Comment "Speakers"


### PR DESCRIPTION
This conveniently provides a workaround for a bug in kernel 5.10+:
https://bugzilla.kernel.org/show_bug.cgi?id=211985