### PR TITLE
Add UCM support for SDM845 based Lenovo yoga c630

### DIFF
--- a/ucm2/Qualcomm/sdm845/HiFi-MM1.conf
+++ b/ucm2/Qualcomm/sdm845/HiFi-MM1.conf
@@ -1,0 +1,77 @@
+# Use case configuration for LenovoYOGAC6301.
+# Author: Srinivas Kandagatla <srinivas.kandagatla@linaro.org>
+
+SectionVerb {
+
+	EnableSequence [
+		cset "name='SLIMBUS_0_RX Audio Mixer MultiMedia1' 1"
+		cset "name='SLIMBUS_1_RX Audio Mixer MultiMedia3' 1"
+		cset "name='MultiMedia2 Mixer SLIMBUS_0_TX' 1"
+	]
+
+	Include.wcde.File "/codecs/wcd934x/DefaultEnableSeq.conf"
+	Include.wsae.File "/codecs/wsa881x/DefaultEnableSeq.conf"
+
+	Include.wcdd {
+		File "/codecs/wcd934x/DefaultDisableSeq.conf"
+		Before.DisableSequence "0"
+	}
+
+	DisableSequence [
+		cset "name='SLIMBUS_0_RX Audio Mixer MultiMedia1' 0"
+		cset "name='SLIMBUS_1_RX Audio Mixer MultiMedia3' 0"
+		cset "name='MultiMedia2 Mixer SLIMBUS_0_TX' 0"
+	]
+
+	Value {
+		TQ "HiFi"
+	}
+}
+
+SectionDevice."Speaker" {
+	Comment "Speaker playback"
+	
+	Include.wcdspke.File "/codecs/wcd934x/SpeakerEnableSeq.conf"
+	Include.wcdspkd.File "/codecs/wcd934x/SpeakerDisableSeq.conf"
+	Include.wsaspke.File "/codecs/wsa881x/SpeakerEnableSeq.conf"
+	Include.wsaspkd.File "/codecs/wsa881x/SpeakerDisableSeq.conf"
+	
+
+	Value {
+		PlaybackPriority 100
+		PlaybackPCM "hw:${CardId},0"
+		PlaybackMixer "default:${CardId}"
+		PlaybackMixerElem "Speaker Digital"
+	}
+}
+
+SectionDevice."Headphones" {
+	Comment "Headphones playback"
+
+	Include.wcdhpe.File "/codecs/wcd934x/HeadphoneEnableSeq.conf"
+	Include.wcdhpd.File "/codecs/wcd934x/HeadphoneDisableSeq.conf"
+
+	Value {
+		PlaybackPriority 200
+		PlaybackPCM "hw:${CardId},2"
+		PlaybackMixer "default:${CardId}"
+		PlaybackMixerElem "HP Digital"
+	}
+}
+
+SectionDevice."Mic" {
+	Comment "Mic"
+
+	Include.wcdmice.File "/codecs/wcd934x/HeadphoneMicEnableSeq.conf"
+	Include.wcdmicd.File "/codecs/wcd934x/HeadphoneMicDisableSeq.conf"
+
+	DisableSequence [
+		cset "name='AMIC MUX0' ZERO"
+	]
+	
+	Value {
+		CapturePriority 100
+		CapturePCM "hw:${CardId},1"
+		CaptureMixerElem "ADC2"
+	}
+}

--- a/ucm2/Qualcomm/sdm845/Lenovo-YOGA-C630-13Q50.conf
+++ b/ucm2/Qualcomm/sdm845/Lenovo-YOGA-C630-13Q50.conf
@@ -1,0 +1,10 @@
+Syntax 4
+
+SectionUseCase."HiFi" {
+	File "/Qualcomm/sdm845/HiFi-MM1.conf"
+	Comment "HiFi quality Music."
+}
+
+Include.card-init.File "/lib/card-init.conf"
+Include.ctl-remap.File "/lib/ctl-remap.conf"
+Include.codec-init.File "/codecs/wcd934x/init.conf"

--- a/ucm2/codecs/wcd934x/DefaultEnableSeq.conf
+++ b/ucm2/codecs/wcd934x/DefaultEnableSeq.conf
@@ -1,16 +1,10 @@
 EnableSequence [
+	cset "name='SLIM RX0 MUX' AIF1_PB"
 	cset "name='SLIM RX1 MUX' AIF1_PB"
-	cset "name='SLIM RX2 MUX' AIF1_PB"
-	cset "name='SLIM RX6 MUX' ZERO"
-	cset "name='SLIM RX7 MUX' ZERO"
-	cset "name='SLIM RX3 MUX' ZERO"
-	cset "name='SLIM RX4 MUX' ZERO"
-	cset "name='SLIM RX5 MUX' ZERO"
-	cset "name='AIF1_CAP Mixer SLIM TX0' 1"
+	cset "name='SLIM RX2 MUX' AIF2_PB"
+	cset "name='SLIM RX3 MUX' AIF2_PB"
 
-	cset "name='RX INT7_1 MIX1 INP0' RX1"
-	cset "name='RX INT8_1 MIX1 INP0' RX2"
-	cset "name='RX INT1_2 MUX' RX1"
-	cset "name='RX INT2_2 MUX' RX2"
+
+	cset "name='AIF1_CAP Mixer SLIM TX0' 1"
 	cset "name='CDC_IF TX0 MUX' DEC0"
 ]

--- a/ucm2/codecs/wcd934x/HeadphoneDisableSeq.conf
+++ b/ucm2/codecs/wcd934x/HeadphoneDisableSeq.conf
@@ -1,6 +1,8 @@
-cset "name='COMP1 Switch' 0"
-cset "name='COMP2 Switch' 0"
-cset "name='RX1 Digital Volume' 0"
-cset "name='RX2 Digital Volume' 0"
-cset "name='RX INT1 DEM MUX' ZERO"
-cset "name='RX INT2 DEM MUX' ZERO"
+DisableSequence [
+	cset "name='COMP1 Switch' 0"
+	cset "name='COMP2 Switch' 0"
+	cset "name='RX INT1_1 MIX1 INP0' ZERO"
+	cset "name='RX INT2_1 MIX1 INP0' ZERO"
+	cset "name='RX INT1 DEM MUX' NORMAL_DSM_OUT"
+	cset "name='RX INT2 DEM MUX' NORMAL_DSM_OUT"
+]

--- a/ucm2/codecs/wcd934x/HeadphoneEnableSeq.conf
+++ b/ucm2/codecs/wcd934x/HeadphoneEnableSeq.conf
@@ -1,6 +1,8 @@
-cset "name='COMP1 Switch' 1"
-cset "name='COMP2 Switch' 1"
-cset "name='RX INT1 DEM MUX' CLSH_DSM_OUT"
-cset "name='RX INT2 DEM MUX' CLSH_DSM_OUT"
-cset "name='RX1 Digital Volume' 68"
-cset "name='RX2 Digital Volume' 68"
+EnableSequence [
+	cset "name='COMP1 Switch' 1"
+	cset "name='COMP2 Switch' 1"
+	cset "name='RX INT1_1 MIX1 INP0' RX2"
+	cset "name='RX INT2_1 MIX1 INP0' RX3"
+	cset "name='RX INT1 DEM MUX' CLSH_DSM_OUT"
+	cset "name='RX INT2 DEM MUX' CLSH_DSM_OUT"
+]

--- a/ucm2/codecs/wcd934x/HeadphoneMicDisableSeq.conf
+++ b/ucm2/codecs/wcd934x/HeadphoneMicDisableSeq.conf
@@ -1,2 +1,4 @@
-cset "name='AMIC MUX0' ZERO"
-cset "name='ADC2 Volume' 0"
+DisableSequence [
+	cset "name='AMIC MUX0' ZERO"
+	cset "name='ADC2 Volume' 0"
+]

--- a/ucm2/codecs/wcd934x/HeadphoneMicEnableSeq.conf
+++ b/ucm2/codecs/wcd934x/HeadphoneMicEnableSeq.conf
@@ -1,3 +1,4 @@
-cset "name='AMIC MUX0' ADC2"
-cset "name='ADC2 Volume' 12"
-cset "name='ADC MUX0' AMIC"
+EnableSequence [
+	cset "name='AMIC MUX0' ADC2"
+	cset "name='ADC MUX0' AMIC"
+]

--- a/ucm2/codecs/wcd934x/SpeakerDisableSeq.conf
+++ b/ucm2/codecs/wcd934x/SpeakerDisableSeq.conf
@@ -1,6 +1,6 @@
 DisableSequence [
-	cset "name='RX7 Digital Volume' 0"
-	cset "name='RX8 Digital Volume' 0"
 	cset "name='COMP7 Switch' 0"
 	cset "name='COMP8 Switch' 0"
+	cset "name='RX INT7_1 MIX1 INP0' ZERO"
+	cset "name='RX INT8_1 MIX1 INP0' ZERO"
 ]

--- a/ucm2/codecs/wcd934x/SpeakerEnableSeq.conf
+++ b/ucm2/codecs/wcd934x/SpeakerEnableSeq.conf
@@ -1,6 +1,6 @@
 EnableSequence [
 	cset "name='COMP7 Switch' 1"
 	cset "name='COMP8 Switch' 1"
-	cset "name='RX7 Digital Volume' 80"
-	cset "name='RX8 Digital Volume' 80"
+	cset "name='RX INT7_1 MIX1 INP0' RX0"
+	cset "name='RX INT8_1 MIX1 INP0' RX1"
 ]

--- a/ucm2/codecs/wcd934x/init.conf
+++ b/ucm2/codecs/wcd934x/init.conf
@@ -1,0 +1,25 @@
+# WCD934X specific volume control settings
+
+BootSequence [
+	cset "name='RX1 Digital Volume' 80"
+	cset "name='RX2 Digital Volume' 80"
+	cset "name='RX7 Digital Volume' 80"
+	cset "name='RX8 Digital Volume' 80"
+	cset "name='ADC2 Volume' 12"
+]
+
+LibraryConfig.remap.Config {
+
+	ctl.default.map {
+		# Merge two mono controls into one stereo
+		"name='HP Digital Volume'" {
+			"name='RX1 Digital Volume'".vindex.0 0
+			"name='RX2 Digital Volume'".vindex.1 0
+		}
+		"name='Speaker Digital Volume'" {
+			"name='RX7 Digital Volume'".vindex.0 0
+			"name='RX8 Digital Volume'".vindex.1 0
+		}
+	}
+}
+

--- a/ucm2/conf.d/sdm845/LENOVO-81JL-LenovoYOGAC630_13Q50-LNVNB161216.conf
+++ b/ucm2/conf.d/sdm845/LENOVO-81JL-LenovoYOGAC630_13Q50-LNVNB161216.conf
@@ -1,0 +1,1 @@
+../../Qualcomm/sdm845/Lenovo-YOGA-C630-13Q50.conf


### PR DESCRIPTION
One of the Lenovo YOGA C360 variant is based off Qualcomm SDM845  SoC. This PR adds support to On Board Speakers and Headset. 
This PR also has a small change to the codec Headphone sequences to be inline with other Sequences.

thanks,
srini 