### PR TITLE
[RFC] ucm2: rt711-sdca: remove 'rt711 FU0F Capture Switch' setting

### DIFF
--- a/ucm2/codecs/rt711-sdca/init.conf
+++ b/ucm2/codecs/rt711-sdca/init.conf
@@ -4,5 +4,4 @@ BootSequence [
 	cset "name='rt711 FU05 Playback Volume' 87"
 	cset "name='rt711 ADC 22 Mux' 'MIC2'"
 	cset "name='rt711 FU0F Capture Volume' 57"
-	cset "name='rt711 FU0F Capture Switch' 1"
 ]


### PR DESCRIPTION
The rt711-sdca codec driver removes the 'rt711 FU0F Capture Switch'
kcontrol. So we need to remove the setting of 'rt711 FU0F Capture Switch'
correspondingly.

Signed-off-by: Libin Yang <libin.yang@intel.com>