### PR TITLE
ucm2: soundwire: use the codec kcontrols for rt711-sdca

### DIFF
--- a/ucm2/sof-soundwire/rt711-sdca.conf
+++ b/ucm2/sof-soundwire/rt711-sdca.conf
@@ -33,8 +33,9 @@ SectionDevice."Headset" {
 		CapturePriority 200
 		CapturePCM "hw:${CardId},1"
 		JackControl "Headset Mic Jack"
-		CaptureSwitch "PGA2.0 2 Master Capture Switch"
-		CaptureVolume "PGA2.0 2 Master Capture Volume"
-		CaptureMixerElem "PGA2.0 2 Master"
+		CaptureSwitch "rt711 FU0F Capture Switch"
+		CaptureVolume "rt711 FU0F Capture Volume"
+		CaptureMixerElem "rt711 FU0F"
+
 	}
 }


### PR DESCRIPTION
Use "rt711 FU0F" as the HW control, instead of the "PGA2.0 2".

Signed-off-by: Libin Yang <libin.yang@intel.com>