### PR TITLE
Add UCMs for Google Asus Nexus 7 and  Acer Iconia A500

### DIFF
--- a/ucm2/Tegra/rt5640/ASUS Google Nexus 7 ALC5642.conf
+++ b/ucm2/Tegra/rt5640/ASUS Google Nexus 7 ALC5642.conf
@@ -1,0 +1,15 @@
+# Use case Configuration for ASUS Google Nexus 7 (2012)
+
+Define.HaveAif1 "yes"
+Define.HaveAif2 ""
+Define.HaveSpeaker "yes"
+Define.HaveHeadsetMic ""
+Define.HaveInternalMic "yes"
+
+Include.hp.File "/codecs/rt5640/HeadPhones.conf"
+Include.mspk.File "/codecs/rt5640/Speaker.conf"
+Include.dmic.File "/codecs/rt5640/DigitalMics.conf"
+
+SectionVerb {
+	Include.e.File "/codecs/rt5640/EnableSeq.conf"
+}

--- a/ucm2/Tegra/wm8903/Acer Iconia Tab A500 WM8903.conf
+++ b/ucm2/Tegra/wm8903/Acer Iconia Tab A500 WM8903.conf
@@ -1,0 +1,114 @@
+# Use case Configuration for Acer Iconia Tab A500
+
+SectionVerb {
+	EnableSequence [
+		# WM8903 Output Configuration
+		cset "name='Digital Playback Volume' 80"
+		cset "name='Headphone Volume' 42"
+		cset "name='Line Out Volume' 42"
+		cset "name='DAC Boost Volume' 0"
+
+		# WM8903 Output Routing
+		cset "name='Left Output Mixer DACL Switch' on"
+		cset "name='Left Output Mixer DACR Switch' off"
+		cset "name='Right Output Mixer DACL Switch' off"
+		cset "name='Right Output Mixer DACR Switch' on"
+
+		# WM8903 Input Configuration
+		cset "name='Digital Capture Volume' 120"
+		cset "name='DRC Compressor Threshold Volume' 124"
+		cset "name='DRC Compressor Slope R0' 1"
+		cset "name='DRC Compressor Slope R1' 1"
+		cset "name='DRC Maximum Gain Volume' 1"
+		cset "name='DRC Minimum Gain Volume' 0"
+		cset "name='DRC Volume' 13"
+
+		# WM8903 Input Routing
+		cset "name='Left Input PGA Switch' on"
+		cset "name='Right Input PGA Switch' on"
+
+		# Tegra-specific switches
+		cset "name='Int Spk Switch' on"
+		cset "name='Int Mic Switch' on"
+	]
+}
+
+SectionDevice."Speakers" {
+	Comment "Speakers"
+
+	ConflictingDevice [
+		"Headphones"
+	]
+
+	EnableSequence [
+		cset "name='Headphone Switch' off"
+		cset "name='Line Out Switch' on"
+	]
+
+	Value {
+		PlaybackPCM "hw:${CardId}"
+		PlaybackMixerElem "Line Out"
+	}
+}
+
+SectionDevice."Headphones" {
+	Comment "Headphones"
+
+	ConflictingDevice [
+		"Speakers"
+	]
+
+	EnableSequence [
+		cset "name='Line Out Switch' off"
+		cset "name='Headphone Switch' on"
+	]
+
+	Value {
+		PlaybackPCM "hw:${CardId}"
+		PlaybackMixerElem "Headphone"
+		JackControl "Headphone Jack"
+	}
+}
+
+SectionDevice."InternalMic" {
+	Comment "Internal Microphone"
+
+	ConflictingDevice [
+		"HeadsetMic"
+	]
+
+	EnableSequence [
+		cset "name='Left Input PGA Volume' 31"
+		cset "name='Right Input PGA Volume' 31"
+		cset "name='Left Input Inverting Mux' IN1L"
+		cset "name='Right Input Inverting Mux' IN1R"
+		cset "name='DRC Switch' on"
+	]
+
+	Value {
+		CapturePCM "hw:${CardId}"
+		CaptureMixerElem "Digital"
+	}
+}
+
+SectionDevice."HeadsetMic" {
+	Comment "Headset Microphone"
+
+	ConflictingDevice [
+		"InternalMic"
+	]
+
+	EnableSequence [
+		cset "name='Left Input PGA Volume' 25"
+		cset "name='Right Input PGA Volume' 25"
+		cset "name='Left Input Inverting Mux' IN2L"
+		cset "name='Right Input Inverting Mux' IN2R"
+		cset "name='DRC Switch' off"
+	]
+
+	Value {
+		CapturePCM "hw:${CardId}"
+		CaptureMixerElem "Digital"
+		JackControl "Mic Jack"
+	}
+}

--- a/ucm2/bytcr-rt5640/HiFi-Components.conf
+++ b/ucm2/bytcr-rt5640/HiFi-Components.conf
@@ -1,4 +1,5 @@
 Define.HaveSpeaker ""
+Define.HaveHeadsetMic ""
 Define.HaveInternalMic ""
 
 If.spk {
@@ -129,6 +130,7 @@ If.in3 {
 If.hsmic {
 	Condition { Type String Empty "" }
 	True.Include.hsmic.File "/codecs/rt5640/HeadsetMic.conf"
+	Define.HaveHeadsetMic "yes"
 
 	SectionDevice."Headset" {
 		EnableSequence [

--- a/ucm2/bytcr-rt5640/HiFi-Components.conf
+++ b/ucm2/bytcr-rt5640/HiFi-Components.conf
@@ -10,6 +10,16 @@ If.spk {
 	True {
 		Include.spk.File "/codecs/rt5640/Speaker.conf"
 		Define.HaveSpeaker "yes"
+
+		SectionDevice."Speaker" {
+			EnableSequence [
+				cset "name='Speaker Switch' on"
+			]
+
+			DisableSequence [
+				cset "name='Speaker Switch' off"
+			]
+		}
 	}
 }
 
@@ -22,12 +32,32 @@ If.mono {
 	True {
 		Include.mspk.File "/codecs/rt5640/MonoSpeaker.conf"
 		Define.HaveSpeaker "yes"
+
+		SectionDevice."Speaker" {
+			EnableSequence [
+				cset "name='Speaker Switch' on"
+			]
+
+			DisableSequence [
+				cset "name='Speaker Switch' off"
+			]
+		}
 	}
 }
 
 If.hp {
 	Condition { Type String Empty "" }
 	True.Include.hs.File "/codecs/rt5640/HeadPhones.conf"
+
+	SectionDevice."Headphones" {
+		EnableSequence [
+			cset "name='Headphone Switch' on"
+		]
+
+		DisableSequence [
+			cset "name='Headphone Switch' off"
+		]
+	}
 }
 
 If.dmic1 {
@@ -39,6 +69,16 @@ If.dmic1 {
 	True {
 		Include.dmic.File "/codecs/rt5640/DigitalMics.conf"
 		Define.HaveInternalMic "yes"
+
+		SectionDevice."Mic" {
+			EnableSequence [
+				cset "name='Internal Mic Switch' on"
+			]
+
+			DisableSequence [
+				cset "name='Internal Mic Switch' off"
+			]
+		}
 	}
 }
 
@@ -51,6 +91,16 @@ If.in1 {
 	True {
 		Include.mic1.File "/codecs/rt5640/IN1-InternalMic.conf"
 		Define.HaveInternalMic "yes"
+
+		SectionDevice."Mic" {
+			EnableSequence [
+				cset "name='Internal Mic Switch' on"
+			]
+
+			DisableSequence [
+				cset "name='Internal Mic Switch' off"
+			]
+		}
 	}
 }
 
@@ -63,10 +113,30 @@ If.in3 {
 	True {
 		Include.mic3.File "/codecs/rt5640/IN3-InternalMic.conf"
 		Define.HaveInternalMic "yes"
+
+		SectionDevice."Mic" {
+			EnableSequence [
+				cset "name='Internal Mic Switch' on"
+			]
+
+			DisableSequence [
+				cset "name='Internal Mic Switch' off"
+			]
+		}
 	}
 }
 
 If.hsmic {
 	Condition { Type String Empty "" }
 	True.Include.hsmic.File "/codecs/rt5640/HeadsetMic.conf"
+
+	SectionDevice."Headset" {
+		EnableSequence [
+			cset "name='Headset Mic Switch' on"
+		]
+
+		DisableSequence [
+			cset "name='Headset Mic Switch' off"
+		]
+	}
 }

--- a/ucm2/bytcr-rt5640/HiFi-LongName.conf
+++ b/ucm2/bytcr-rt5640/HiFi-LongName.conf
@@ -1,4 +1,5 @@
 Define.HaveSpeaker ""
+Define.HaveHeadsetMic ""
 Define.HaveInternalMic ""
 
 If.spk {
@@ -129,6 +130,7 @@ If.in3 {
 If.hsmic {
 	Condition { Type String Empty "" }
 	True.Include.hsmic.File "/codecs/rt5640/HeadsetMic.conf"
+	Define.HaveHeadsetMic "yes"
 
 	SectionDevice."Headset" {
 		EnableSequence [

--- a/ucm2/bytcr-rt5640/HiFi-LongName.conf
+++ b/ucm2/bytcr-rt5640/HiFi-LongName.conf
@@ -10,6 +10,16 @@ If.spk {
 	True {
 		Include.spk.File "/codecs/rt5640/Speaker.conf"
 		Define.HaveSpeaker "yes"
+
+		SectionDevice."Speaker" {
+			EnableSequence [
+				cset "name='Speaker Switch' on"
+			]
+
+			DisableSequence [
+				cset "name='Speaker Switch' off"
+			]
+		}
 	}
 }
 
@@ -22,12 +32,32 @@ If.mono {
 	True {
 		Include.mspk.File "/codecs/rt5640/MonoSpeaker.conf"
 		Define.HaveSpeaker "yes"
+
+		SectionDevice."Speaker" {
+			EnableSequence [
+				cset "name='Speaker Switch' on"
+			]
+
+			DisableSequence [
+				cset "name='Speaker Switch' off"
+			]
+		}
 	}
 }
 
 If.hp {
 	Condition { Type String Empty "" }
 	True.Include.hs.File "/codecs/rt5640/HeadPhones.conf"
+
+	SectionDevice."Headphones" {
+		EnableSequence [
+			cset "name='Headphone Switch' on"
+		]
+
+		DisableSequence [
+			cset "name='Headphone Switch' off"
+		]
+	}
 }
 
 If.dmic1 {
@@ -39,6 +69,16 @@ If.dmic1 {
 	True {
 		Include.dmic.File "/codecs/rt5640/DigitalMics.conf"
 		Define.HaveInternalMic "yes"
+
+		SectionDevice."Mic" {
+			EnableSequence [
+				cset "name='Internal Mic Switch' on"
+			]
+
+			DisableSequence [
+				cset "name='Internal Mic Switch' off"
+			]
+		}
 	}
 }
 
@@ -51,6 +91,16 @@ If.in1 {
 	True {
 		Include.mic1.File "/codecs/rt5640/IN1-InternalMic.conf"
 		Define.HaveInternalMic "yes"
+
+		SectionDevice."Mic" {
+			EnableSequence [
+				cset "name='Internal Mic Switch' on"
+			]
+
+			DisableSequence [
+				cset "name='Internal Mic Switch' off"
+			]
+		}
 	}
 }
 
@@ -63,10 +113,30 @@ If.in3 {
 	True {
 		Include.mic3.File "/codecs/rt5640/IN3-InternalMic.conf"
 		Define.HaveInternalMic "yes"
+
+		SectionDevice."Mic" {
+			EnableSequence [
+				cset "name='Internal Mic Switch' on"
+			]
+
+			DisableSequence [
+				cset "name='Internal Mic Switch' off"
+			]
+		}
 	}
 }
 
 If.hsmic {
 	Condition { Type String Empty "" }
 	True.Include.hsmic.File "/codecs/rt5640/HeadsetMic.conf"
+
+	SectionDevice."Headset" {
+		EnableSequence [
+			cset "name='Headset Mic Switch' on"
+		]
+
+		DisableSequence [
+			cset "name='Headset Mic Switch' off"
+		]
+	}
 }

--- a/ucm2/bytcr-rt5640/HiFi.conf
+++ b/ucm2/bytcr-rt5640/HiFi.conf
@@ -24,6 +24,13 @@ If.DefineAif2 {
 SectionVerb {
 	Include.e.File "/codecs/rt5640/EnableSeq.conf"
 
+	EnableSequence [
+		cset "name='Speaker Switch' off"
+		cset "name='Headphone Switch' off"
+		cset "name='Headset Mic Switch' off"
+		cset "name='Internal Mic Switch' off"
+	]
+
 	If.Controls {
 		Condition {
 			Type ControlExists

--- a/ucm2/codecs/rt5640/DigitalMics.conf
+++ b/ucm2/codecs/rt5640/DigitalMics.conf
@@ -1,9 +1,17 @@
 SectionDevice."Mic" {
 	Comment "Internal Digital Microphones"
 
-	ConflictingDevice [
-		"Headset"
-	]
+	If.have-headset {
+		Condition {
+			Type String
+			Empty "${var:HaveHeadsetMic}"
+		}
+		False {
+			ConflictingDevice [
+				"Headset"
+			]
+		}
+	}
 
 	EnableSequence [
 		cset "name='Mono ADC MIXL ADC2 Switch' on"

--- a/ucm2/codecs/rt5640/DigitalMics.conf
+++ b/ucm2/codecs/rt5640/DigitalMics.conf
@@ -10,7 +10,6 @@ SectionDevice."Mic" {
 		cset "name='Mono ADC MIXR ADC2 Switch' on"
 		cset "name='Stereo ADC MIXL ADC2 Switch' on"
 		cset "name='Stereo ADC MIXR ADC2 Switch' on"
-		cset "name='Internal Mic Switch' on"
 
 	]
 
@@ -19,7 +18,6 @@ SectionDevice."Mic" {
 		cset "name='Mono ADC MIXR ADC2 Switch' off"
 		cset "name='Stereo ADC MIXL ADC2 Switch' off"
 		cset "name='Stereo ADC MIXR ADC2 Switch' off"
-		cset "name='Internal Mic Switch' off"
 
 	]
 

--- a/ucm2/codecs/rt5640/EnableSeq.conf
+++ b/ucm2/codecs/rt5640/EnableSeq.conf
@@ -79,4 +79,7 @@ EnableSequence [
 	cset "name='HP R Playback Switch' off"
 	cset "name='Speaker L Playback Switch' off"
 	cset "name='Speaker R Playback Switch' off"
+
+	cset "name='HP Playback Volume' 29"
+	cset "name='Speaker Playback Volume' 35"
 ]

--- a/ucm2/codecs/rt5640/EnableSeq.conf
+++ b/ucm2/codecs/rt5640/EnableSeq.conf
@@ -71,4 +71,12 @@ EnableSequence [
 	cset "name='Mono ADC MIXR ADC1 Switch' off"
 	cset "name='Mono ADC MIXL ADC2 Switch' off"
 	cset "name='Mono ADC MIXR ADC2 Switch' off"
+
+	# Turn off playback switches by default, otherwise both Speaker
+	# and headphones are playing audio initially until headphones are
+	# re-inserted.
+	cset "name='HP L Playback Switch' off"
+	cset "name='HP R Playback Switch' off"
+	cset "name='Speaker L Playback Switch' off"
+	cset "name='Speaker R Playback Switch' off"
 ]

--- a/ucm2/codecs/rt5640/EnableSeq.conf
+++ b/ucm2/codecs/rt5640/EnableSeq.conf
@@ -71,9 +71,4 @@ EnableSequence [
 	cset "name='Mono ADC MIXR ADC1 Switch' off"
 	cset "name='Mono ADC MIXL ADC2 Switch' off"
 	cset "name='Mono ADC MIXR ADC2 Switch' off"
-
-	cset "name='Speaker Switch' off"
-	cset "name='Headphone Switch' off"
-	cset "name='Internal Mic Switch' off"
-	cset "name='Headset Mic Switch' off"
 ]

--- a/ucm2/codecs/rt5640/HeadPhones.conf
+++ b/ucm2/codecs/rt5640/HeadPhones.conf
@@ -18,7 +18,6 @@ SectionDevice."Headphones" {
 		cset "name='HP Channel Switch' on"
 		cset "name='HP L Playback Switch' on"
 		cset "name='HP R Playback Switch' on"
-		cset "name='HP Playback Volume' 29"
 
 	]
 
@@ -26,7 +25,6 @@ SectionDevice."Headphones" {
 		cset "name='HP Channel Switch' off"
 		cset "name='HP L Playback Switch' off"
 		cset "name='HP R Playback Switch' off"
-		cset "name='HP Playback Volume' 0"
 	]
 
 	Value {

--- a/ucm2/codecs/rt5640/HeadPhones.conf
+++ b/ucm2/codecs/rt5640/HeadPhones.conf
@@ -15,7 +15,6 @@ SectionDevice."Headphones" {
 
 	EnableSequence [
  		cset "name='HPO MIX HPVOL Switch'  on"
- 		cset "name='Headphone Switch'  on"
 		cset "name='HP Channel Switch' on"
 		cset "name='HP L Playback Switch' on"
 		cset "name='HP R Playback Switch' on"
@@ -24,7 +23,6 @@ SectionDevice."Headphones" {
 	]
 
 	DisableSequence [
-		cset "name='Headphone Switch' off"
 		cset "name='HP Channel Switch' off"
 		cset "name='HP L Playback Switch' off"
 		cset "name='HP R Playback Switch' off"

--- a/ucm2/codecs/rt5640/HeadsetMic.conf
+++ b/ucm2/codecs/rt5640/HeadsetMic.conf
@@ -14,8 +14,6 @@ SectionDevice."Headset" {
 	}
 
 	EnableSequence [
-		cset "name='Headset Mic Switch' on"
-
 		cset "name='RECMIXL BST2 Switch' on"
 		cset "name='RECMIXR BST2 Switch' on"
 
@@ -33,8 +31,6 @@ SectionDevice."Headset" {
 
 		cset "name='RECMIXL BST2 Switch' off"
 		cset "name='RECMIXR BST2 Switch' off"
-
-		cset "name='Headset Mic Switch' off"
 	]
 
 	Value {

--- a/ucm2/codecs/rt5640/IN1-InternalMic.conf
+++ b/ucm2/codecs/rt5640/IN1-InternalMic.conf
@@ -6,8 +6,6 @@ SectionDevice."Mic" {
 	]
 
 	EnableSequence [
-		cset "name='Internal Mic Switch' on"
-
 		cset "name='RECMIXL BST1 Switch' on"
 		cset "name='RECMIXR BST1 Switch' on"
 
@@ -25,8 +23,6 @@ SectionDevice."Mic" {
 
 		cset "name='RECMIXL BST1 Switch' off"
 		cset "name='RECMIXR BST1 Switch' off"
-
-		cset "name='Internal Mic Switch' off"
 	]
 
 	Value {

--- a/ucm2/codecs/rt5640/IN1-InternalMic.conf
+++ b/ucm2/codecs/rt5640/IN1-InternalMic.conf
@@ -1,9 +1,17 @@
 SectionDevice."Mic" {
 	Comment "Internal Microphone on IN1"
 
-	ConflictingDevice [
-		"Headset"
-	]
+	If.have-headset {
+		Condition {
+			Type String
+			Empty "${var:HaveHeadsetMic}"
+		}
+		False {
+			ConflictingDevice [
+				"Headset"
+			]
+		}
+	}
 
 	EnableSequence [
 		cset "name='RECMIXL BST1 Switch' on"

--- a/ucm2/codecs/rt5640/IN3-InternalMic.conf
+++ b/ucm2/codecs/rt5640/IN3-InternalMic.conf
@@ -6,8 +6,6 @@ SectionDevice."Mic" {
 	]
 
 	EnableSequence [
-		cset "name='Internal Mic Switch' on"
-
 		cset "name='RECMIXL BST3 Switch' on"
 		cset "name='RECMIXR BST3 Switch' on"
 
@@ -25,8 +23,6 @@ SectionDevice."Mic" {
 
 		cset "name='RECMIXL BST3 Switch' off"
 		cset "name='RECMIXR BST3 Switch' off"
-
-		cset "name='Internal Mic Switch' off"
 	]
 
 	Value {

--- a/ucm2/codecs/rt5640/IN3-InternalMic.conf
+++ b/ucm2/codecs/rt5640/IN3-InternalMic.conf
@@ -1,9 +1,17 @@
 SectionDevice."Mic" {
 	Comment "Internal Microphone on IN3"
 
-	ConflictingDevice [
-		"Headset"
-	]
+	If.have-headset {
+		Condition {
+			Type String
+			Empty "${var:HaveHeadsetMic}"
+		}
+		False {
+			ConflictingDevice [
+				"Headset"
+			]
+		}
+	}
 
 	EnableSequence [
 		cset "name='RECMIXL BST3 Switch' on"

--- a/ucm2/codecs/rt5640/MonoSpeaker.conf
+++ b/ucm2/codecs/rt5640/MonoSpeaker.conf
@@ -10,7 +10,6 @@ SectionDevice."Speaker" {
 # for mono speaker we apply left on right
 #		cset "name='SPOR MIX SPKVOL R Switch' on"
 		cset "name='SPOL MIX SPKVOL R Switch' on"
-		cset "name='Speaker Switch' on"
 		cset "name='Speaker Channel Switch' on"
 		cset "name='Speaker L Playback Switch' on"
 		cset "name='Speaker R Playback Switch' on"
@@ -19,7 +18,6 @@ SectionDevice."Speaker" {
 	]
 
 	DisableSequence [
-		cset "name='Speaker Switch' off"
 		cset "name='Speaker Channel Switch' off"
 		cset "name='Speaker L Playback Switch' off"
 		cset "name='Speaker R Playback Switch' off"

--- a/ucm2/codecs/rt5640/MonoSpeaker.conf
+++ b/ucm2/codecs/rt5640/MonoSpeaker.conf
@@ -13,7 +13,6 @@ SectionDevice."Speaker" {
 		cset "name='Speaker Channel Switch' on"
 		cset "name='Speaker L Playback Switch' on"
 		cset "name='Speaker R Playback Switch' on"
-		cset "name='Speaker Playback Volume' 35"
 
 	]
 
@@ -21,7 +20,6 @@ SectionDevice."Speaker" {
 		cset "name='Speaker Channel Switch' off"
 		cset "name='Speaker L Playback Switch' off"
 		cset "name='Speaker R Playback Switch' off"
-		cset "name='Speaker Playback Volume' 0"
 	]
 
 	Value {

--- a/ucm2/codecs/rt5640/Speaker.conf
+++ b/ucm2/codecs/rt5640/Speaker.conf
@@ -13,7 +13,6 @@ SectionDevice."Speaker" {
 		cset "name='Speaker Channel Switch' on"
 		cset "name='Speaker L Playback Switch' on"
 		cset "name='Speaker R Playback Switch' on"
-		cset "name='Speaker Playback Volume' 35"
 
 	]
 
@@ -21,7 +20,6 @@ SectionDevice."Speaker" {
 		cset "name='Speaker Channel Switch' off"
 		cset "name='Speaker L Playback Switch' off"
 		cset "name='Speaker R Playback Switch' off"
-		cset "name='Speaker Playback Volume' 0"
 	]
 
 	Value {

--- a/ucm2/codecs/rt5640/Speaker.conf
+++ b/ucm2/codecs/rt5640/Speaker.conf
@@ -10,7 +10,6 @@ SectionDevice."Speaker" {
 		cset "name='SPOR MIX SPKVOL R Switch' on"
 		# undo MonoSpeaker mixing of right channel to left speaker
 		cset "name='SPOL MIX SPKVOL R Switch' off"
-		cset "name='Speaker Switch' on"
 		cset "name='Speaker Channel Switch' on"
 		cset "name='Speaker L Playback Switch' on"
 		cset "name='Speaker R Playback Switch' on"
@@ -19,7 +18,6 @@ SectionDevice."Speaker" {
 	]
 
 	DisableSequence [
-		cset "name='Speaker Switch' off"
 		cset "name='Speaker Channel Switch' off"
 		cset "name='Speaker L Playback Switch' off"
 		cset "name='Speaker R Playback Switch' off"

--- a/ucm2/conf.d/tegra/ASUS Google Nexus 7 ALC5642.conf
+++ b/ucm2/conf.d/tegra/ASUS Google Nexus 7 ALC5642.conf
@@ -1,0 +1,8 @@
+# Use case Configuration for ASUS Google Nexus 7 (2012)
+
+Syntax 4
+
+SectionUseCase."HiFi" {
+	File "/Tegra/rt5640/ASUS Google Nexus 7 ALC5642.conf"
+	Comment "Play HiFi quality Music"
+}

--- a/ucm2/conf.d/tegra/Acer Iconia Tab A500 WM8903.conf
+++ b/ucm2/conf.d/tegra/Acer Iconia Tab A500 WM8903.conf
@@ -1,0 +1,8 @@
+# Use case Configuration for Acer Iconia Tab A500
+
+Syntax 4
+
+SectionUseCase."HiFi" {
+	File "/Tegra/wm8903/Acer Iconia Tab A500 WM8903.conf"
+	Comment "Play HiFi quality Music"
+}

--- a/ucm2/conf.d/tegra/Compal PAZ00.conf
+++ b/ucm2/conf.d/tegra/Compal PAZ00.conf
@@ -1,0 +1,1 @@
+../../Tegra/alc5632/alc5632.conf

--- a/ucm2/conf.d/tegra/GoogleNyanBig.conf
+++ b/ucm2/conf.d/tegra/GoogleNyanBig.conf
@@ -1,0 +1,1 @@
+../../Tegra/max98090/max98090.conf

--- a/ucm2/conf.d/tegra/GoogleNyanBlaze.conf
+++ b/ucm2/conf.d/tegra/GoogleNyanBlaze.conf
@@ -1,0 +1,1 @@
+../../Tegra/max98090/max98090.conf


### PR DESCRIPTION
@perexg As was discussed previouly at https://www.spinics.net/lists/alsa-devel/msg126382.html I'm opening PR with the UCMs for  Nexus 7 and A500. Both these devices are supported by the mainline Linux kernel. 

You're right that Tegra ASoC driver doesn't set card's name properly. In particular I found that we need to set the card's `driver_name` to `tegra`, then UCM get a proper lookup path.

I rebased UCMs on top of the recent alsa-ucm-conf master and switched Nexus 7 UCM to use generic RT5640 UCM. Everything works great once the card name of the kernel driver is corrected. I'll send the kernel patches ASAP for review.

Nexus 7 alsa-info: https://alsa-project.org/db/?f=0a29f1dab39ec5b33e01215dee42dbfd1dbbf08e
A500 alsa-info: https://alsa-project.org/db/?f=bde4f7938a39b1d26904b414969fc811e726242f

The alsa-info is taken using the updated kernel ASoC driver.