### PR TITLE
Add UCM for Nvidia Tegra HDMI Audio

### DIFF
--- a/ucm2/Tegra/tegra-hda/tegra-hda-HiFi.conf
+++ b/ucm2/Tegra/tegra-hda/tegra-hda-HiFi.conf
@@ -1,0 +1,12 @@
+If.hdmi {
+	Condition { Type String Empty "" }
+	True {
+		Define {
+			HdmiNum 1
+			HdmiPCM 3
+			HdmiCtlIndex 0
+			HdmiPrio 1100
+		}
+		Include.hdmi.File "/codecs/hda/hdmi.conf"
+	}
+}

--- a/ucm2/Tegra/tegra-hda/tegra-hda.conf
+++ b/ucm2/Tegra/tegra-hda/tegra-hda.conf
@@ -1,0 +1,8 @@
+# UCM for Nvidia Tegra30 HDMI Audio
+
+Syntax 4
+
+SectionUseCase."HiFi" {
+	File "/Tegra/tegra-hda/tegra-hda-HiFi.conf"
+	Comment "Play HiFi quality Music"
+}

--- a/ucm2/conf.d/tegra-hda/tegra-hda.conf
+++ b/ucm2/conf.d/tegra-hda/tegra-hda.conf
@@ -1,0 +1,1 @@
+../../Tegra/tegra-hda/tegra-hda.conf


### PR DESCRIPTION
This were used to have audio over HDMI on Asus Transformers. You may find original configs [in pmOS](https://gitlab.com/postmarketOS/pmaports/-/tree/master/device/testing/device-asus-tf201/ucm) and paths used [here](https://gitlab.com/postmarketOS/pmaports/-/blob/master/device/testing/device-asus-tf201/APKBUILD#L30-38). I have adjusted them to use syntax 4 and re-use common codecs. 

This ucm is universal for all Tegra 3 devices and hopefully Tegra 2 as well.