### PR TITLE
hda: improve the microphone device allocation

### DIFF
--- a/ucm2/HDA-Intel/HDA-Intel.conf
+++ b/ucm2/HDA-Intel/HDA-Intel.conf
@@ -3,13 +3,17 @@ Syntax 4
 Define.Use ""	# a non-empty string to use UCM configuration for HDA devices
 
 Define.AcpCardId "$${find-card:field=name,return=id,regex='^acp$'}"
+Define.DeviceMic "Mic"
 
 If.acp {
 	Condition {
 		Type String
 		Empty "${var:AcpCardId}"
 	}
-	False.Define.Use y
+	False {
+		Define.Use y
+		Define.DeviceMic "Mic2"
+	}
 }
 
 If.use {

--- a/ucm2/HDA-Intel/HiFi-analog.conf
+++ b/ucm2/HDA-Intel/HiFi-analog.conf
@@ -87,7 +87,7 @@ If.monomic {
 		ControlEnum "Headphone Mic"
 	}
 	True {
-		SectionDevice."Mic2" {
+		SectionDevice."${var:DeviceMic}" {
 			Comment "Headphones Stereo Microphone"
 
 			ConflictingDevice [
@@ -120,7 +120,7 @@ If.monomic {
 		}
 	}
 	False {
-		SectionDevice."Mic2" {
+		SectionDevice."${var:DeviceMic}" {
 			Comment "Headphones Stereo Microphone"
 
 			Value {

--- a/ucm2/HDA-Intel/HiFi.conf
+++ b/ucm2/HDA-Intel/HiFi.conf
@@ -16,11 +16,8 @@ If.analog {
 				Type String
 				Empty "${var:AcpCardId}"
 			}
-			True {
-				RenameDevice."Mic1" "Mic"
-			}
 			False.Include.acp {
-				Before.SectionDevice "Mic1"
+				Before.SectionDevice "${var:DeviceMic}"
 				File "/HDA-Intel/HiFi-acp.conf"
 			}
 		}

--- a/ucm2/sof-hda-dsp/HiFi.conf
+++ b/ucm2/sof-hda-dsp/HiFi.conf
@@ -4,43 +4,48 @@ SectionVerb {
 	Value.TQ "HiFi"
 }
 
-<HDA-Intel/HiFi-analog.conf>
+Include.hda-analog.File "/HDA-Intel/HiFi-analog.conf"
 
-If.monomic.After.SectionDevice "Mic1"
+If.dmic {
+	Condition {
+		Type String
+		Empty "${var:DeviceDmic}"
+	}
+	Before.SectionDevice "${var:DeviceMic}"
+	False.SectionDevice."${var:DeviceDmic}" {
+		Comment "Digital Microphone"
 
-SectionDevice."Mic1" {
-	Comment "Digital Microphone"
-
-	Value {
-		CapturePriority 100
-		CapturePCM "hw:${CardId},6"
-		If.chn {
-			Condition {
-				Type RegexMatch
-				Regex "cfg-dmics:[34]"
-				String "${CardComponents}"
+		Value {
+			CapturePriority 100
+			CapturePCM "hw:${CardId},6"
+			If.chn {
+				Condition {
+					Type RegexMatch
+					Regex "cfg-dmics:[34]"
+					String "${CardComponents}"
+				}
+				True {
+					CaptureChannels 4
+				}
 			}
-			True {
-				CaptureChannels 4
-			}
-		}
-		If.vol {
-			Condition {
-				Type ControlExists
-				Control "name='Dmic0 Capture Switch'"
-			}
-			True {
-				CaptureMixerElem "Dmic0"
-				CaptureVolume "Dmic0 Capture Volume"
-				CaptureSwitch "Dmic0 Capture Switch"
-			}
-			False {
-				# v1.3 SOF firmware
-				CaptureMixerElem "PGA10.0 10 Master"
-				CaptureVolume "PGA10.0 10 Master Capture Volume"
+			If.vol {
+				Condition {
+					Type ControlExists
+					Control "name='Dmic0 Capture Switch'"
+				}
+				True {
+					CaptureMixerElem "Dmic0"
+					CaptureVolume "Dmic0 Capture Volume"
+					CaptureSwitch "Dmic0 Capture Switch"
+				}
+				False {
+					# v1.3 SOF firmware
+					CaptureMixerElem "PGA10.0 10 Master"
+					CaptureVolume "PGA10.0 10 Master Capture Volume"
+				}
 			}
 		}
 	}
 }
 
-<sof-hda-dsp/Hdmi.conf>
+Include.hdmi.File "/sof-hda-dsp/Hdmi.conf"

--- a/ucm2/sof-hda-dsp/sof-hda-dsp.conf
+++ b/ucm2/sof-hda-dsp/sof-hda-dsp.conf
@@ -1,4 +1,17 @@
-Syntax 3
+Syntax 4
+
+Define.DeviceMic "Mic"
+Define.DeviceDmic ""
+
+If.dmic {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "cfg-dmics:"
+	}
+	True.Define.DeviceDmic "Mic1"
+	True.Define.DeviceMic "Mic2"
+}
 
 SectionUseCase."HiFi" {
 	File "HiFi.conf"
@@ -48,12 +61,18 @@ If.headphone {
 	]
 }
 
-If.Dmic0 {
+If.dmic {
 	Condition {
-		Type ControlExists
-		Control "name='Dmic0 Capture Volume'"
+		Type String
+		Empty "${var:DeviceDmic}"
 	}
-	True.BootSequence [
-		cset "name='Dmic0 Capture Volume' 70%"
-	]
+	False.If.Dmic0 {
+		Condition {
+			Type ControlExists
+			Control "name='Dmic0 Capture Volume'"
+		}
+		True.BootSequence [
+			cset "name='Dmic0 Capture Volume' 70%"
+		]
+	}
 }


### PR DESCRIPTION
This change use the local variables for the UCM microphone
device names. Also, handle the no-dmic case for sof-hda-dsp
hardware.
