### PR TITLE
HDA-Intel: add Boost volume control for Headset Mic

### DIFF
--- a/ucm2/HDA-Intel/HiFi-analog.conf
+++ b/ucm2/HDA-Intel/HiFi-analog.conf
@@ -101,6 +101,7 @@ If.monomic {
 			Value {
 				CapturePriority 200
 				Include.value.File "/HDA-Intel/HDA-Capture-value.conf"
+				CaptureMasterElem "Headphone Mic Boost"
 				JackControl "Headphone Mic Jack"
 			}
 		}
@@ -115,6 +116,7 @@ If.monomic {
 			Value {
 				CapturePriority 300
 				Include.value.File "/HDA-Intel/HDA-Capture-value.conf"
+				CaptureMasterElem "Headset Mic Boost"
 				JackControl "Headphone Mic Jack"
 			}
 		}
@@ -126,6 +128,7 @@ If.monomic {
 			Value {
 				CapturePriority 200
 				Include.value.File "/HDA-Intel/HDA-Capture-value.conf"
+				CaptureMasterElem "Mic Boost"
 				JackControl "Mic Jack"
 			}
 		}


### PR DESCRIPTION
Ubuntu Linux users complain even they set the input volume to maximum,
they still can't record sound with a pretty satisfied volume, they
need to run commandline commands to adjust "Mic Boost/Headset Mic
Boost/Headphone Mic boost" value to increase the input volume.

That is because the current ucm only defines "Capture Volume" to
control the input volume. Here we add Boost control, then users could
adjust both "Capture Volume" and "Boost Volume" through Pulseaudio and
Gnome.

BugLink: https://bugs.launchpad.net/bugs/1930188
Signed-off-by: Hui Wang <hui.wang@canonical.com>