### PR TITLE
Add UCM for Librem 5 Devkit

### DIFF
--- a/ucm2/NXP/iMX8/Librem_5_Devkit/HiFi.conf
+++ b/ucm2/NXP/iMX8/Librem_5_Devkit/HiFi.conf
@@ -1,0 +1,74 @@
+SectionVerb {
+	EnableSequence [
+		cset "name='Digital Input Mux' I2S"
+		cset "name='PCM Playback Volume' 144"
+
+		cset "name='AVC Switch' off"
+		cset "name='Headphone Playback ZC Switch' off"
+
+		cset "name='Capture Attenuate Switch (-6dB)' off"
+		cset "name='Capture Mux' MIX_IN"
+		cset "name='Capture ZC Switch' off"
+		cset "name='Capture Switch' On"
+		cset "name='Capture Volume' 15,15"
+	]
+	DisableSequence [
+		cset "name='PCM Playback Volume' 0"
+	]
+	Value {
+	}
+}
+
+SectionDevice."Handset".0 {
+	Comment "Handset"
+
+	ConflictingDevice [
+		"Headset"
+	]
+
+	EnableSequence [
+		cset "name='Mic Mux MUX' Input 2"
+		cset "name='Lineout Playback Switch' on"
+		cset "name='Lineout Playback Volume' 18"
+		cset "name='Mic Volume' 2"
+	]
+	DisableSequence [
+		cset "name='Lineout Playback Switch' off"
+		cset "name='Mic Volume' 0"
+	]
+	Value {
+		PlaybackPriority "1000"
+		PlaybackPCM "hw:${CardId},0"
+		PlaybackVolume "name='Lineout Playback Volume'"
+		PlaybackSwitch "name='Lineout Playback Switch'"
+		CapturePriority "1000"
+		CapturePCM "hw:${CardId},0"
+	}
+}
+
+SectionDevice."Headset".0 {
+	Comment "Headset"
+
+	ConflictingDevice [
+		"Handset"
+	]
+
+	EnableSequence [
+		cset "name='Mic Mux MUX' Input 1"
+		cset "name='Headphone Mux' DAC"
+		cset "name='Headphone Playback Volume' 63"
+		cset "name='Headphone Playback Switch' on"
+	]
+	DisableSequence [
+		cset "name='Headphone Playback Switch' off"
+	]
+	Value {
+		PlaybackPriority "700"
+		PlaybackPCM "hw:${CardId},0"
+		PlaybackVolume "name='Headphone Playback Volume'"
+		PlaybackSwitch "name='Headphone Playback Switch'"
+		CapturePriority "700"
+		CapturePCM "hw:${CardId},0"
+		JackControl "Headphones Jack"
+	}
+}

--- a/ucm2/NXP/iMX8/Librem_5_Devkit/Librem 5 Devkit.conf
+++ b/ucm2/NXP/iMX8/Librem_5_Devkit/Librem 5 Devkit.conf
@@ -1,0 +1,10 @@
+Syntax 2
+
+SectionUseCase."HiFi" {
+	File "HiFi.conf"
+}
+
+ValueDefaults {
+	PlaybackPCM "hw:${CardId},0"
+	CapturePCM "hw:${CardId},0"
+}

--- a/ucm2/conf.d/simple-card/Librem 5 Devkit.conf
+++ b/ucm2/conf.d/simple-card/Librem 5 Devkit.conf
@@ -1,0 +1,1 @@
+../../NXP/iMX8/Librem_5_Devkit/Librem 5 Devkit.conf


### PR DESCRIPTION
The DTS configuration is in Linux mainline since 5.12:

https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/arm64/boot/dts/freescale/imx8mq-librem5-devkit.dts?h=v5.12#n166

This is based on initial work by Bob Ham.

Signed-off-by: Guido Günther <agx@sigxcpu.org>