### PR TITLE
sof-ehl-rt5660: Add UCM for Intel sof-ehl-rt5660

### DIFF
--- a/ucm2/sof-ehl-rt5660/Hdmi.conf
+++ b/ucm2/sof-ehl-rt5660/Hdmi.conf
@@ -1,0 +1,85 @@
+# Usecase for device HDMI/Display Port stereo playback on Intel ELKHARTLAKE platforms
+
+SectionDevice."HDMI1" {
+	Comment "HDMI/Display Port 1 Stereo"
+
+	Value {
+		PlaybackPCM "hw:${CardId},3"
+		PlaybackPriority 500
+		If.1 {
+			Condition {
+				Type ControlExists
+				Control "iface=CARD,name='HDMI/DP,pcm=3 Jack'"
+			}
+			True {
+				JackControl "HDMI/DP,pcm=3 Jack"
+			}
+			False {
+				JackControl "HDMI/DP, pcm=3 Jack"
+			}
+		}
+	}
+}
+
+SectionDevice."HDMI2" {
+	Comment "HDMI/Display Port 2 Stereo"
+
+	Value {
+		PlaybackPCM "hw:${CardId},4"
+		PlaybackPriority 600
+		If.1 {
+			Condition {
+				Type ControlExists
+				Control "iface=CARD,name='HDMI/DP,pcm=4 Jack'"
+			}
+			True {
+				JackControl "HDMI/DP,pcm=4 Jack"
+			}
+			False {
+				JackControl "HDMI/DP, pcm=4 Jack"
+			}
+		}
+	}
+}
+
+SectionDevice."HDMI3" {
+	Comment "HDMI/Display Port 3 Stereo"
+
+	Value {
+		PlaybackPCM "hw:${CardId},5"
+		PlaybackPriority 600
+		If.1 {
+			Condition {
+				Type ControlExists
+				Control "iface=CARD,name='HDMI/DP,pcm=5 Jack'"
+			}
+			True {
+				JackControl "HDMI/DP,pcm=5 Jack"
+			}
+			False {
+				JackControl "HDMI/DP, pcm=5 Jack"
+			}
+		}
+	}
+}
+
+SectionDevice."HDMI4" {
+	Comment "HDMI/Display Port 4 Stereo"
+
+	Value {
+		PlaybackPCM "hw:${CardId},6"
+		PlaybackPriority 600
+		If.1 {
+			Condition {
+				Type ControlExists
+				Control "iface=CARD,name='HDMI/DP,pcm=6 Jack'"
+			}
+			True {
+				JackControl "HDMI/DP,pcm=6 Jack"
+			}
+			False {
+				JackControl "HDMI/DP, pcm=6 Jack"
+			}
+		}
+	}
+}

--- a/ucm2/sof-ehl-rt5660/HiFi.conf
+++ b/ucm2/sof-ehl-rt5660/HiFi.conf
@@ -1,0 +1,75 @@
+# Usecase for stereo playback Speaker and Headset, Recording on DMIC and Headset MIC.
+# For Audio in I2S mode on Intel ElkhartLake platforms
+
+SectionVerb {
+
+}
+
+SectionDevice."Speaker" {
+	Comment "Speaker"
+
+	ConflictingDevice [
+		"Lineout"
+	]
+
+	EnableSequence [
+		cset "name='Speaker Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Speaker Switch' off"
+	]
+	Value {
+		PlaybackPriority 100
+		PlaybackPCM "hw:${CardId}"
+	}
+}
+
+SectionDevice."Lineout" {
+	Comment "Lineout"
+
+	ConflictingDevice [
+		"Speaker"
+	]
+
+	EnableSequence [
+		cset "name='Line Out Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Line Out Switch' off"
+	]
+
+	Value {
+		PlaybackPriority 200
+		PlaybackPCM "hw:${CardId}"
+	}
+}
+
+SectionDevice."Mic" {
+	Comment "Digital Microphone"
+
+	Value {
+		CapturePriority 100
+		CapturePCM "hw:${CardId},1"
+	}
+}
+
+SectionDevice."Headset" {
+	Comment "Headset Microphone"
+
+	EnableSequence [
+		cset "name='Headset Mic2 Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Headset Mic2 Switch' off"
+	]
+
+	Value {
+		CapturePriority 200
+		CapturePCM "hw:${CardId}"
+	}
+}
+
+Include.hdmi.File "/sof-ehl-rt5660/Hdmi.conf"

--- a/ucm2/sof-ehl-rt5660/sof-ehl-rt5660.conf
+++ b/ucm2/sof-ehl-rt5660/sof-ehl-rt5660.conf
@@ -1,0 +1,19 @@
+# UCM for Intel ElkhartLake platforms
+# For Audio in I2S mode
+
+Syntax 3
+
+SectionUseCase."HiFi" {
+	File "HiFi.conf"
+	Comment "Play and record HiFi quality Music"
+}
+
+SectionDefaults [
+	cset "name='DAC1 MIXL DAC1 Switch' on"
+	cset "name='DAC1 MIXR DAC1 Switch' on"
+	cset "name='Stereo DAC MIXL DAC L1 Switch' on"
+	cset "name='Stereo DAC MIXR DAC R1 Switch' on"
+	cset "name='LOUT MIX DAC Switch' on"
+	cset "name='RECMIXL BST2 Switch' on"
+	cset "name='RECMIXR BST2 Switch' on"
+]


### PR DESCRIPTION
Add the UCM support for the sof-ehl-rt5660 platform.

Signed-off-by: Libin Yang <libin.yang@intel.com>