### PR TITLE
sof-hda-dsp: Set Capture Switch on in the BootSequence

### DIFF
--- a/ucm2/sof-hda-dsp/sof-hda-dsp.conf
+++ b/ucm2/sof-hda-dsp/sof-hda-dsp.conf
@@ -57,3 +57,14 @@ If.Dmic0 {
 		cset "name='Dmic0 Capture Volume' 70%"
 	]
 }
+
+If.Capture {
+	Condition {
+		Type ControlExists
+		Control "name='Capture Switch'"
+	}
+	True.BootSequence [
+		cset "name='Capture Volume' 60%"
+		cset "name='Capture Switch' on"
+	]
+}


### PR DESCRIPTION
We found an issue that the PA source of Mic2/Headset and Mic2 is
muted by default after newly install an OS, the root cause is the
'Capture Switch' is set to off in the kernel.

Without ucm, the /usr/share/alsa/init/default will set the 'Capture
Switch' to on, similarly we set it to on in the BootSequence of ucm.

Signed-off-by: Hui Wang <hui.wang@canonical.com>