### PR TITLE
sof-soundwire: rt1316 - DAC L and R is replaced by DAC

### DIFF
--- a/ucm2/sof-soundwire/rt1316-1.conf
+++ b/ucm2/sof-soundwire/rt1316-1.conf
@@ -3,17 +3,36 @@
 SectionDevice."Speaker" {
 	Comment	"Speaker"
 
-	EnableSequence [
-		cset "name='rt1316-1 DAC L Switch' 1"
-		cset "name='rt1316-1 DAC R Switch' 1"
-		cset "name='Speaker Switch' on"
-	]
+	If.lrswitch {
+		Condition {
+			Type ControlExists
+			Control "name='rt1316-1 DAC L Switch'"
+		}
+		True {
+			EnableSequence [
+				cset "name='rt1316-1 DAC L Switch' 1"
+				cset "name='rt1316-1 DAC R Switch' 1"
+				cset "name='Speaker Switch' on"
+			]
 
-	DisableSequence [
-		cset "name='rt1316-1 DAC L Switch' 0"
-		cset "name='rt1316-1 DAC R Switch' 0"
-		cset "name='Speaker Switch' off"
-	]
+			DisableSequence [
+				cset "name='rt1316-1 DAC L Switch' 0"
+				cset "name='rt1316-1 DAC R Switch' 0"
+				cset "name='Speaker Switch' off"
+			]
+		}
+		False {
+			EnableSequence [
+				cset "name='rt1316-1 DAC Switch' 1"
+				cset "name='Speaker Switch' on"
+			]
+
+			DisableSequence [
+				cset "name='rt1316-1 DAC Switch' 0"
+				cset "name='Speaker Switch' off"
+			]
+		}
+	}
 
 	Value {
 	      PlaybackPriority 100

--- a/ucm2/sof-soundwire/rt1316-2.conf
+++ b/ucm2/sof-soundwire/rt1316-2.conf
@@ -3,24 +3,46 @@
 SectionDevice."Speaker" {
 	Comment	"Speaker"
 
-	EnableSequence [
-		cset "name='rt1316-1 RX Channel Select' L,L"
-		cset "name='rt1316-2 RX Channel Select' R,R"
+	If.lrswitch {
+		Condition {
+			Type ControlExists
+			Control "name='rt1316-1 DAC L Switch'"
+		}
+		True {
+			EnableSequence [
+				cset "name='rt1316-1 RX Channel Select' L,L"
+				cset "name='rt1316-2 RX Channel Select' R,R"
+				cset "name='rt1316-1 DAC L Switch' 1"
+				cset "name='rt1316-1 DAC R Switch' 1"
+				cset "name='rt1316-2 DAC L Switch' 1"
+				cset "name='rt1316-2 DAC R Switch' 1"
+				cset "name='Speaker Switch' on"
+			]
 
-		cset "name='rt1316-1 DAC L Switch' 1"
-		cset "name='rt1316-1 DAC R Switch' 1"
-		cset "name='rt1316-2 DAC L Switch' 1"
-		cset "name='rt1316-2 DAC R Switch' 1"
-		cset "name='Speaker Switch' on"
-	]
+			DisableSequence [
+				cset "name='rt1316-1 DAC L Switch' 0"
+				cset "name='rt1316-1 DAC R Switch' 0"
+				cset "name='rt1316-2 DAC L Switch' 0"
+				cset "name='rt1316-2 DAC R Switch' 0"
+				cset "name='Speaker Switch' off"
+			]
+		}
+		False {
+			EnableSequence [
+				cset "name='rt1316-1 RX Channel Select' L,L"
+				cset "name='rt1316-2 RX Channel Select' R,R"
+				cset "name='rt1316-1 DAC Switch' 1"
+				cset "name='rt1316-2 DAC Switch' 1"
+				cset "name='Speaker Switch' on"
+			]
 
-	DisableSequence [
-		cset "name='rt1316-1 DAC L Switch' 0"
-		cset "name='rt1316-1 DAC R Switch' 0"
-		cset "name='rt1316-2 DAC L Switch' 0"
-		cset "name='rt1316-2 DAC R Switch' 0"
-		cset "name='Speaker Switch' off"
-	]
+			DisableSequence [
+				cset "name='rt1316-1 DAC Switch' 0"
+				cset "name='rt1316-2 DAC Switch' 0"
+				cset "name='Speaker Switch' off"
+			]
+		}
+	}
 
 	Value {
 	      PlaybackPriority 100


### PR DESCRIPTION
In the latest codec driver rt1316-sdw.c, the DAC L and DAC R are
replaced by DAC, so we change the ucm to add the condition checking,
if 'DAC L' exists, will set those mixers in the old way, otherwise,
set the mixers with new name.

The codec rt1316 is used on a Dell TGL soundwire audio machine.

Signed-off-by: Hui Wang <hui.wang@canonical.com>