### PR TITLE
ucm2: Add UCM support for rockchip_es8316 on Pinebook Pro

### DIFF
--- a/ucm2/Rockchip/rockchip_es8316/HiFi.conf
+++ b/ucm2/Rockchip/rockchip_es8316/HiFi.conf
@@ -1,0 +1,66 @@
+# Reference:
+# https://gitlab.manjaro.org/manjaro-arm/packages/community/pinebookpro-post-install/-/blob/4b4206c57b21044bf9c00848bd1f8b6f710d19eb/asound.state
+# https://gitlab.manjaro.org/manjaro-arm/packages/community/pinebookpro-audio/-/blob/1f567db09495acc3beb5405c9ef85c3c07b86785/audio_jack_plugged_in.sh
+
+SectionDevice."Speaker" {
+	Comment "Speaker"
+
+	ConflictingDevice [
+		"Headphones"
+	]
+
+	EnableSequence [
+		cset "name='Playback Polarity' 'R Invert'"
+		cset "name='Speaker Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Speaker Switch' off"
+	]
+
+	Value {
+		PlaybackPriority 100
+		PlaybackPCM "hw:${CardId}"
+		PlaybackMixerElem "Headphone Mixer"
+		PlaybackMasterElem "DAC"
+	}
+}
+
+SectionDevice."Mic" {
+	Comment "Internal Microphone"
+
+	EnableSequence [
+		cset "name='Differential Mux' lin1-rin1"
+	]
+
+	Value {
+		CapturePriority 100
+		CapturePCM "hw:${CardId}"
+		CaptureMixerElem "ADC PGA Gain"
+		CaptureMasterElem "ADC"
+	}
+}
+
+SectionDevice."Headphones" {
+	Comment "Headphones"
+
+	ConflictingDevice [
+		"Speaker"
+	]
+
+	EnableSequence [
+		cset "name='Playback Polarity' 'Normal'"
+	]
+	DisableSequence [
+		cset "name='Playback Polarity' 'R Invert'"
+	]
+
+	Value {
+		PlaybackPriority 200
+		PlaybackPCM "hw:${CardId}"
+		PlaybackMixerElem "Headphone Mixer"
+		PlaybackMasterElem "DAC"
+		JackControl "Headphones Jack"
+		JackHWMute "Speaker"
+	}
+}

--- a/ucm2/Rockchip/rockchip_es8316/rockchip_es8316.conf
+++ b/ucm2/Rockchip/rockchip_es8316/rockchip_es8316.conf
@@ -1,0 +1,29 @@
+Syntax 3
+
+SectionUseCase."HiFi" {
+	File "/Rockchip/rockchip_es8316/HiFi.conf"
+	Comment "Play HiFi quality Music"
+}
+
+BootSequence [
+	# Disable all outputs
+	cset "name='Speaker Switch' off"
+
+	# Set HP vol to 0 dB (3/3)
+	cset "name='Headphone Playback Volume' 3"
+	# Set HP mixer vol to 0 dB
+	cset "name='Headphone Mixer Volume' 11"
+	# Set DAC vol to 0 dB (192/192)
+	cset "name='DAC Playback Volume' 192"
+
+	# Disable Auto Level Control
+	cset "name='ALC Capture Switch' off"
+	# Set ADC vol to 0 dB (192/192)
+	cset "name='ADC Capture Volume' 192"
+	# Set Mic amplifier to +16 dB
+	cset "name='ADC PGA Gain Volume' 7"
+
+	# Setup muxes / switches
+	cset "name='Left Headphone Mixer Left DAC Switch' on"
+	cset "name='Right Headphone Mixer Right DAC Switch' on"
+]

--- a/ucm2/conf.d/rockchip_es8316/rockchip_es8316.conf
+++ b/ucm2/conf.d/rockchip_es8316/rockchip_es8316.conf
@@ -1,0 +1,1 @@
+../../Rockchip/rockchip_es8316/rockchip_es8316.conf


### PR DESCRIPTION
Add UCM config files for Pinebook Pro's audio. The config files are
transformed and tuned from Manjaro ARM's packages:
* pinebookpro-post-install's asound.state [1]
* pinebookpro-audio's audio_jack_plugged_in.sh [2]

By the way, with these config files, the Speaker and Headphones will be
switched according to the (un)plugged state automatically.

[1] https://gitlab.manjaro.org/manjaro-arm/packages/community/pinebookpro-post-install/-/blob/4b4206c57b21044bf9c00848bd1f8b6f710d19eb/asound.state
[2] https://gitlab.manjaro.org/manjaro-arm/packages/community/pinebookpro-audio/-/blob/1f567db09495acc3beb5405c9ef85c3c07b86785/audio_jack_plugged_in.sh

Fixes: https://github.com/alsa-project/alsa-ucm-conf/issues/110
Signed-off-by: Jian-Hong Pan <jhp@endlessos.org>