### PR TITLE
ucm2: Add support for RT5650 on MediaTek SoCs

### DIFF
--- a/ucm2/MediaTek/mtk-rt5650/HDMI.conf
+++ b/ucm2/MediaTek/mtk-rt5650/HDMI.conf
@@ -1,0 +1,9 @@
+SectionDevice."HDMI" {
+	Comment "HDMI Audio"
+
+	Value {
+		PlaybackPriority 200
+		PlaybackPCM "hw:${CardId},2"
+		JackControl "mtk-rt5650 HDMI Jack"
+	}
+}

--- a/ucm2/MediaTek/mtk-rt5650/HiFi.conf
+++ b/ucm2/MediaTek/mtk-rt5650/HiFi.conf
@@ -1,0 +1,85 @@
+# Use case configuration for mtk-rt5650
+
+SectionVerb {
+	Include.e.File "/codecs/rt5645/EnableSeq.conf"
+
+	# ALSA PCM
+	Value {
+		TQ "HiFi"
+	}
+}
+
+SectionDevice."Speaker" {
+	Comment "Speaker"
+
+	ConflictingDevice [
+		"Headphones"
+	]
+
+	Include.spk.File "/codecs/rt5645/SpeakerEnableSeq.conf"
+
+	Value {
+		PlaybackPCM "hw:${CardId},0"
+		PlaybackPriority 100
+		PlaybackMixerElem "Speaker"
+		PlaybackVolume "Speaker Playback Volume"
+	}
+}
+
+SectionDevice."Headphones" {
+	Comment "Headphones"
+
+	ConflictingDevice [
+		"Speaker"
+	]
+
+	Include.hse.File "/codecs/rt5645/HeadphonesEnableSeq.conf"
+
+	DisableSequence [
+		cset "name='Headphone Switch' off"
+		cset "name='Headphone Channel Switch' off"
+	]
+
+	Value {
+		PlaybackPCM "hw:${CardId},0"
+		PlaybackPriority 200
+		PlaybackMixerElem "Headphone"
+		PlaybackVolume "Headphone Playback Volume"
+		JackControl "Headset Jack"
+		JackHWMute "Speaker"
+	}
+}
+
+Include.hdmi.File "/MediaTek/mtk-rt5650/HDMI.conf"
+
+SectionDevice."Mic" {
+	Comment "Internal Microphone"
+
+	Include.dmice.File "/codecs/rt5645/DigitalMicEnableSeq.conf"
+	Include.dmicd.File "/codecs/rt5645/DigitalMicDisableSeq.conf"
+
+	Value {
+		CapturePCM "hw:${CardId},1"
+		CapturePriority 100
+		CaptureMasterElem "ADC"
+		CaptureMixerElem "IN"
+		CaptureVolume "IN Capture Volume"
+	}
+}
+
+SectionDevice."Headset" {
+	Comment "Headset Microphone"
+
+	Include.hsmice.File "/codecs/rt5645/HSMicEnableSeq.conf"
+	Include.hsmicd.File "/codecs/rt5645/HSMicDisableSeq.conf"
+
+	Value {
+		CapturePCM "hw:${CardId},1"
+		CapturePriority 200
+		CaptureMasterElem "ADC"
+		CaptureMixerElem "IN"
+		CaptureVolume "IN Capture Volume"
+		JackControl "Headset Jack"
+		JackHWMute "Mic"
+	}
+}

--- a/ucm2/MediaTek/mtk-rt5650/init.conf
+++ b/ucm2/MediaTek/mtk-rt5650/init.conf
@@ -1,0 +1,17 @@
+# mtk-rt5650 specific boot sequence
+
+BootSequence [
+	cset "name='O03 I05 Switch' 1"
+	cset "name='O04 I06 Switch' 1"
+	cset "name='O09 I17 Switch' 1"
+	cset "name='O10 I18 Switch' 1"
+
+	# Internal speaker amplification params
+	cset "name='DAC1 Playback Volume' 69"
+	cset "name='Speaker ClassD Playback Volume' 6"
+
+	# Muxing
+	cset "name='IF2 ADC Mux' IF_ADC1"
+	cset "name='RT5650 IF1 ADC1 Swap Mux' L/R"
+	cset "name='Stereo1 ADC1 Mux' ADC"
+]

--- a/ucm2/MediaTek/mtk-rt5650/mtk-rt5650.conf
+++ b/ucm2/MediaTek/mtk-rt5650/mtk-rt5650.conf
@@ -1,0 +1,12 @@
+Comment "ALC5650 sound card on MediaTek SoC"
+Syntax 4
+
+SectionUseCase."HiFi" {
+	File "/MediaTek/mtk-rt5650/HiFi.conf"
+	Comment "Default"
+}
+
+Include.card-init.File "/lib/card-init.conf"
+Include.ctl-remap.File "/lib/ctl-remap.conf"
+Include.codec-init.File "/codecs/rt5645/init.conf"
+Include.init.File "/MediaTek/mtk-rt5650/init.conf"

--- a/ucm2/conf.d/mtk-rt5650/mtk-rt5650.conf
+++ b/ucm2/conf.d/mtk-rt5650/mtk-rt5650.conf
@@ -1,0 +1,1 @@
+../../MediaTek/mtk-rt5650/mtk-rt5650.conf


### PR DESCRIPTION
At least one MT8173 machine uses a RT5650 codec and that's Google Elm:
add a UCM2 configuration for this codec.

This was tested on Acer Chromebook R13 (MT8173 Elm).

Signed-off-by: AngeloGioacchino Del Regno <angelogioacchino.delregno@collabora.com>