### PR TITLE
ucm2: Add support for SC7180 Trogdor Lazor Chromebooks

### DIFF
--- a/ucm2/Qualcomm/sc7180/rt5682-max98357a/HiFi.conf
+++ b/ucm2/Qualcomm/sc7180/rt5682-max98357a/HiFi.conf
@@ -1,0 +1,101 @@
+# Use case configuration for ALC5682+MAX98357A on SC7180
+
+SectionVerb {
+	Value {
+		TQ "HiFi"
+	}
+}
+
+SectionDevice."Speaker" {
+	Comment "Speaker"
+
+	Value {
+		PlaybackChannels 2
+		PlaybackPCM "hw:${CardId},1"
+		PlaybackPriority 100
+		PlaybackMixerElem "Speaker"
+		PlaybackVolume "Speaker Playback Volume"
+	}
+}
+
+SectionDevice."Headphones" {
+	Comment "Headphones"
+
+	EnableSequence [
+		cset "name='HPOL Playback Switch' 1"
+		cset "name='HPOR Playback Switch' 1"
+		cset "name='Stereo1 DAC MIXL DAC L1 Switch' 1"
+		cset "name='Stereo1 DAC MIXR DAC R1 Switch' 1"
+	]
+
+	DisableSequence [
+		cset "name='HPOL Playback Switch' 0"
+		cset "name='HPOR Playback Switch' 0"
+		cset "name='Stereo1 DAC MIXL DAC L1 Switch' 0"
+		cset "name='Stereo1 DAC MIXR DAC R1 Switch' 0"
+	]
+
+	Value {
+		PlaybackPCM "hw:${CardId},0"
+		PlaybackPriority 200
+		PlaybackMasterElem "DAC1"
+		PlaybackMixerElem "Headphone"
+		PlaybackVolume "Headphone Playback Volume"
+	}
+}
+
+SectionDevice."Mic" {
+	Comment "Internal Microphone"
+
+	ConflictingDevice [
+		"Headset"
+	]
+
+	EnableSequence [
+		cset "name='IF1 01 ADC Swap Mux' 1"
+		cset "name='Stereo1 ADC L2 Mux' 1"
+		cset "name='Stereo1 ADC R2 Mux' 1"
+		cset "name='Stereo1 ADC MIXL ADC2 Switch' 1"
+		cset "name='Stereo1 ADC MIXR ADC2 Switch' 1"
+	]
+
+	DisableSequence [
+		cset "name='Stereo1 ADC L2 Mux' 0"
+		cset "name='Stereo1 ADC R2 Mux' 0"
+		cset "name='Stereo1 ADC MIXL ADC2 Switch' 0"
+		cset "name='Stereo1 ADC MIXR ADC2 Switch' 0"
+	]
+
+	Value {
+		CapturePCM "hw:${CardId},0"
+		CapturePriority 100
+		CaptureMixerElem "STO1 ADC"
+		CaptureVolume "STO1 ADC Capture Volume"
+	}
+}
+
+SectionDevice."Headset" {
+	Comment "Headset Microphone"
+
+	EnableSequence [
+		cset "name='IF1 01 ADC Swap Mux' 2"
+		cset "name='Stereo1 ADC L1 Mux' 1"
+		cset "name='Stereo1 ADC R1 Mux' 1"
+		cset "name='Stereo1 ADC MIXL ADC1 Switch' 1"
+		cset "name='Stereo1 ADC MIXR ADC1 Switch' 1"
+	]
+
+	DisableSequence [
+		cset "name='Stereo1 ADC L1 Mux' 0"
+		cset "name='Stereo1 ADC R1 Mux' 0"
+		cset "name='Stereo1 ADC MIXL ADC1 Switch' 0"
+		cset "name='Stereo1 ADC MIXR ADC1 Switch' 0"
+	]
+
+	Value {
+		CapturePCM "hw:${CardId},0"
+		CapturePriority 200
+		CaptureMixerElem "STO1 ADC"
+		CaptureVolume "STO1 ADC Capture Volume"
+	}
+}

--- a/ucm2/Qualcomm/sc7180/rt5682-max98357a/init.conf
+++ b/ucm2/Qualcomm/sc7180/rt5682-max98357a/init.conf
@@ -1,0 +1,24 @@
+BootSequence [
+	# Headphone
+	cset "name='HPOL Playback Switch' 0"
+	cset "name='HPOR Playback Switch' 0"
+	cset "name='Stereo1 DAC MIXL DAC L1 Switch' 0"
+	cset "name='Stereo1 DAC MIXR DAC R1 Switch' 0"
+
+	# Headset mic
+	cset "name='Stereo1 ADC L Mux' 0"
+	cset "name='STO1 ADC Capture Switch' on"
+	cset "name='RECMIX1L CBJ Switch' 1"
+	cset "name='CBJ Boost Volume' 3"
+	cset "name='Stereo1 ADC L1 Mux' 0"
+	cset "name='Stereo1 ADC R1 Mux' 0"
+	cset "name='Stereo1 ADC MIXL ADC1 Switch' 0"
+	cset "name='Stereo1 ADC MIXR ADC1 Switch' 0"
+
+	# Internal mic on ALC5682
+	cset "name='IF1 01 ADC Swap Mux' 1"
+	cset "name='Stereo1 ADC L2 Mux' 0"
+	cset "name='Stereo1 ADC R2 Mux' 0"
+	cset "name='Stereo1 ADC MIXL ADC2 Switch' 0"
+	cset "name='Stereo1 ADC MIXR ADC2 Switch' 0"
+]

--- a/ucm2/Qualcomm/sc7180/rt5682-max98357a/sc7180-rt5682-max98357a-1mic.conf
+++ b/ucm2/Qualcomm/sc7180/rt5682-max98357a/sc7180-rt5682-max98357a-1mic.conf
@@ -1,0 +1,11 @@
+Comment "SC7180 RT5682 MAX98357A single microphone sound card"
+Syntax 4
+
+SectionUseCase."HiFi" {
+	File "/Qualcomm/sc7180/rt5682-max98357a/HiFi.conf"
+	Comment "Default"
+}
+
+Include.card-init.File "/lib/card-init.conf"
+Include.ctl-remap.File "/lib/ctl-remap.conf"
+Include.init.File "/Qualcomm/sc7180/rt5682-max98357a/init.conf"

--- a/ucm2/conf.d/SC7180/sc7180-rt5682-max98357a-1mic.conf
+++ b/ucm2/conf.d/SC7180/sc7180-rt5682-max98357a-1mic.conf
@@ -1,0 +1,1 @@
+../../Qualcomm/sc7180/rt5682-max98357a/sc7180-rt5682-max98357a-1mic.conf


### PR DESCRIPTION
Almost all Trogdor Chromebooks are using RT5682 for headphones/headset
on 3.5mm jack, internal microphone and headset microphone, and MAX98357A
for the internal speakers (Lazor and Limozeen).

This adds support for the sc7180-rt5682-max98357a-1mic sound card found
on the aforementioned Chromebooks.

`Signed-off-by: AngeloGioacchino Del Regno <angelogioacchino.delregno@collabora.com>`

Tested on sc7180-trogdor-lazor-limozeen-nots.