### PR TITLE
sof-hda-dsp: fix path to Hdmi.conf

### DIFF
--- a/ucm2/Intel/sof-hda-dsp/HiFi.conf
+++ b/ucm2/Intel/sof-hda-dsp/HiFi.conf
@@ -48,4 +48,4 @@ If.dmic {
 	}
 }
 
-Include.hdmi.File "/sof-hda-dsp/Hdmi.conf"
+Include.hdmi.File "/Intel/sof-hda-dsp/Hdmi.conf"


### PR DESCRIPTION
Fixes https://github.com/alsa-project/alsa-ucm-conf/issues/126 .