### PR TITLE
Add profile for Behringer UMC204HD

### DIFF
--- a/ucm2/USB-Audio/Behringer/UMC204HD-HiFi.conf
+++ b/ucm2/USB-Audio/Behringer/UMC204HD-HiFi.conf
@@ -137,7 +137,7 @@ LibraryConfig.pcm.Config {
 SectionDevice."Line1" {
 	Comment "Line A"
 	Value {
-		PlaybackPriority 100
+		PlaybackPriority 200
 		PlaybackChannels 2
 		PlaybackPCM "umc204hd_line1:${CardId}"
 		PlaybackCTL "umc204hd_out:${CardId}"
@@ -149,7 +149,7 @@ SectionDevice."Line2" {
 	Comment "Line B"
 
 	Value {
-		PlaybackPriority 200
+		PlaybackPriority 100
 		PlaybackChannels 2
 		PlaybackPCM "umc204hd_line2:${CardId}"
 		PlaybackCTL "umc204hd_out:${CardId}"
@@ -161,7 +161,7 @@ SectionDevice."Mic1" {
 	Comment "Input 1"
 
 	Value {
-		CapturePriority 100
+		CapturePriority 200
 		CaptureChannels 1
 		CapturePCM "umc204hd_mic1:${CardId}"
 		CaptureCTL "umc204hd_in:${CardId}"
@@ -173,7 +173,7 @@ SectionDevice."Mic2" {
 	Comment "Input 2"
 
 	Value {
-		CapturePriority 200
+		CapturePriority 100
 		CaptureChannels 1
 		CapturePCM "umc204hd_mic2:${CardId}"
 		CaptureCTL "umc204hd_in:${CardId}"

--- a/ucm2/USB-Audio/Behringer/UMC204HD-HiFi.conf
+++ b/ucm2/USB-Audio/Behringer/UMC204HD-HiFi.conf
@@ -82,6 +82,58 @@ LibraryConfig.pcm.Config {
 			strings [ "umc204hd_mono_in:" $CARD ",1,1" ]
 		}
 	}
+
+	ctl.umc204hd_out {
+	    @args [ CARD ]
+	    @args.CARD.type string
+	    type remap
+	    child {
+	        type hw
+	        card $CARD
+	    }
+	    map {
+	        "name='Line A Playback Volume'"."name='UMC204HD 192k Output Volume'" {
+	            vindex.0 0
+	            vindex.1 1
+	        },
+	        "name='Line A Playback Switch'"."name='UMC204HD 192k Output Switch'" {
+	            vindex.0 0
+	            vindex.1 1
+	        },
+	        "name='Line B Playback Volume'"."name='UMC204HD 192k Output Volume'" {
+	            vindex.0 2
+	            vindex.1 3
+	        },
+	        "name='Line B Playback Switch'"."name='UMC204HD 192k Output Switch'" {
+	            vindex.0 2
+	            vindex.1 3
+	        }
+	    }
+	}
+
+	ctl.umc204hd_in {
+	    @args [ CARD ]
+	    @args.CARD.type string
+	    type remap
+	    child {
+	        type hw
+	        card $CARD
+	    }
+	    map {
+	        "name='Input 1 Recording Volume'"."name='Mic Volume'" {
+	            vindex.0 0
+	        },
+	        "name='Input 1 Recording Switch'"."name='Mic Switch'" {
+	            vindex.0 0
+	        },
+	        "name='Input 2 Recording Volume'"."name='Mic Volume'" {
+	            vindex.0 1
+	        },
+	        "name='Input 2 Recording Switch'"."Name='Mic Switch'" {
+	            vindex.0 1
+	        }
+	    }
+	}
 }
 
 SectionDevice."Line1" {
@@ -89,6 +141,8 @@ SectionDevice."Line1" {
 	Value {
 		PlaybackPriority 100
 		PlaybackPCM "umc204hd_line1:${CardId}"
+		PlaybackCTL "umc204hd_out:${CardId}"
+		PlaybackMixerElem "UMC204HD 192k Output"
 	}
 }
 
@@ -98,6 +152,8 @@ SectionDevice."Line2" {
 	Value {
 		PlaybackPriority 200
 		PlaybackPCM "umc204hd_line2:${CardId}"
+		PlaybackCTL "umc204hd_out:${CardId}"
+		PlaybackMixerElem "UMC204HD 192k Output"
 	}
 }
 
@@ -107,6 +163,8 @@ SectionDevice."Mic1" {
 	Value {
 		CapturePriority 100
 		CapturePCM "umc204hd_mic1:${CardId}"
+		CaptureCTL "umc204hd_in:${CardId}"
+		CaptureMixerElem "Mic"
 	}
 }
 
@@ -116,5 +174,7 @@ SectionDevice."Mic2" {
 	Value {
 		CapturePriority 200
 		CapturePCM "umc204hd_mic2:${CardId}"
+		CaptureCTL "umc204hd_in:${CardId}"
+		CaptureMixerElem "Mic"
 	}
 }

--- a/ucm2/USB-Audio/Behringer/UMC204HD-HiFi.conf
+++ b/ucm2/USB-Audio/Behringer/UMC204HD-HiFi.conf
@@ -8,7 +8,6 @@ LibraryConfig.pcm.Config {
 		}
 		type dshare
 		ipc_key 572442
-		ipc_perm 0600
 		slave {
 			pcm {
 				type hw
@@ -29,7 +28,6 @@ LibraryConfig.pcm.Config {
 		}
 		type dsnoop
 		ipc_key 572542
-		ipc_perm 0600
 		slave {
 			pcm {
 				type hw

--- a/ucm2/USB-Audio/Behringer/UMC204HD-HiFi.conf
+++ b/ucm2/USB-Audio/Behringer/UMC204HD-HiFi.conf
@@ -79,7 +79,7 @@ LibraryConfig.pcm.Config {
 		}
 	}
 
-	ctl.umc204hd_out {
+	ctl.umc204hd {
 	    @args [ CARD ]
 	    @args.CARD.type string
 	    type remap
@@ -88,44 +88,32 @@ LibraryConfig.pcm.Config {
 	        card $CARD
 	    }
 	    map {
-	        "name='Line A Playback Volume'"."name='UMC204HD 192k Output Volume'" {
+	        'name="Line A Playback Volume"'.'name="UMC204HD 192k Output Playback Volume"' {
 	            vindex.0 0
 	            vindex.1 1
 	        },
-	        "name='Line A Playback Switch'"."name='UMC204HD 192k Output Switch'" {
+	        'name="Line A Playback Switch"'.'name="UMC204HD 192k Output Playback Switch"' {
 	            vindex.0 0
 	            vindex.1 1
 	        },
-	        "name='Line B Playback Volume'"."name='UMC204HD 192k Output Volume'" {
+	        'name="Line B Playback Volume"'.'name="UMC204HD 192k Output Playback Volume"' {
 	            vindex.0 2
 	            vindex.1 3
 	        },
-	        "name='Line B Playback Switch'"."name='UMC204HD 192k Output Switch'" {
+	        'name="Line B Playback Switch"'.'name="UMC204HD 192k Output Playback Switch"' {
 	            vindex.0 2
 	            vindex.1 3
-	        }
-	    }
-	}
-
-	ctl.umc204hd_in {
-	    @args [ CARD ]
-	    @args.CARD.type string
-	    type remap
-	    child {
-	        type hw
-	        card $CARD
-	    }
-	    map {
-	        "name='Input 1 Recording Volume'"."name='Mic Volume'" {
+	        },
+ 	        'name="Input 1 Capture Volume"'.'name="Mic Capture Volume"' {
 	            vindex.0 0
 	        },
-	        "name='Input 1 Recording Switch'"."name='Mic Switch'" {
+	        'name="Input 1 Capture Switch"'.'name="Mic Capture Switch"' {
 	            vindex.0 0
 	        },
-	        "name='Input 2 Recording Volume'"."name='Mic Volume'" {
+	        'name="Input 2 Capture Volume"'.'name="Mic Capture Volume"' {
 	            vindex.0 1
 	        },
-	        "name='Input 2 Recording Switch'"."Name='Mic Switch'" {
+	        'name="Input 2 Capture Switch"'.'Name="Mic Capture Switch"' {
 	            vindex.0 1
 	        }
 	    }
@@ -138,8 +126,7 @@ SectionDevice."Line1" {
 		PlaybackPriority 200
 		PlaybackChannels 2
 		PlaybackPCM "umc204hd_line1:${CardId}"
-		PlaybackCTL "umc204hd_out:${CardId}"
-		PlaybackMixerElem "UMC204HD 192k Output"
+		PlaybackCTL "umc204hd:${CardId}"
 	}
 }
 
@@ -150,8 +137,7 @@ SectionDevice."Line2" {
 		PlaybackPriority 100
 		PlaybackChannels 2
 		PlaybackPCM "umc204hd_line2:${CardId}"
-		PlaybackCTL "umc204hd_out:${CardId}"
-		PlaybackMixerElem "UMC204HD 192k Output"
+		PlaybackCTL "umc204hd:${CardId}"
 	}
 }
 
@@ -162,8 +148,7 @@ SectionDevice."Mic1" {
 		CapturePriority 200
 		CaptureChannels 1
 		CapturePCM "umc204hd_mic1:${CardId}"
-		CaptureCTL "umc204hd_in:${CardId}"
-		CaptureMixerElem "Mic"
+		CaptureCTL "umc204hd:${CardId}"
 	}
 }
 
@@ -174,7 +159,6 @@ SectionDevice."Mic2" {
 		CapturePriority 100
 		CaptureChannels 1
 		CapturePCM "umc204hd_mic2:${CardId}"
-		CaptureCTL "umc204hd_in:${CardId}"
-		CaptureMixerElem "Mic"
+		CaptureCTL "umc204hd:${CardId}"
 	}
 }

--- a/ucm2/USB-Audio/Behringer/UMC204HD-HiFi.conf
+++ b/ucm2/USB-Audio/Behringer/UMC204HD-HiFi.conf
@@ -22,11 +22,10 @@ LibraryConfig.pcm.Config {
 	}
 
 	pcm.umc204hd_mono_in {
-		@args [ CARD CHN0 CHN1 ]
+		@args [ CARD CHN0 ]
 		@args {
 			CARD.type string
 			CHN0.type integer
-			CHN1.type integer
 		}
 		type dsnoop
 		ipc_key 572542
@@ -40,7 +39,6 @@ LibraryConfig.pcm.Config {
 			channels 2
 		}
 		bindings.0 $CHN0
-		bindings.1 $CHN1
 	}
 
 	pcm.umc204hd_line1 {
@@ -69,7 +67,7 @@ LibraryConfig.pcm.Config {
 		type empty
 		slave.pcm {
 			@func concat
-			strings [ "umc204hd_mono_in:" $CARD ",0,0" ]
+			strings [ "umc204hd_mono_in:" $CARD ",0" ]
 		}
 	}
 
@@ -79,7 +77,7 @@ LibraryConfig.pcm.Config {
 		type empty
 		slave.pcm {
 			@func concat
-			strings [ "umc204hd_mono_in:" $CARD ",1,1" ]
+			strings [ "umc204hd_mono_in:" $CARD ",1" ]
 		}
 	}
 
@@ -140,6 +138,7 @@ SectionDevice."Line1" {
 	Comment "Line A"
 	Value {
 		PlaybackPriority 100
+		PlaybackChannels 2
 		PlaybackPCM "umc204hd_line1:${CardId}"
 		PlaybackCTL "umc204hd_out:${CardId}"
 		PlaybackMixerElem "UMC204HD 192k Output"
@@ -151,6 +150,7 @@ SectionDevice."Line2" {
 
 	Value {
 		PlaybackPriority 200
+		PlaybackChannels 2
 		PlaybackPCM "umc204hd_line2:${CardId}"
 		PlaybackCTL "umc204hd_out:${CardId}"
 		PlaybackMixerElem "UMC204HD 192k Output"
@@ -162,6 +162,7 @@ SectionDevice."Mic1" {
 
 	Value {
 		CapturePriority 100
+		CaptureChannels 1
 		CapturePCM "umc204hd_mic1:${CardId}"
 		CaptureCTL "umc204hd_in:${CardId}"
 		CaptureMixerElem "Mic"
@@ -173,6 +174,7 @@ SectionDevice."Mic2" {
 
 	Value {
 		CapturePriority 200
+		CaptureChannels 1
 		CapturePCM "umc204hd_mic2:${CardId}"
 		CaptureCTL "umc204hd_in:${CardId}"
 		CaptureMixerElem "Mic"

--- a/ucm2/USB-Audio/Behringer/UMC204HD-HiFi.conf
+++ b/ucm2/USB-Audio/Behringer/UMC204HD-HiFi.conf
@@ -1,0 +1,120 @@
+LibraryConfig.pcm.Config {
+	pcm.umc204hd_stereo_out {
+		@args [ CARD CHN0 CHN1 ]
+		@args {
+			CARD.type string
+			CHN0.type integer
+			CHN1.type integer
+		}
+		type dshare
+		ipc_key 572442
+		ipc_perm 0600
+		slave {
+			pcm {
+				type hw
+				card $CARD
+				device 0
+			}
+			channels 4
+		}
+		bindings.0 $CHN0
+		bindings.1 $CHN1
+	}
+
+	pcm.umc204hd_mono_in {
+		@args [ CARD CHN0 CHN1 ]
+		@args {
+			CARD.type string
+			CHN0.type integer
+			CHN1.type integer
+		}
+		type dsnoop
+		ipc_key 572542
+		ipc_perm 0600
+		slave {
+			pcm {
+				type hw
+				card $CARD
+				device 0
+			}
+			channels 2
+		}
+		bindings.0 $CHN0
+		bindings.1 $CHN1
+	}
+
+	pcm.umc204hd_line1 {
+		@args [ CARD ]
+		@args.CARD.type string
+		type empty
+		slave.pcm {
+			@func concat
+			strings [ "umc204hd_stereo_out:" $CARD ",0,1" ]
+		}
+	}
+
+	pcm.umc204hd_line2 {
+		@args [ CARD ]
+		@args.CARD.type string
+		type empty
+		slave.pcm {
+			@func concat
+			strings [ "umc204hd_stereo_out:" $CARD ",2,3" ]
+		}
+	}
+
+	pcm.umc204hd_mic1 {
+		@args [ CARD ]
+		@args.CARD.type string
+		type empty
+		slave.pcm {
+			@func concat
+			strings [ "umc204hd_mono_in:" $CARD ",0,0" ]
+		}
+	}
+
+	pcm.umc204hd_mic2 {
+		@args [ CARD ]
+		@args.CARD.type string
+		type empty
+		slave.pcm {
+			@func concat
+			strings [ "umc204hd_mono_in:" $CARD ",1,1" ]
+		}
+	}
+}
+
+SectionDevice."Line1" {
+	Comment "Line A"
+	Value {
+		PlaybackPriority 100
+		PlaybackPCM "umc204hd_line1:${CardId}"
+	}
+}
+
+SectionDevice."Line2" {
+	Comment "Line B"
+
+	Value {
+		PlaybackPriority 200
+		PlaybackPCM "umc204hd_line2:${CardId}"
+	}
+}
+
+SectionDevice."Mic1" {
+	Comment "Input 1"
+
+	Value {
+		CapturePriority 100
+		CapturePCM "umc204hd_mic1:${CardId}"
+	}
+}
+
+SectionDevice."Mic2" {
+	Comment "Input 2"
+
+	Value {
+		CapturePriority 200
+		CapturePCM "umc204hd_mic2:${CardId}"
+	}
+}

--- a/ucm2/USB-Audio/Behringer/UMC204HD.conf
+++ b/ucm2/USB-Audio/Behringer/UMC204HD.conf
@@ -1,5 +1,5 @@
 Comment "Behringer UMC204HD"
 SectionUseCase."HiFi" {
 	Comment "Default Alsa Profile"
-	File "Behringer/UMC204HD-HiFi.conf"
+	File "/USB-Audio/Behringer/UMC204HD-HiFi.conf"
 }

--- a/ucm2/USB-Audio/Behringer/UMC204HD.conf
+++ b/ucm2/USB-Audio/Behringer/UMC204HD.conf
@@ -1,0 +1,5 @@
+Comment "Behringer UMC204HD"
+SectionUseCase."HiFi" {
+	Comment "Default Alsa Profile"
+	File "Behringer/UMC204HD-HiFi.conf"
+}

--- a/ucm2/USB-Audio/Behringer/UMC204HD.conf
+++ b/ucm2/USB-Audio/Behringer/UMC204HD.conf
@@ -1,5 +1,5 @@
 Comment "Behringer UMC204HD"
 SectionUseCase."HiFi" {
-	Comment "Default Alsa Profile"
+	Comment "Default"
 	File "/USB-Audio/Behringer/UMC204HD-HiFi.conf"
 }

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -91,6 +91,15 @@ If.lenovo-p620-main {
 	True.Define.ProfileName "Lenovo/ThinkStation-P620-Main"
 }
 
+If.behringer-umc204hd {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB1397:0508"
+	}
+	True.Define.ProfileName "Behringer/UMC204HD"
+}
+
 If.inc {
 	Condition {
 		Type String


### PR DESCRIPTION
Adds a profile for the Behringer UMC204HD to split a 4-channel output into two outputs, and a 2-channel input into two inputs, as per the physical layout of the device. I have very little idea what I'm doing, so let me know if something looks incorrect (there's one thing that looks incorrect even to me which I shall point out in a comment below). The config does at least work, though.

[alsa-info.txt](https://github.com/alsa-project/alsa-ucm-conf/files/7698277/alsa-info.txt)


-----

![UMC204HD_P0BK0_Front_XL](https://user-images.githubusercontent.com/5822375/145704001-5bb9b741-0d1f-4f83-8184-6335c9b53fbf.png)
![UMC204HD_P0BK0_Rear_XL](https://user-images.githubusercontent.com/5822375/145703999-918614e6-3298-4191-a7b6-7260e8eb3638.png)

