### PR TITLE
sof-hda-dsp: Fix DMIC detection

### DIFF
--- a/ucm2/Intel/sof-hda-dsp/HiFi.conf
+++ b/ucm2/Intel/sof-hda-dsp/HiFi.conf
@@ -6,7 +6,7 @@ SectionVerb {
 
 Include.hda-analog.File "/HDA/HiFi-analog.conf"
 
-If.dmic {
+If.notdmic {
 	Condition {
 		Type String
 		Empty "${var:DeviceDmic}"

--- a/ucm2/Intel/sof-hda-dsp/sof-hda-dsp.conf
+++ b/ucm2/Intel/sof-hda-dsp/sof-hda-dsp.conf
@@ -61,7 +61,7 @@ If.headphone {
 	]
 }
 
-If.dmic {
+If.notdmic {
 	Condition {
 		Type String
 		Empty "${var:DeviceDmic}"


### PR DESCRIPTION
Due to conflicting labels, DMIC was always detected as present.

Signed-off-by: Kacper Michajłow <kasper93@gmail.com>