### PR TITLE
Add UCM for PinePhone

### DIFF
--- a/ucm2/Allwinner/A64/PinePhone/HiFi.conf
+++ b/ucm2/Allwinner/A64/PinePhone/HiFi.conf
@@ -3,24 +3,6 @@ SectionVerb {
 		cset "name='AIF2 Digital DAC Playback Switch' off"
 		cset "name='AIF2 ADC Mixer ADC Capture Switch' off"
 	]
-
-	SectionDefaults [
-		# Switch playback off.
-		cset "name='Earpiece Playback Switch' off"
-		cset "name='Headphone Playback Switch' off"
-		cset "name='Line In Playback Switch' off"
-		cset "name='Line Out Playback Switch' off"
-		cset "name='Mic1 Playback Switch' off"
-		cset "name='Mic2 Playback Switch' off"
-
-		# Switch capture off.
-		cset "name='Line In Capture Switch' off"
-		cset "name='Mic1 Capture Switch' off"
-		cset "name='Mic2 Capture Switch' off"
-		cset "name='Mixer Capture Switch' off"
-		cset "name='Mixer Reversed Capture Switch' off"
-	]
-
 }
 
 SectionDevice."Speaker" {

--- a/ucm2/Allwinner/A64/PinePhone/HiFi.conf
+++ b/ucm2/Allwinner/A64/PinePhone/HiFi.conf
@@ -18,7 +18,6 @@ SectionDevice."Speaker" {
 	Value {
 		PlaybackVolume "Line Out Playback Volume"
 		PlaybackSwitch "Line Out Playback Switch"
-		PlaybackChannels 2
 		PlaybackPriority 300
 		PlaybackPCM "hw:${CardId},0"
 	}
@@ -38,7 +37,6 @@ SectionDevice."Earpiece" {
 	Value {
 		PlaybackVolume "Earpiece Playback Volume"
 		PlaybackSwitch "Earpiece Playback Switch"
-		PlaybackChannels 2
 		PlaybackPriority 200
 		PlaybackPCM "hw:${CardId},0"
 	}
@@ -62,7 +60,6 @@ SectionDevice."Mic" {
 	Value {
 		CapturePriority 100
 		CapturePCM "hw:${CardId},0"
-		CaptureChannels 2
 		CaptureVolume "ADC Capture Volume"
 		CaptureSwitch "Mic1 Capture Switch"
 	}
@@ -86,7 +83,6 @@ SectionDevice."Headset" {
 	Value {
 		CapturePriority 500
 		CapturePCM "hw:${CardId},0"
-		CaptureChannels 2
 		CaptureVolume "ADC Capture Volume"
 		CaptureSwitch "Mic2 Capture Switch"
 		JackControl "Headset Microphone Jack"
@@ -107,7 +103,6 @@ SectionDevice."Headphones" {
 	Value {
 		PlaybackVolume "Headphone Playback Volume"
 		PlaybackSwitch "Headphone Playback Switch"
-		PlaybackChannels 2
 		PlaybackPriority 500
 		PlaybackPCM "hw:${CardId},0"
 		JackControl "Headphone Jack"

--- a/ucm2/Allwinner/A64/PinePhone/HiFi.conf
+++ b/ucm2/Allwinner/A64/PinePhone/HiFi.conf
@@ -1,0 +1,101 @@
+SectionVerb {
+	EnableSequence [
+		cset "name='AIF2 Digital DAC Playback Switch' off"
+		cset "name='AIF2 ADC Mixer ADC Capture Switch' off"
+	]
+}
+
+SectionDevice."Speaker" {
+	Comment "Internal speaker"
+	EnableSequence [
+		cset "name='Line Out Playback Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Line Out Playback Switch' off"
+	]
+
+	Value {
+		PlaybackVolume "Line Out Playback Volume"
+		PlaybackSwitch "Line Out Playback Switch"
+		PlaybackChannels 2
+		PlaybackPriority 300
+		PlaybackPCM "hw:${CardId},0"
+	}
+}
+SectionDevice."Earpiece" {
+	Comment "Internal Earpiece"
+	EnableSequence [
+		cset "name='Earpiece Playback Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Earpiece Playback Switch' off"
+	]
+
+	Value {
+		PlaybackVolume "Earpiece Playback Volume"
+		PlaybackSwitch "Earpiece Playback Switch"
+		PlaybackChannels 2
+		PlaybackPriority 200
+		PlaybackPCM "hw:${CardId},0"
+	}
+}
+SectionDevice."Mic" {
+	Comment "Internal Microphone"
+	ConflictingDevice [
+		"Headset"
+	]
+	EnableSequence [
+		cset "name='Mic1 Capture Switch' on"
+	]
+	DisableSequence [
+		cset "name='Mic1 Capture Switch' off"
+	]
+	Value {
+		CapturePriority 100
+		CapturePCM "hw:${CardId},0"
+		CaptureChannels 2
+		CaptureVolume "ADC Capture Volume"
+		CaptureSwitch "Mic1 Capture Switch"
+	}
+}
+SectionDevice."Headset" {
+	Comment "Headset Microphone"
+	ConflictingDevice [
+		"Mic"
+	]
+	EnableSequence [
+		cset "name='Mic2 Capture Switch' on"
+	]
+	DisableSequence [
+		cset "name='Mic2 Capture Switch' off"
+	]
+	Value {
+		CapturePriority 500
+		CapturePCM "hw:${CardId},0"
+		CaptureChannels 2
+		CaptureVolume "ADC Capture Volume"
+		CaptureSwitch "Mic2 Capture Switch"
+		JackControl "Headset Microphone Jack"
+	}
+}
+SectionDevice."Headphones" {
+	Comment "Headphones"
+	EnableSequence [
+		cset "name='Headphone Playback Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Headphone Playback Switch' off"
+	]
+
+	Value {
+		PlaybackVolume "Headphone Playback Volume"
+		PlaybackSwitch "Headphone Playback Switch"
+		PlaybackChannels 2
+		PlaybackPriority 500
+		PlaybackPCM "hw:${CardId},0"
+		JackControl "Headphone Jack"
+	}
+}

--- a/ucm2/Allwinner/A64/PinePhone/HiFi.conf
+++ b/ucm2/Allwinner/A64/PinePhone/HiFi.conf
@@ -34,8 +34,7 @@ SectionDevice."Speaker" {
 	]
 
 	Value {
-		PlaybackVolume "Line Out Playback Volume"
-		PlaybackSwitch "Line Out Playback Switch"
+		PlaybackMixerElem "Line Out"
 		PlaybackPriority 300
 		PlaybackPCM "hw:${CardId},0"
 	}
@@ -53,8 +52,7 @@ SectionDevice."Earpiece" {
 	]
 
 	Value {
-		PlaybackVolume "Earpiece Playback Volume"
-		PlaybackSwitch "Earpiece Playback Switch"
+		PlaybackMixerElem "Earpiece"
 		PlaybackPriority 200
 		PlaybackPCM "hw:${CardId},0"
 	}
@@ -119,8 +117,7 @@ SectionDevice."Headphones" {
 	]
 
 	Value {
-		PlaybackVolume "Headphone Playback Volume"
-		PlaybackSwitch "Headphone Playback Switch"
+		PlaybackMixerElem "Headphone"
 		PlaybackPriority 500
 		PlaybackPCM "hw:${CardId},0"
 		JackControl "Headphone Jack"

--- a/ucm2/Allwinner/A64/PinePhone/HiFi.conf
+++ b/ucm2/Allwinner/A64/PinePhone/HiFi.conf
@@ -3,6 +3,24 @@ SectionVerb {
 		cset "name='AIF2 Digital DAC Playback Switch' off"
 		cset "name='AIF2 ADC Mixer ADC Capture Switch' off"
 	]
+
+	SectionDefaults [
+		# Switch playback off.
+		cset "name='Earpiece Playback Switch' off"
+		cset "name='Headphone Playback Switch' off"
+		cset "name='Line In Playback Switch' off"
+		cset "name='Line Out Playback Switch' off"
+		cset "name='Mic1 Playback Switch' off"
+		cset "name='Mic2 Playback Switch' off"
+
+		# Switch capture off.
+		cset "name='Line In Capture Switch' off"
+		cset "name='Mic1 Capture Switch' off"
+		cset "name='Mic2 Capture Switch' off"
+		cset "name='Mixer Capture Switch' off"
+		cset "name='Mixer Reversed Capture Switch' off"
+	]
+
 }
 
 SectionDevice."Speaker" {

--- a/ucm2/Allwinner/A64/PinePhone/HiFi.conf
+++ b/ucm2/Allwinner/A64/PinePhone/HiFi.conf
@@ -23,8 +23,10 @@ SectionDevice."Speaker" {
 		PlaybackPCM "hw:${CardId},0"
 	}
 }
+
 SectionDevice."Earpiece" {
 	Comment "Internal Earpiece"
+
 	EnableSequence [
 		cset "name='Earpiece Playback Switch' on"
 	]
@@ -41,17 +43,22 @@ SectionDevice."Earpiece" {
 		PlaybackPCM "hw:${CardId},0"
 	}
 }
+
 SectionDevice."Mic" {
 	Comment "Internal Microphone"
+
 	ConflictingDevice [
 		"Headset"
 	]
+
 	EnableSequence [
 		cset "name='Mic1 Capture Switch' on"
 	]
+
 	DisableSequence [
 		cset "name='Mic1 Capture Switch' off"
 	]
+
 	Value {
 		CapturePriority 100
 		CapturePCM "hw:${CardId},0"
@@ -60,17 +67,22 @@ SectionDevice."Mic" {
 		CaptureSwitch "Mic1 Capture Switch"
 	}
 }
+
 SectionDevice."Headset" {
 	Comment "Headset Microphone"
+
 	ConflictingDevice [
 		"Mic"
 	]
+
 	EnableSequence [
 		cset "name='Mic2 Capture Switch' on"
 	]
+
 	DisableSequence [
 		cset "name='Mic2 Capture Switch' off"
 	]
+
 	Value {
 		CapturePriority 500
 		CapturePCM "hw:${CardId},0"
@@ -80,8 +92,10 @@ SectionDevice."Headset" {
 		JackControl "Headset Microphone Jack"
 	}
 }
+
 SectionDevice."Headphones" {
 	Comment "Headphones"
+
 	EnableSequence [
 		cset "name='Headphone Playback Switch' on"
 	]

--- a/ucm2/Allwinner/A64/PinePhone/PinePhone.conf
+++ b/ucm2/Allwinner/A64/PinePhone/PinePhone.conf
@@ -1,0 +1,65 @@
+Syntax 2
+
+# https://wiki.pine64.org/index.php/PinePhone
+# https://files.pine64.org/doc/PinePhone/PinePhone%20v1.2%20Released%20Schematic.pdf
+# https://xnux.eu/devices/feature/audio-pp.html
+
+SectionUseCase."HiFi" {
+	File "/Allwinner/A64/PinePhone/HiFi.conf"
+	Comment "Play HiFi quality music"
+}
+
+SectionUseCase."Voice Call" {
+	File "/Allwinner/A64/PinePhone/VoiceCall.conf"
+	Comment "Make a phone call"
+}
+
+FixedBootSequence [
+	# Switch playback off.
+	cset "name='Earpiece Playback Switch' off"
+	cset "name='Headphone Playback Switch' off"
+	cset "name='Line In Playback Switch' off"
+	cset "name='Line Out Playback Switch' off"
+	cset "name='Mic1 Playback Switch' off"
+	cset "name='Mic2 Playback Switch' off"
+
+	# Switch capture off.
+	cset "name='Line In Capture Switch' off"
+	cset "name='Mic1 Capture Switch' off"
+	cset "name='Mic2 Capture Switch' off"
+	cset "name='Mixer Capture Switch' off"
+	cset "name='Mixer Reversed Capture Switch' off"
+
+	# Routing.
+	cset "name='ADC Digital DAC Playback Switch' off"
+	cset "name='AIF1 DA0 Stereo Playback Route' Stereo"
+	cset "name='AIF1 Data Digital ADC Capture Switch' on"
+	cset "name='AIF1 Slot 0 Digital DAC Playback Switch' on"
+	cset "name='AIF2 DAC Source Playback Route' AIF2"
+	# AIF2 (Modem) is mono.
+	cset "name='AIF2 DAC Stereo Playback Route' Mix Mono"
+	cset "name='AIF3 ADC Source Capture Route' None"
+	cset "name='DAC Playback Switch' on"
+	# Routes DACR->MIXL and DACL->MIXR => MIXL are MIXR are identical mono-mix of the DAC.
+	cset "name='DAC Reversed Playback Switch' on"
+	cset "name='Earpiece Source Playback Route' Left Mixer"
+	cset "name='Headphone Source Playback Route' DAC"
+	# The Pinephone speaker is mono.
+	cset "name='Line Out Source Playback Route' Mono Differential"
+]
+
+BootSequence [
+	# Playback volumes.
+	cset "name='AIF1 DA0 Playback Volume' 160"
+	cset "name='AIF2 DAC Playback Volume' 160"
+	cset "name='DAC Playback Volume' 160"
+	cset "name='Earpiece Playback Volume' 100%"
+	cset "name='Headphone Playback Volume' 70%"
+	cset "name='Line Out Playback Volume' 100%"
+	cset "name='Mic2 Boost Volume' 1"
+
+	# Capture volumes.
+	cset "name='ADC Capture Volume' 160"
+	cset "name='AIF1 AD0 Capture Volume' 160"
+	cset "name='AIF2 ADC Capture Volume' 160"
+]

--- a/ucm2/Allwinner/A64/PinePhone/PinePhone.conf
+++ b/ucm2/Allwinner/A64/PinePhone/PinePhone.conf
@@ -48,3 +48,20 @@ BootSequence [
 	cset "name='AIF1 AD0 Capture Volume' 160"
 	cset "name='AIF2 ADC Capture Volume' 160"
 ]
+
+SectionDefaults [
+	# Switch playback off.
+	cset "name='Earpiece Playback Switch' off"
+	cset "name='Headphone Playback Switch' off"
+	cset "name='Line In Playback Switch' off"
+	cset "name='Line Out Playback Switch' off"
+	cset "name='Mic1 Playback Switch' off"
+	cset "name='Mic2 Playback Switch' off"
+
+	# Switch capture off.
+	cset "name='Line In Capture Switch' off"
+	cset "name='Mic1 Capture Switch' off"
+	cset "name='Mic2 Capture Switch' off"
+	cset "name='Mixer Capture Switch' off"
+	cset "name='Mixer Reversed Capture Switch' off"
+]

--- a/ucm2/Allwinner/A64/PinePhone/PinePhone.conf
+++ b/ucm2/Allwinner/A64/PinePhone/PinePhone.conf
@@ -15,21 +15,6 @@ SectionUseCase."Voice Call" {
 }
 
 FixedBootSequence [
-	# Switch playback off.
-	cset "name='Earpiece Playback Switch' off"
-	cset "name='Headphone Playback Switch' off"
-	cset "name='Line In Playback Switch' off"
-	cset "name='Line Out Playback Switch' off"
-	cset "name='Mic1 Playback Switch' off"
-	cset "name='Mic2 Playback Switch' off"
-
-	# Switch capture off.
-	cset "name='Line In Capture Switch' off"
-	cset "name='Mic1 Capture Switch' off"
-	cset "name='Mic2 Capture Switch' off"
-	cset "name='Mixer Capture Switch' off"
-	cset "name='Mixer Reversed Capture Switch' off"
-
 	# Routing.
 	cset "name='ADC Digital DAC Playback Switch' off"
 	cset "name='AIF1 DA0 Stereo Playback Route' Stereo"

--- a/ucm2/Allwinner/A64/PinePhone/VoiceCall.conf
+++ b/ucm2/Allwinner/A64/PinePhone/VoiceCall.conf
@@ -4,6 +4,23 @@ SectionVerb {
 		cset "name='AIF2 ADC Mixer ADC Capture Switch' on"
 	]
 
+	SectionDefaults [
+		# Switch playback off.
+		cset "name='Earpiece Playback Switch' off"
+		cset "name='Headphone Playback Switch' off"
+		cset "name='Line In Playback Switch' off"
+		cset "name='Line Out Playback Switch' off"
+		cset "name='Mic1 Playback Switch' off"
+		cset "name='Mic2 Playback Switch' off"
+
+		# Switch capture off.
+		cset "name='Line In Capture Switch' off"
+		cset "name='Mic1 Capture Switch' off"
+		cset "name='Mic2 Capture Switch' off"
+		cset "name='Mixer Capture Switch' off"
+		cset "name='Mixer Reversed Capture Switch' off"
+	]
+
 	Value {
 		PlaybackRate 8000
 	}

--- a/ucm2/Allwinner/A64/PinePhone/VoiceCall.conf
+++ b/ucm2/Allwinner/A64/PinePhone/VoiceCall.conf
@@ -1,0 +1,105 @@
+SectionVerb {
+	EnableSequence [
+		cset "name='AIF2 Digital DAC Playback Switch' on"
+		cset "name='AIF2 ADC Mixer ADC Capture Switch' on"
+	]
+
+	Value {
+		PlaybackRate 8000
+	}
+}
+
+SectionDevice."Speaker" {
+	Comment "Internal speaker"
+	EnableSequence [
+		cset "name='Line Out Playback Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Line Out Playback Switch' off"
+	]
+
+	Value {
+		PlaybackVolume "Line Out Playback Volume"
+		PlaybackSwitch "Line Out Playback Switch"
+		PlaybackChannels 2
+		PlaybackPriority 300
+		PlaybackPCM "hw:${CardId},0"
+	}
+}
+SectionDevice."Earpiece" {
+	Comment "Internal Earpiece"
+	EnableSequence [
+		cset "name='Earpiece Playback Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Earpiece Playback Switch' off"
+	]
+
+	Value {
+		PlaybackVolume "Earpiece Playback Volume"
+		PlaybackSwitch "Earpiece Playback Switch"
+		PlaybackChannels 2
+		PlaybackPriority 500
+		PlaybackPCM "hw:${CardId},0"
+	}
+}
+SectionDevice."Mic" {
+	Comment "Internal Microphone"
+	ConflictingDevice [
+		"Headset"
+	]
+	EnableSequence [
+		cset "name='Mic1 Capture Switch' on"
+	]
+	DisableSequence [
+		cset "name='Mic1 Capture Switch' off"
+	]
+	Value {
+		CapturePriority 200
+		CapturePCM "hw:${CardId},0"
+		CaptureVolume "ADC Capture Volume"
+		CaptureSwitch "Mic1 Capture Switch"
+		CaptureChannels 2
+	}
+}
+SectionDevice."Headset" {
+	Comment "Headset Microphone"
+	ConflictingDevice [
+		"Mic"
+	]
+	EnableSequence [
+		cset "name='Mic2 Capture Switch' on"
+	]
+	DisableSequence [
+		cset "name='Mic2 Capture Switch' off"
+	]
+	Value {
+		CapturePriority 500
+		CapturePCM "hw:${CardId},0"
+		CaptureChannels 2
+		CaptureVolume "ADC Capture Volume"
+		CaptureSwitch "Mic2 Capture Switch"
+		JackControl "Headset Microphone Jack"
+	}
+}
+SectionDevice."Headphones" {
+	Comment "Headphones"
+	EnableSequence [
+		cset "name='Headphone Playback Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Headphone Playback Switch' off"
+	]
+
+	Value {
+		PlaybackVolume "Headphone Playback Volume"
+		PlaybackSwitch "Headphone Playback Switch"
+		PlaybackChannels 2
+		PlaybackPriority 500
+		PlaybackPCM "hw:${CardId},0"
+		JackControl "Headphone Jack"
+	}
+}

--- a/ucm2/Allwinner/A64/PinePhone/VoiceCall.conf
+++ b/ucm2/Allwinner/A64/PinePhone/VoiceCall.conf
@@ -38,8 +38,7 @@ SectionDevice."Speaker" {
 	]
 
 	Value {
-		PlaybackVolume "Line Out Playback Volume"
-		PlaybackSwitch "Line Out Playback Switch"
+		PlaybackMixerElem "Line Out"
 		PlaybackPriority 300
 		PlaybackPCM "hw:${CardId},0"
 	}
@@ -57,8 +56,7 @@ SectionDevice."Earpiece" {
 	]
 
 	Value {
-		PlaybackVolume "Earpiece Playback Volume"
-		PlaybackSwitch "Earpiece Playback Switch"
+		PlaybackMixerElem "Earpiece"
 		PlaybackPriority 500
 		PlaybackPCM "hw:${CardId},0"
 	}
@@ -123,8 +121,7 @@ SectionDevice."Headphones" {
 	]
 
 	Value {
-		PlaybackVolume "Headphone Playback Volume"
-		PlaybackSwitch "Headphone Playback Switch"
+		PlaybackMixerElem "Headphone"
 		PlaybackPriority 500
 		PlaybackPCM "hw:${CardId},0"
 		JackControl "Headphone Jack"

--- a/ucm2/Allwinner/A64/PinePhone/VoiceCall.conf
+++ b/ucm2/Allwinner/A64/PinePhone/VoiceCall.conf
@@ -4,23 +4,6 @@ SectionVerb {
 		cset "name='AIF2 ADC Mixer ADC Capture Switch' on"
 	]
 
-	SectionDefaults [
-		# Switch playback off.
-		cset "name='Earpiece Playback Switch' off"
-		cset "name='Headphone Playback Switch' off"
-		cset "name='Line In Playback Switch' off"
-		cset "name='Line Out Playback Switch' off"
-		cset "name='Mic1 Playback Switch' off"
-		cset "name='Mic2 Playback Switch' off"
-
-		# Switch capture off.
-		cset "name='Line In Capture Switch' off"
-		cset "name='Mic1 Capture Switch' off"
-		cset "name='Mic2 Capture Switch' off"
-		cset "name='Mixer Capture Switch' off"
-		cset "name='Mixer Reversed Capture Switch' off"
-	]
-
 	Value {
 		PlaybackRate 8000
 	}

--- a/ucm2/Allwinner/A64/PinePhone/VoiceCall.conf
+++ b/ucm2/Allwinner/A64/PinePhone/VoiceCall.conf
@@ -11,6 +11,7 @@ SectionVerb {
 
 SectionDevice."Speaker" {
 	Comment "Internal speaker"
+
 	EnableSequence [
 		cset "name='Line Out Playback Switch' on"
 	]
@@ -27,8 +28,10 @@ SectionDevice."Speaker" {
 		PlaybackPCM "hw:${CardId},0"
 	}
 }
+
 SectionDevice."Earpiece" {
 	Comment "Internal Earpiece"
+
 	EnableSequence [
 		cset "name='Earpiece Playback Switch' on"
 	]
@@ -45,17 +48,22 @@ SectionDevice."Earpiece" {
 		PlaybackPCM "hw:${CardId},0"
 	}
 }
+
 SectionDevice."Mic" {
 	Comment "Internal Microphone"
+
 	ConflictingDevice [
 		"Headset"
 	]
+
 	EnableSequence [
 		cset "name='Mic1 Capture Switch' on"
 	]
+
 	DisableSequence [
 		cset "name='Mic1 Capture Switch' off"
 	]
+
 	Value {
 		CapturePriority 200
 		CapturePCM "hw:${CardId},0"
@@ -64,17 +72,22 @@ SectionDevice."Mic" {
 		CaptureChannels 2
 	}
 }
+
 SectionDevice."Headset" {
 	Comment "Headset Microphone"
+
 	ConflictingDevice [
 		"Mic"
 	]
+
 	EnableSequence [
 		cset "name='Mic2 Capture Switch' on"
 	]
+
 	DisableSequence [
 		cset "name='Mic2 Capture Switch' off"
 	]
+
 	Value {
 		CapturePriority 500
 		CapturePCM "hw:${CardId},0"
@@ -84,8 +97,10 @@ SectionDevice."Headset" {
 		JackControl "Headset Microphone Jack"
 	}
 }
+
 SectionDevice."Headphones" {
 	Comment "Headphones"
+
 	EnableSequence [
 		cset "name='Headphone Playback Switch' on"
 	]

--- a/ucm2/Allwinner/A64/PinePhone/VoiceCall.conf
+++ b/ucm2/Allwinner/A64/PinePhone/VoiceCall.conf
@@ -23,7 +23,6 @@ SectionDevice."Speaker" {
 	Value {
 		PlaybackVolume "Line Out Playback Volume"
 		PlaybackSwitch "Line Out Playback Switch"
-		PlaybackChannels 2
 		PlaybackPriority 300
 		PlaybackPCM "hw:${CardId},0"
 	}
@@ -43,7 +42,6 @@ SectionDevice."Earpiece" {
 	Value {
 		PlaybackVolume "Earpiece Playback Volume"
 		PlaybackSwitch "Earpiece Playback Switch"
-		PlaybackChannels 2
 		PlaybackPriority 500
 		PlaybackPCM "hw:${CardId},0"
 	}
@@ -69,7 +67,6 @@ SectionDevice."Mic" {
 		CapturePCM "hw:${CardId},0"
 		CaptureVolume "ADC Capture Volume"
 		CaptureSwitch "Mic1 Capture Switch"
-		CaptureChannels 2
 	}
 }
 
@@ -91,7 +88,6 @@ SectionDevice."Headset" {
 	Value {
 		CapturePriority 500
 		CapturePCM "hw:${CardId},0"
-		CaptureChannels 2
 		CaptureVolume "ADC Capture Volume"
 		CaptureSwitch "Mic2 Capture Switch"
 		JackControl "Headset Microphone Jack"
@@ -112,7 +108,6 @@ SectionDevice."Headphones" {
 	Value {
 		PlaybackVolume "Headphone Playback Volume"
 		PlaybackSwitch "Headphone Playback Switch"
-		PlaybackChannels 2
 		PlaybackPriority 500
 		PlaybackPCM "hw:${CardId},0"
 		JackControl "Headphone Jack"

--- a/ucm2/conf.d/simple-card/PinePhone.conf
+++ b/ucm2/conf.d/simple-card/PinePhone.conf
@@ -1,0 +1,1 @@
+../../Allwinner/A64/PinePhone/PinePhone.conf


### PR DESCRIPTION
Fixes https://github.com/alsa-project/alsa-ucm-conf/issues/124.

This PR adds support for the https://wiki.pine64.org/index.php/PinePhone 

This PR contains:
* This UCM config copied from https://gitlab.com/pine64-org/pine64-alsa-ucm/, which was developed by many developers ( https://gitlab.com/pine64-org/pine64-alsa-ucm/-/merge_requests/1 ) and is BSD-3-Clause licensed.
* Fix paths to be relative to alsa-ucm-conf root.
* Some refactoring of the UCM config, incl. removing duplicate directives, and moving volume directives to BootSequence.
* Updating the routing/playback/boost volumes, in response to comments on this PR.

I have tested:

* HiFi
    * Record audio via the headset.
    * Record audio via the internal mic.
    * Play audio on the headphones.
    * Play audio on the speaker.
    * Play audio on the internal speaker.
* Voice Call
    * Speak on the headset.
    * Speak on the internal mic.
    * Listen on the headphones.
    * Listen on the speaker. This induces an echo, and given the audio routing is entirely on chip, and the chip doesn't advertise echo cancellation, I don't see how this is avoidable.
    * Listen on the internal speaker.

See also:
* `alsa-info`: https://alsa-project.org/db/?f=5e331f5ef10bd167b3bd7640bfcf0e879100f80d
* `pa-info`: [pa-info.txt](https://github.com/alsa-project/alsa-ucm-conf/files/8015083/pa-info.txt)
* https://gitlab.com/pine64-org/pine64-alsa-ucm/-/issues/3
* Schematics/code
    * The device-tree configuration has had a unique audio card name since 5.14: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dtsi?h=v5.14#n436
    * http://files.pine64.org/doc/PinePhone/PinePhone%20v1.2%20Released%20Schematic.pdf
    * https://xnux.eu/devices/feature/audio-pp.html
    * https://github.com/torvalds/linux/blob/master/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dtsi
    * https://github.com/torvalds/linux/blob/master/arch/arm64/boot/dts/allwinner/sun50i-a64.dtsi
    * https://github.com/torvalds/linux/blob/master/sound/soc/sunxi/sun50i-codec-analog.c
    * https://files.pine64.org/doc/datasheet/pine64/Allwinner_A64_User_Manual_V1.0.pdf
    * https://static.chipdip.ru/lib/126/DOC001126567.pdf
