### PR TITLE
ucm2: add additional symlink for Pinebook Pro

### DIFF
--- a/ucm2/conf.d/simple-card/rockchip,es8316-codec.conf
+++ b/ucm2/conf.d/simple-card/rockchip,es8316-codec.conf
@@ -1,0 +1,1 @@
+../../Rockchip/es8316/es8316.conf


### PR DESCRIPTION
since 907f0a305186 ASoC: simple-card: Fill in driver name of the linux
kernel, the base name is simple-card instead of rockchip_es8316

Fixes: 85eea19783cf ("ucm2: Add UCM support for rockchip_es8316 on Pinebook Pro")
Signed-off-by: Kyle Copperfield <kmcopper@danwin1210.me>