### PR TITLE
USB-Audio: Add profile for MSI MPG X570S Carbon Max Wifi.

### DIFF
--- a/ucm2/USB-Audio/Realtek/ALC4080-HiFi.conf
+++ b/ucm2/USB-Audio/Realtek/ALC4080-HiFi.conf
@@ -1,3 +1,14 @@
+Define.SPDIFIndex "3"
+
+If.asus-rog-usb {
+	Condition {
+		Type RegexMatch
+		String "${CardComponents}"
+		Regex "USB(0b05:1996)"
+	}
+	True.Define.SPDIFIndex "2"
+}
+
 SectionDevice."Speaker" {
 	Comment "Speakers"
 	Value {
@@ -23,7 +34,7 @@ SectionDevice."SPDIF" {
 	Comment "S/PDIF Out"
 	Value {
 		PlaybackPriority 100
-		PlaybackPCM "hw:${CardId},3"
+		PlaybackPCM "hw:${CardId},${var:SPDIFIndex}"
 		PlaybackMixerElem "IEC958"
 	}
 }
@@ -47,10 +58,19 @@ SectionDevice."Mic" {
 		cset "name='Mic Capture Switch' on"
 	]
 
-	Comment "Microphone"
+	Comment "Front Microphone"
 	Value {
 		CapturePriority 200
 		CapturePCM "hw:${CardId},2"
+		JackControl "Mic - Input Jack"
+		CaptureMixerElem "Mic"
+	}
+
+	# On ASUS ROG Maximus XIII and others, back microphone
+	Comment "Microphone"
+	Value {
+		CapturePriority 300
+		CapturePCM "hw:${CardId}"
 		JackControl "Mic - Input Jack"
 		CaptureMixerElem "Mic"
 	}

--- a/ucm2/USB-Audio/Realtek/ALC4080-HiFi.conf
+++ b/ucm2/USB-Audio/Realtek/ALC4080-HiFi.conf
@@ -1,4 +1,5 @@
 Define.SPDIFIndex "3"
+Define.Mic1Name "Microphone"
 
 If.asus-rog-usb {
 	Condition {
@@ -6,7 +7,21 @@ If.asus-rog-usb {
 		String "${CardComponents}"
 		Regex "USB(0b05:1996)"
 	}
-	True.Define.SPDIFIndex "2"
+	True {
+		Define.SPDIFIndex "2"
+		Define.Mic1Name "Front Microphone"
+
+		SectionDevice."Mic2" {
+			# On ASUS ROG Maximus XIII and others, back microphone
+			Comment "Microphone"
+			Value {
+				CapturePriority 300
+				CapturePCM "hw:${CardId}"
+				JackControl "Mic - Input Jack"
+				CaptureMixerElem "Mic"
+			}
+		}
+	}
 }
 
 SectionDevice."Speaker" {
@@ -53,24 +68,15 @@ SectionDevice."Line" {
 	}
 }
 
-SectionDevice."Mic" {
+SectionDevice."Mic1" {
 	EnableSequence [
 		cset "name='Mic Capture Switch' on"
 	]
 
-	Comment "Front Microphone"
+	Comment "${var:Mic1Name}"
 	Value {
 		CapturePriority 200
 		CapturePCM "hw:${CardId},2"
-		JackControl "Mic - Input Jack"
-		CaptureMixerElem "Mic"
-	}
-
-	# On ASUS ROG Maximus XIII and others, back microphone
-	Comment "Microphone"
-	Value {
-		CapturePriority 300
-		CapturePCM "hw:${CardId}"
 		JackControl "Mic - Input Jack"
 		CaptureMixerElem "Mic"
 	}

--- a/ucm2/USB-Audio/Realtek/ALC4080-HiFi.conf
+++ b/ucm2/USB-Audio/Realtek/ALC4080-HiFi.conf
@@ -1,0 +1,57 @@
+SectionDevice."Speaker" {
+	Comment "Speakers"
+	Value {
+		PlaybackChannels 8
+		PlaybackPriority 200
+		PlaybackPCM "hw:${CardId}"
+		JackControl "Speaker - Output Jack"
+		PlaybackMixerElem "Speaker"
+	}
+}
+
+SectionDevice."Headphones" {
+	Comment "Front Headphones"
+	Value {
+		PlaybackPriority 300
+		PlaybackPCM "hw:${CardId},1"
+		JackControl "Headphone - Output Jack"
+		PlaybackMixerElem "Front Headphone"
+	}
+}
+
+SectionDevice."SPDIF" {
+	Comment "S/PDIF Out"
+	Value {
+		PlaybackPriority 100
+		PlaybackPCM "hw:${CardId},3"
+		PlaybackMixerElem "IEC958"
+	}
+}
+
+SectionDevice."Line" {
+	EnableSequence [
+		cset "name='Line Capture Switch' on"
+	]
+
+	Comment "Line In"
+	Value {
+		CapturePriority 100
+		CapturePCM "hw:${CardId},1"
+		JackControl "Line - Input Jack"
+		CaptureMixerElem "Line"
+	}
+}
+
+SectionDevice."Mic" {
+	EnableSequence [
+		cset "name='Mic Capture Switch' on"
+	]
+
+	Comment "Microphone"
+	Value {
+		CapturePriority 200
+		CapturePCM "hw:${CardId},2"
+		JackControl "Mic - Input Jack"
+		CaptureMixerElem "Mic"
+	}
+}

--- a/ucm2/USB-Audio/Realtek/ALC4080.conf
+++ b/ucm2/USB-Audio/Realtek/ALC4080.conf
@@ -1,0 +1,5 @@
+Comment "USB-audio on Realtek ALC4080"
+SectionUseCase."HiFi" {
+	File "/USB-Audio/Realtek/ALC4080-HiFi.conf"
+	Comment "Default Alsa Profile"
+}

--- a/ucm2/USB-Audio/Realtek/ALC4080.conf
+++ b/ucm2/USB-Audio/Realtek/ALC4080.conf
@@ -1,5 +1,5 @@
 Comment "USB-audio on Realtek ALC4080"
 SectionUseCase."HiFi" {
 	File "/USB-Audio/Realtek/ALC4080-HiFi.conf"
-	Comment "Default Alsa Profile"
+	Comment "Play HiFi quality Music"
 }

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -28,6 +28,17 @@ If.realtek-alc1220-vb {
 	True.Define.ProfileName "Realtek/ALC1220-VB-Desktop"
 }
 
+If.realtek-alc4080 {
+
+	Condition {
+		Type RegexMatch
+		String "${CardComponents}"
+		# 0db0:419c MSI MPG X570S Carbon Max Wifi
+		Regex "USB(0db0:419c)"
+	}
+	True.Define.ProfileName "Realtek/ALC4080"
+}
+
 If.gigabyte-aorus-main {
 	Condition {
 		Type String

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -33,8 +33,10 @@ If.realtek-alc4080 {
 	Condition {
 		Type RegexMatch
 		String "${CardComponents}"
+		# 0b05:1996 ASUS on multiple boards (including ASUS ROG Maximus XIII)
 		# 0db0:419c MSI MPG X570S Carbon Max Wifi
-		Regex "USB(0db0:419c)"
+		# 0db0:a073 MSI MAG X570S Torpedo Max
+		Regex "USB((0b05:1996)|(0db0:419c)|(0db0:a073))"
 	}
 	True.Define.ProfileName "Realtek/ALC4080"
 }

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -34,9 +34,10 @@ If.realtek-alc4080 {
 		Type RegexMatch
 		String "${CardComponents}"
 		# 0b05:1996 ASUS on multiple boards (including ASUS ROG Maximus XIII)
+		# 0db0:1feb MSI Edge Wifi Z690
 		# 0db0:419c MSI MPG X570S Carbon Max Wifi
 		# 0db0:a073 MSI MAG X570S Torpedo Max
-		Regex "USB((0b05:1996)|(0db0:419c)|(0db0:a073))"
+		Regex "USB((0b05:1996)|(0db0:1feb)|(0db0:419c)|(0db0:a073))"
 	}
 	True.Define.ProfileName "Realtek/ALC4080"
 }


### PR DESCRIPTION
This patch depends on Linux 5.17.

This board features an Realtek ALC4080 chip. The various inputs and
outputs are distributed over multiple hardware devices:
* Input
 - hw:$card,0 loop back from speaker (called "Analog In")
 - hw:$card,1 line in at back panel
 - hw:$card,2 microphone from front AND back panel
* Output
 - hw:$card,0 speaker output at back panel (up to 7.1)
 - hw:$card,1 headerphone output at front panel
 - hw:$card,2 could not figure this one out
 - hw:$card,3 guessed S/PDIF output (sadly no way to test)

By default Mic and Line in are disabled. This confuses applications,
thus I made the profile enable them by default.

Without an UCM profile PulseAudio is not able to create output on
the front panel nor record any microphone input.

Signed-off-by: Johannes Schickel <lordhoto@gmail.com>