### PR TITLE
Fix support for sof-essx8336

### DIFF
--- a/ucm2/Intel/sof-essx8336/HiFi.conf
+++ b/ucm2/Intel/sof-essx8336/HiFi.conf
@@ -21,18 +21,21 @@ If.amic {
 			"Headset"
 		]
 
-		Value {
-			CapturePriority 100
-			CapturePCM "hw:${CardId}"
-		}
-
 		EnableSequence [
+			cset "name='Differential Mux' lin1-rin1"
 			cset "name='Internal Mic Switch' on"
 		]
 
 		DisableSequence [
 			cset "name='Internal Mic Switch' off"
 		]
+
+		Value {
+			CapturePriority 100
+			CapturePCM "hw:${CardId}"
+			CaptureMixerElem "ADC PGA Gain"
+			CaptureMasterElem "ADC"
+		}
 	}
 }
 
@@ -65,7 +68,7 @@ If.dmic {
 }
 
 SectionDevice."Speaker" {
-	Comment "Speaker"
+	Comment "Speakers"
 
 	ConflictingDevice [
 		"Headphones"
@@ -81,10 +84,10 @@ SectionDevice."Speaker" {
 	Value {
 		PlaybackPriority 100
 		PlaybackPCM "hw:${CardId}"
-		PlaybackMixerElem "Speaker"
-		PlaybackMasterElem "Master"
-		PlaybackVolume "Speaker Volume"
-		PlaybackSwitch "Speaker Switch"
+		# The es8316 only has a HP-amp which is muxed to the speaker
+		# or to the headpones output
+		PlaybackMixerElem "Headphone Mixer"
+		PlaybackMasterElem "DAC"
 	}
 }
 
@@ -95,21 +98,11 @@ SectionDevice."Headphones" {
 		"Speaker"
 	]
 
-	EnableSequence [
-		cset "name='Headphone Switch' on"
-	]
-
-	DisableSequence [
-		cset "name='Headphone Switch' off"
-	]
-
 	Value {
 		PlaybackPriority 300
 		PlaybackPCM "hw:${CardId}"
-		PlaybackMixerElem "Headphone"
-		PlaybackMasterElem "Master"
-		PlaybackVolume "Headphone Volume"
-		PlaybackSwitch "Headphone Switch"
+		PlaybackMixerElem "Headphone Mixer"
+		PlaybackMasterElem "DAC"
 		JackControl "Headphone Jack"
 		JackHWMute "Speaker"
 	}
@@ -129,16 +122,19 @@ SectionDevice."Headset" {
 	}
 
 	EnableSequence [
-		cset "name='Headset Mic Switch' on"
+		cset "name='Headset Switch' on"
+		cset "name='Digital Mic Mux' 'dmic disable'"
 	]
 
 	DisableSequence [
-		cset "name='Headset Mic Switch' off"
+		cset "name='Headset Switch' on"
 	]
 
 	Value {
 		CapturePriority 300
 		CapturePCM "hw:${CardId}"
+		CaptureMixerElem "ADC PGA Gain"
+		CaptureMasterElem "ADC"
 		JackControl "Headset Mic Jack"
 	}
 }

--- a/ucm2/Intel/sof-essx8336/HiFi.conf
+++ b/ucm2/Intel/sof-essx8336/HiFi.conf
@@ -1,4 +1,13 @@
 SectionVerb {
+	EnableSequence [
+		# Disable all inputs / outputs
+		cset "name='Speaker Switch' off"
+		cset "name='Headphone Switch' off"
+		cset "name='Headset Mic Switch' off"
+		cset "name='Internal Mic Switch' off"
+		cset "name='DAC Mono Mix Switch' off"
+	]
+}
 
 If.amic {
 	Condition {

--- a/ucm2/Intel/sof-essx8336/sof-essx8336.conf
+++ b/ucm2/Intel/sof-essx8336/sof-essx8336.conf
@@ -1,5 +1,29 @@
 Syntax 4
 
+BootSequence [
+	# Setup muxes / switches
+	cset "name='Left Headphone Mixer Left DAC Switch' on"
+	cset "name='Right Headphone Mixer Right DAC Switch' on"
+	# Set digital mix mux to "dmic disable"
+	# That doesn't affect dmic, but other values mute headset mic
+	cset "name='Digital Mic Mux' 0"
+
+	# Set HP vol to 0 dB
+	cset "name='Headphone Playback Volume' 100%"
+	cset "name='Headphone Mixer Volume' 100%"
+
+	# Set DAC vol
+	cset "name='DAC Playback Volume' 60%"
+	# LDATA TO LDAC, RDATA TO RDAC
+	cset "name='DAC Source Mux' 0"
+
+	# Disable Auto Level Control
+	cset "name='ALC Capture Switch' off"
+
+	# Set capture vol
+	cset "name='ADC Capture Volume' 60%"
+]
+
 Define.DeviceDmic ""
 
 If.devdmic {

--- a/ucm2/Intel/sof-essx8336/sof-essx8336.conf
+++ b/ucm2/Intel/sof-essx8336/sof-essx8336.conf
@@ -12,7 +12,7 @@ If.devdmic {
 }
 
 SectionUseCase."HiFi" {
-	File "/Intel/sof-es8336/HiFi.conf"
+	File "/Intel/sof-essx8336/HiFi.conf"
 	Comment "Play and record HiFi quality Music"
 }
 

--- a/ucm2/Intel/sof-essx8336/sof-essx8336.conf
+++ b/ucm2/Intel/sof-essx8336/sof-essx8336.conf
@@ -39,28 +39,6 @@ SectionUseCase."HiFi" {
 	File "/Intel/sof-essx8336/HiFi.conf"
 	Comment "Play and record HiFi quality Music"
 }
-
-# the kcontrols initial values, which will be set by `alsactl init`
-If.speaker {
-	Condition {
-		Type ControlExists
-		Control "DAC Playback Volume"
-	}
-	True.BootSequence [
-		cset "name='DAC Playback Volume' 60%"
-	]
-}
-
-If.headphone {
-	Condition {
-		Type ControlExists
-		Control "name='Headphone Playback Volume'"
-	}
-	True.BootSequence [
-		cset "name='Headphone Playback Volume' 60%"
-	]
-}
-
 If.dmic {
 	Condition {
 		Type String
@@ -77,12 +55,3 @@ If.dmic {
 	}
 }
 
-If.Capture {
-	Condition {
-		Type ControlExists
-		Control "name='ADC Capture Volume'"
-	}
-	True.BootSequence [
-		cset "name='ADC Capture Volume' 60%"
-	]
-}


### PR DESCRIPTION
There are a couple of issues at the support for sof-essx8336, causing it to fail working.

This PR fix them. Tested on Huawei Matebook D15. Before the fix, the device was appearing as "sysdefault:0" instead of "hw:0", and there were several other problems.

 After the fix:
- the device is now identified as hw:0;
- calling alsamixer without `-Dsysdefault:0` (or `-Dhw:0`) now shows a mixer (instead of showing nothing);
- The HDMI volume controls now appear;
- Using `alsaucm load` now works fine.

There are still a couple of things to be fixed, but I suspect that at least some of them would require firmware (or driver?) changes:
- the internal microphone is not working yet;
- the headphone/headset doesn't work.