### PR TITLE
Add Use Case for Arturia Minifuse 2

### DIFF
--- a/ucm2/USB-Audio/Arturia/Minifuse-2-Direct-HW-HiFi.conf
+++ b/ucm2/USB-Audio/Arturia/Minifuse-2-Direct-HW-HiFi.conf
@@ -1,0 +1,32 @@
+LibraryConfig.generic.Config {
+
+	ctl.hw {
+		@args [ CARD ]
+		@args.CARD.type string
+		type hw
+		card $CARD
+	}
+
+	pcm.hw {
+		@args [ CARD ]
+		@args {
+			CARD.type string
+		}
+		type hw
+		card $CARD
+		device 0
+	}
+
+}
+
+SectionDevice."PCM" {
+	Comment "Direct hardware access"
+	Value {
+		PlaybackPriority 300
+		PlaybackChannels 4
+		PlaybackPCM "hw:${CardId}"
+		CapturePriority 300
+		CaptureChannels 4
+		CapturePCM "hw:${CardId}"
+	}
+}

--- a/ucm2/USB-Audio/Arturia/Minifuse-2-HiFi.conf
+++ b/ucm2/USB-Audio/Arturia/Minifuse-2-HiFi.conf
@@ -1,0 +1,179 @@
+LibraryConfig.pcm.Config {
+
+	pcm.minifuse2_stereo_p {
+		@args [ CARD CHN0 CHN1 ]
+		@args {
+			CARD.type string
+			CHN0.type integer
+			CHN1.type integer
+		}
+		type dshare
+		ipc_key 583542
+		slave {
+			pcm {
+				type hw
+				card $CARD
+				device 0
+			}
+			channels 4
+		}
+		bindings.0 $CHN0
+		bindings.1 $CHN1
+	}
+
+	pcm.minifuse2_stereo_c {
+		@args [ CARD CHN0 CHN1 ]
+		@args {
+			CARD.type string
+			CHN0.type integer
+			CHN1.type integer
+		}
+		type dsnoop
+		ipc_key 583542
+		slave {
+			pcm {
+				type hw
+				card $CARD
+				device 0
+			}
+			channels 4
+		}
+		bindings.0 $CHN0
+		bindings.1 $CHN1
+	}
+
+	pcm.minifuse2_mono_c {
+		@args [ CARD CHN0 ]
+		@args {
+			CARD.type string
+			CHN0.type integer
+		}
+		type dsnoop
+		ipc_key 583542
+		slave {
+			pcm {
+				type hw
+				card $CARD
+				device 0
+			}
+			channels 4
+		}
+		bindings.0 $CHN0
+	}
+
+	pcm.minifuse2_main_p {
+		@args [ CARD ]
+		@args.CARD.type string
+		type empty
+		slave.pcm {
+			@func concat
+			strings [ "minifuse2_stereo_p:" $CARD ",0,1" ]
+		}
+	}
+
+	pcm.minifuse2_loopback_p {
+		@args [ CARD ]
+		@args.CARD.type string
+		type empty
+		slave.pcm {
+			@func concat
+			strings [ "minifuse2_stereo_p:" $CARD ",2,3" ]
+		}
+	}
+
+	pcm.minifuse2_loopback_c {
+		@args [ CARD ]
+		@args.CARD.type string
+		type empty
+		slave.pcm {
+			@func concat
+			strings [ "minifuse2_stereo_c:" $CARD ",2,3" ]
+		}
+	}
+
+	pcm.minifuse2_mic1_c {
+		@args [ CARD ]
+		@args.CARD.type string
+		type empty
+		slave.pcm {
+			@func concat
+			strings [ "minifuse2_mono_c:" $CARD ",0" ]
+		}
+	}
+
+	pcm.minifuse2_mic2_c {
+		@args [ CARD ]
+		@args.CARD.type string
+		type empty
+		slave.pcm {
+			@func concat
+			strings [ "minifuse2_mono_c:" $CARD ",1" ]
+		}
+	}
+
+	pcm.minifuse2_combo_c {
+		@args [ CARD ]
+		@args.CARD.type string
+		type empty
+		slave.pcm {
+			@func concat
+			strings [ "minifuse2_stereo_c:" $CARD ",0,1" ]
+		}
+	}
+}
+
+SectionDevice."Main" {
+	Comment "Main Playback L/R"
+	Value {
+		PlaybackPriority 300
+		PlaybackChannels 2
+		PlaybackPCM "minifuse2_main_p:${CardId}"
+	}
+}
+
+SectionDevice."Loopback_p" {
+	Comment "Loopback Playback L/R"
+	Value {
+		PlaybackPriority 200
+		PlaybackChannels 2
+		PlaybackPCM "minifuse2_loopback_p:${CardId}"
+	}
+}
+
+SectionDevice."Loopback_c" {
+	Comment "Loopback Capture L/R"
+	Value {
+		CapturePriority 200
+		CaptureChannels 2
+		CapturePCM "minifuse2_loopback_c:${CardId}"
+	}
+}
+
+SectionDevice."Combo_c" {
+	Comment "Stereo Capture 1+2 L/R"
+	Value {
+		CapturePriority 100
+		CaptureChannels 2
+		CapturePCM "minifuse2_combo_c:${CardId}"
+	}
+}
+
+SectionDevice."Mic1" {
+	Comment "Mic/Line/Inst 1 (L)"
+
+	Value {
+		CapturePriority 300
+		CaptureChannels 1
+		CapturePCM "minifuse2_mic1_c:${CardId}"
+	}
+}
+
+SectionDevice."Mic2" {
+	Comment "Mic/Line/Inst 2 (R)"
+
+	Value {
+		CapturePriority 200
+		CaptureChannels 1
+		CapturePCM "minifuse2_mic2_c:${CardId}"
+	}
+}

--- a/ucm2/USB-Audio/Arturia/Minifuse-2.conf
+++ b/ucm2/USB-Audio/Arturia/Minifuse-2.conf
@@ -1,0 +1,5 @@
+Comment "Arturia Minifuse 2"
+SectionUseCase."HiFi" {
+	Comment "Default Alsa Profile"
+	File "/USB-Audio/Arturia/Minifuse-2-HiFi.conf"
+}

--- a/ucm2/USB-Audio/Arturia/Minifuse-2.conf
+++ b/ucm2/USB-Audio/Arturia/Minifuse-2.conf
@@ -3,3 +3,7 @@ SectionUseCase."HiFi" {
 	Comment "Default Alsa Profile"
 	File "/USB-Audio/Arturia/Minifuse-2-HiFi.conf"
 }
+SectionUseCase."Direct HW HiFi" {
+	Comment "Direct device access - Pro Audio"
+	File "/USB-Audio/Arturia/Minifuse-2-Direct-HW-HiFi.conf"
+}

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -91,6 +91,15 @@ If.lenovo-p620-main {
 	True.Define.ProfileName "Lenovo/ThinkStation-P620-Main"
 }
 
+If.minifuse2 {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB1c75:af90"
+	}
+	True.Define.ProfileName "Arturia/Minifuse-2"
+}
+
 If.inc {
 	Condition {
 		Type String


### PR DESCRIPTION
Arturia Minifuse 2
(https://www.arturia.com/products/audio/minifuse/minifuse2)
is an USB audio interface with 2 mono inputs and 2 channel outputs.
It uses 1 subinterface with 4 capture and 4 playback channels:
Capture channels:
- Mic/Line/Inst 1 (Mono)
- Mic/Line/Inst 2 (Mono)
- Loopback (Stereo, L+R)

Playback:
- Main (Stereo, L+R)
- Loopback (L+R)

The Loopback capture and playback are intended to ease recording sound
from the computer, e.g if you're doing a podcast and want to record
something that plays from the computer. Of course us linux user don't
need that, since we have many tools able to do that.

However, without a dedicated use case, alsa treats the channels as
surround 4.0, which make the card difficult to use.

At this stage, no controls are available.

TODO/FIXMEs:
- add a channel map override on the pcm device ?