### PR TITLE
ucm2: USB-Audio/Steinberg/UR44: initial support

### DIFF
--- a/ucm2/USB-Audio/Steinberg/UR44-HiFi.conf
+++ b/ucm2/USB-Audio/Steinberg/UR44-HiFi.conf
@@ -1,0 +1,202 @@
+LibraryConfig.pcm.Config {
+
+	pcm.steinberg_ur44_mono_in {
+		@args [ CARD CHAN ]
+		@args {
+			CARD.type string
+			CHAN.type integer
+		}
+		type dsnoop
+		ipc_key 582201
+		slave {
+			pcm {
+				type hw
+				card $CARD
+				device 0
+			}
+			channels 6
+		}
+		bindings.0 $CHAN
+	}
+
+	pcm.steinberg_ur44_stereo_out {
+		@args [ CARD CHN0 CHN1 ]
+		@args {
+			CARD.type string
+			CHN0.type integer
+			CHN1.type integer
+		}
+		type dshare
+		ipc_key 582101
+		slave {
+			pcm {
+				type hw
+				card $CARD
+				device 0
+			}
+			channels 4
+		}
+		bindings.0 $CHN0
+		bindings.1 $CHN1
+	}
+
+	pcm.steinberg_ur44_input1 {
+		@args [ CARD ]
+		@args.CARD.type string
+		type empty
+		slave.pcm {
+			@func concat
+			strings [ "steinberg_ur44_mono_in:" $CARD ",0" ]
+		}
+	}
+
+	pcm.steinberg_ur44_input2 {
+		@args [ CARD ]
+		@args.CARD.type string
+		type empty
+		slave.pcm {
+			@func concat
+			strings [ "steinberg_ur44_mono_in:" $CARD ",1" ]
+		}
+	}
+
+	pcm.steinberg_ur44_input3 {
+		@args [ CARD ]
+		@args.CARD.type string
+		type empty
+		slave.pcm {
+			@func concat
+			strings [ "steinberg_ur44_mono_in:" $CARD ",2" ]
+		}
+	}
+
+	pcm.steinberg_ur44_input4 {
+		@args [ CARD ]
+		@args.CARD.type string
+		type empty
+		slave.pcm {
+			@func concat
+			strings [ "steinberg_ur44_mono_in:" $CARD ",3" ]
+		}
+	}
+
+	pcm.steinberg_ur44_input5 {
+		@args [ CARD ]
+		@args.CARD.type string
+		type empty
+		slave.pcm {
+			@func concat
+			strings [ "steinberg_ur44_mono_in:" $CARD ",4" ]
+		}
+	}
+
+	pcm.steinberg_ur44_input6 {
+		@args [ CARD ]
+		@args.CARD.type string
+		type empty
+		slave.pcm {
+			@func concat
+			strings [ "steinberg_ur44_mono_in:" $CARD ",5" ]
+		}
+	}
+
+	pcm.steinberg_ur44_stereo1 {
+		@args [ CARD ]
+		@args.CARD.type string
+		type empty
+		slave.pcm {
+			@func concat
+			strings [ "steinberg_ur44_stereo_out:" $CARD ",0,1" ]
+		}
+	}
+
+	pcm.steinberg_ur44_stereo2 {
+		@args [ CARD ]
+		@args.CARD.type string
+		type empty
+		slave.pcm {
+			@func concat
+			strings [ "steinberg_ur44_stereo_out:" $CARD ",2,3" ]
+		}
+	}
+}
+
+SectionDevice."Input1" {
+	Comment "Input 1"
+
+	Value {
+		CaptureChannels 1
+		CapturePriority 600
+		CapturePCM "steinberg_ur44_input1:${CardId}"
+	}
+}
+
+SectionDevice."Input2" {
+	Comment "Input 2"
+
+	Value {
+		CaptureChannels 1
+		CapturePriority 500
+		CapturePCM "steinberg_ur44_input2:${CardId}"
+	}
+}
+
+SectionDevice."Input3" {
+	Comment "Input 3"
+
+	Value {
+		CaptureChannels 1
+		CapturePriority 400
+		CapturePCM "steinberg_ur44_input3:${CardId}"
+	}
+}
+
+SectionDevice."Input4" {
+	Comment "Input 4"
+
+	Value {
+		CaptureChannels 1
+		CapturePriority 300
+		CapturePCM "steinberg_ur44_input4:${CardId}"
+	}
+}
+
+SectionDevice."Input5" {
+	Comment "Input 5"
+
+	Value {
+		CaptureChannels 1
+		CapturePriority 200
+		CapturePCM "steinberg_ur44_input5:${CardId}"
+	}
+}
+
+SectionDevice."Input6" {
+	Comment "Input 6"
+
+	Value {
+		CaptureChannels 1
+		CapturePriority 100
+		CapturePCM "steinberg_ur44_input6:${CardId}"
+	}
+}
+
+SectionDevice."Stereo 1" {
+	Comment "Line Outputs 1 and 2"
+
+	Value {
+		PlaybackChannels 2
+		PlaybackPriority 200
+		PlaybackPCM "steinberg_ur44_stereo1:${CardId}"
+	}
+}
+
+SectionDevice."Stereo 2" {
+	Comment "Line Outputs 3 and 4"
+
+	Value {
+		PlaybackChannels 2
+		PlaybackPriority 100
+		PlaybackPCM "steinberg_ur44_stereo2:${CardId}"
+	}
+}

--- a/ucm2/USB-Audio/Steinberg/UR44.conf
+++ b/ucm2/USB-Audio/Steinberg/UR44.conf
@@ -1,0 +1,5 @@
+Comment "Steinberg UR44 USB-Audio"
+SectionUseCase."HiFi" {
+	Comment "Default"
+	File "/USB-Audio/Steinberg/UR44-HiFi.conf"
+}

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -73,6 +73,15 @@ If.goxlr {
 	True.Define.ProfileName "GoXLR/GoXLR"
 }
 
+If.steinberg-ur44 {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB0499:1700"
+	}
+	True.Define.ProfileName "Steinberg/UR44"
+}
+
 If.lenovo-p620-rear {
 	Condition {
 		Type String


### PR DESCRIPTION
Home/pro audio interface with 6 inputs and 4 outputs, which I configure
as 6 mono capture devices and 2 stereo playback devices.

Signed-off-by: Cameron Nemo <cnemo@tutanota.com>
