### PR TITLE
HDA-DualCodecs: Fix wrong jack control on Lenovo P520

### DIFF
--- a/ucm2/HDA/DualCodecs/HiFi.conf
+++ b/ucm2/HDA/DualCodecs/HiFi.conf
@@ -57,25 +57,23 @@ SectionDevice."Line1" {
 	Value {
 		PlaybackPriority 200
 		PlaybackPCM "hw:${CardId}"
+		PlaybackMixerElem "Front"
+		Control "name='Front Playback Switch'"
 	}
 
-	If.0 {
+	If.lenovo {
 		Condition {
-			Type ControlExists
-			Control "name='Front Playback Switch'"
+			Type String
+			Haystack "${CardLongName}"
+			Needle "HDAudio-Lenovo"
 		}
 		True {
-			Value {
-				PlaybackMixerElem "Front"
-				JackControl "Line Out Front Jack"
-			}
-		}
-		False {
 			Value {
 				JackControl "Line Out Jack"
 				JackHWMute "Speaker"
 			}
 		}
+		False.Value.JackControl "Line Out Front Jack"
 	}
 }
 
@@ -104,7 +102,6 @@ SectionDevice."Headphones" {
 		}
 		True.Value.JackHWMute "Speaker"
 	}
-
 }
 
 SectionDevice."Line2" {


### PR DESCRIPTION
Lenovo P520 uses the same line out switch like other dual codecs
systems, however it uses another jack control. So consolidate the switch and
separate the jacks to make its jack control work again.

Fixes: 7dda1e21 ("HDA: improve support for HDAudio-Gigabyte-ALC1220DualCodecs")