### PR TITLE
USB-Audio: add Audient iD4 configuration

### DIFF
--- a/ucm2/USB-Audio/Audient/Audient-iD4-HiFi.conf
+++ b/ucm2/USB-Audio/Audient/Audient-iD4-HiFi.conf
@@ -1,0 +1,122 @@
+LibraryConfig.pcm.Config {
+	pcm.id4_stereo_out {
+		@args [ CARD CHN0 CHN1 ]
+		@args {
+			CARD.type string
+			CHN0.type integer
+			CHN1.type integer
+		}
+		type dshare
+		ipc_key 5678493
+		ipc_perm 0600
+		slave {
+			pcm {
+				type hw
+				card $CARD
+				device 0
+			}
+			channels 4
+		}
+		bindings.0 $CHN0
+		bindings.1 $CHN1
+	}
+
+	pcm.id4_stereo_in {
+		@args [ CARD CHN0 CHN1 ]
+		@args {
+			CARD.type string
+			CHN0.type integer
+			CHN1.type integer
+		}
+		type dsnoop
+		ipc_key 5678493
+		ipc_perm 0600
+		slave {
+			pcm {
+				type hw
+				card $CARD
+				device 0
+			}
+			channels 4
+		}
+		bindings.0 $CHN0
+		bindings.1 $CHN1
+	}
+
+	pcm.id4_monitor {
+		@args [ CARD ]
+		@args.CARD.type string
+		type empty
+		slave.pcm {
+			@func concat
+			strings [ "id4_stereo_out:" $CARD ",0,1" ]
+		}
+	}
+
+	pcm.id4_speaker {
+		@args [ CARD ]
+		@args.CARD.type string
+		type empty
+		slave.pcm {
+			@func concat
+			strings [ "id4_stereo_out:" $CARD ",2,3" ]
+		}
+	}
+
+	pcm.id4_mic {
+		@args [ CARD ]
+		@args.CARD.type string
+		type empty
+		slave.pcm {
+			@func concat
+			strings [ "id4_stereo_in:" $CARD ",0,1" ]
+		}
+	}
+
+	pcm.id4_di {
+		@args [ CARD ]
+		@args.CARD.type string
+		type empty
+		slave.pcm {
+			@func concat
+			strings [ "id4_stereo_in:" $CARD ",2,3" ]
+		}
+	}
+}
+
+SectionDevice."Speaker" {
+	Comment "Speaker"
+
+	Value {
+		PlaybackPriority 100
+		PlaybackPCM "id4_speaker:${CardId}"
+	}
+}
+
+SectionDevice."Headphones" {
+	Comment "Headphones / Monitor"
+
+	Value {
+		PlaybackPriority 200
+		PlaybackPCM "id4_monitor:${CardId}"
+	}
+}
+
+SectionDevice."Mic" {
+	Comment "XLR Microphone"
+
+	Value {
+		CapturePriority 200
+		CapturePCM "id4_mic:${CardId}"
+	}
+}
+
+SectionDevice."Line2" {
+	Comment "Line In"
+
+	Value {
+		CapturePriority 100
+		CapturePCM "id4_di:${CardId}"
+	}
+}
+

--- a/ucm2/USB-Audio/Audient/Audient-iD4.conf
+++ b/ucm2/USB-Audio/Audient/Audient-iD4.conf
@@ -1,0 +1,5 @@
+Comment "Audient iD4 USB-Audio"
+SectionUseCase."HiFi" {
+	Comment "Default Alsa Profile"
+	File "/USB-Audio/Audient/Audient-iD4-HiFi.conf"
+}

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -73,6 +73,15 @@ If.goxlr {
 	True.Define.ProfileName "GoXLR/GoXLR"
 }
 
+If.id4 {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB2708:0009"
+	}
+	True.Define.ProfileName "Audient/Audient-iD4"
+}
+
 If.lenovo-p620-rear {
 	Condition {
 		Type String


### PR DESCRIPTION
hardware represents 2 stereo inputs/outputs as a single multichannel
input/output, similar to 97beee6ded9e3dddfb56580eee360088fbfa8595 we
split it using dsnoop/dshare

Signed-off-by: Robert Günzler <r@gnzler.io>