### PR TITLE
Add "Pro Audio" profile for UMC204HD

### DIFF
--- a/ucm2/USB-Audio/Behringer/UMC204HD-ProAudio.conf
+++ b/ucm2/USB-Audio/Behringer/UMC204HD-ProAudio.conf
@@ -1,0 +1,36 @@
+LibraryConfig.generic.Config {
+	ctl.hw {
+		@args [ CARD ]
+		@args.CARD.type string
+		type hw
+		card $CARD
+	}
+
+	pcm.hw {
+		@args [ CARD ]
+		@args {
+			CARD.type string
+		}
+		type hw
+		card $CARD
+		device 0
+	}
+}
+
+SectionDevice."Output" {
+	Comment "UMC204HD 192k Multichannel Output"
+	Value {
+		PlaybackPriority 300
+		PlaybackChannels 4
+		PlaybackPCM "hw:${CardId}"
+	}
+}
+
+SectionDevice."Input" {
+	Comment "UMC204HD 192k Multichannel Input"
+	Value {
+		CapturePriority 300
+		CaptureChannels 2
+		CapturePCM "hw:${CardId}"
+    }
+}

--- a/ucm2/USB-Audio/Behringer/UMC204HD.conf
+++ b/ucm2/USB-Audio/Behringer/UMC204HD.conf
@@ -3,3 +3,8 @@ SectionUseCase."HiFi" {
 	Comment "Default"
 	File "/USB-Audio/Behringer/UMC204HD-HiFi.conf"
 }
+
+SectionUseCase."ProAudio" {
+    Comment "Pro Audio"
+    File "/USB-Audio/Behringer/UMC204HD-ProAudio.conf"
+}


### PR DESCRIPTION
Follow-up to #128 

I figured that some users might prefer to keep the channel mapping untouched from what the card defaults to when unconfigured. Providing an alternative profile like this (implementation adapted from #145) for these users seems like a good idea.

I believe PipeWire autogenerates profiles like these for unconfigured devices, so that's where the "Pro Audio" nomenclature comes from. Likely a good idea to match that since PipeWire is increasingly the default on most distributions.