### PR TITLE
GoXLR: Fixed sampler input configuration

### DIFF
--- a/ucm2/USB-Audio/GoXLR/GoXLR-HiFi.conf
+++ b/ucm2/USB-Audio/GoXLR/GoXLR-HiFi.conf
@@ -114,13 +114,13 @@ LibraryConfig.pcm.Config {
 		}
 	}
 
-	pcm.goxlr_sample_input {
+	pcm.goxlr_sampler_input {
 		@args [ CARD ]
 		@args.CARD.type string
 		type empty
 		slave.pcm {
 			@func concat
-			strings [ "goxlr_stereo_in:" $CARD ",16,17" ]
+			strings [ "goxlr_stereo_in:" $CARD ",4,5" ]
 		}
 	}
 
@@ -190,10 +190,10 @@ SectionDevice."Headset" {
 }
 
 SectionDevice."Line5" {
-	Comment "Sample"
+	Comment "Sampler"
 
 	Value {
 		CapturePriority 300
-		CapturePCM "goxlr_sample_input:${CardId}"
+		CapturePCM "goxlr_sampler_input:${CardId}"
 	}
 }


### PR DESCRIPTION
Renamed the 'Sample' input channel to 'Sampler' to better reflect it's behaviour, and corrected channel numbers. This fixes sampler capture on the GoXLR.