### PR TITLE
ucm2 profile for MOTU M4 interface

### DIFF
--- a/ucm2/USB-Audio/MOTU/M4-HiFi-Stereo-Mono.conf
+++ b/ucm2/USB-Audio/MOTU/M4-HiFi-Stereo-Mono.conf
@@ -1,0 +1,139 @@
+Include.pcm_split.File "/common/pcm/split.conf"
+
+Macro [
+	{
+		SplitPCM {
+			Name "m4_stereo_out"
+			Direction Playback
+			Channels 2
+			HWChannels 4
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 FC
+			HWChannelPos3 LFE
+		}
+	}
+	{
+		SplitPCM {
+			Name "m4_mono_in"
+			Direction Capture
+			Channels 1
+			HWChannels 4
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 FC
+			HWChannelPos3 LFE
+		}
+	}
+]
+
+SectionDevice."Line1-2" {
+	Comment "Headphone + Monitor Out"
+	Value {
+		PlaybackPriority 200
+		PlaybackMixer "default:${CardId}"
+		PlaybackMixerElem "Line A"
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "m4_stereo_out"
+		Direction Playback
+		HWChannels 4
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line3-4" {
+	Comment "Line Out"
+
+	Value {
+		PlaybackPriority 100
+		PlaybackMixer "default:${CardId}"
+		PlaybackMixerElem "Line B"
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "m4_stereo_out"
+		Direction Playback
+		HWChannels 4
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."In1L" {
+	Comment "Mic In 1L"
+
+	Value {
+		CapturePriority 200
+		CaptureMixer "default:${CardId}"
+		CaptureMixerElem "Input 1"
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "m4_mono_in"
+		Direction Capture
+		HWChannels 4
+		Channels 1
+		Channel0 0
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."In2R" {
+	Comment "Mic In 2R"
+
+	Value {
+		CapturePriority 100
+		CaptureMixer "default:${CardId}"
+		CaptureMixerElem "Input 2"
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "m4_mono_in"
+		Direction Capture
+		HWChannels 4
+		Channels 1
+		Channel0 1
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."LineInL" {
+	Comment "Line In L"
+
+	Value {
+		CapturePriority 100
+		CaptureMixer "default:${CardId}"
+		CaptureMixerElem "Input 3"
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "m4_mono_in"
+		Direction Capture
+		HWChannels 4
+		Channels 1
+		Channel0 2
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."LineInR" {
+	Comment "Line In R"
+
+	Value {
+		CapturePriority 100
+		CaptureMixer "default:${CardId}"
+		CaptureMixerElem "Input 4"
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "m4_mono_in"
+		Direction Capture
+		HWChannels 4
+		Channels 1
+		Channel0 3
+		ChannelPos0 MONO
+	}
+}

--- a/ucm2/USB-Audio/MOTU/M4-HiFi-Stereo-Mono.conf
+++ b/ucm2/USB-Audio/MOTU/M4-HiFi-Stereo-Mono.conf
@@ -27,7 +27,7 @@ Macro [
 	}
 ]
 
-SectionDevice."Line1-2" {
+SectionDevice."Line1" {
 	Comment "Headphone + Monitor Out"
 	Value {
 		PlaybackPriority 200
@@ -46,7 +46,7 @@ SectionDevice."Line1-2" {
 	}
 }
 
-SectionDevice."Line3-4" {
+SectionDevice."Line2" {
 	Comment "Line Out"
 
 	Value {
@@ -66,7 +66,7 @@ SectionDevice."Line3-4" {
 	}
 }
 
-SectionDevice."In1L" {
+SectionDevice."Mic1" {
 	Comment "Mic In 1L"
 
 	Value {
@@ -84,7 +84,7 @@ SectionDevice."In1L" {
 	}
 }
 
-SectionDevice."In2R" {
+SectionDevice."Mic2" {
 	Comment "Mic In 2R"
 
 	Value {
@@ -102,7 +102,7 @@ SectionDevice."In2R" {
 	}
 }
 
-SectionDevice."LineInL" {
+SectionDevice."Mic3" {
 	Comment "Line In L"
 
 	Value {
@@ -120,7 +120,7 @@ SectionDevice."LineInL" {
 	}
 }
 
-SectionDevice."LineInR" {
+SectionDevice."Mic4" {
 	Comment "Line In R"
 
 	Value {

--- a/ucm2/USB-Audio/MOTU/M4-HiFi.conf
+++ b/ucm2/USB-Audio/MOTU/M4-HiFi.conf
@@ -9,8 +9,8 @@ Macro [
 			HWChannels 4
 			HWChannelPos0 FL
 			HWChannelPos1 FR
-			HWChannelPos2 FC
-			HWChannelPos3 LFE
+			HWChannelPos2 FL
+			HWChannelPos3 FR
 		}
 	}
 	{
@@ -19,10 +19,22 @@ Macro [
 			Direction Capture
 			Channels 1
 			HWChannels 4
+			HWChannelPos0 MONO
+			HWChannelPos1 MONO
+			HWChannelPos2 MONO
+			HWChannelPos3 MONO
+		}
+	}
+	{
+		SplitPCM {
+			Name "m4_stereo_in"
+			Direction Capture
+			Channels 2
+			HWChannels 4
 			HWChannelPos0 FL
 			HWChannelPos1 FR
-			HWChannelPos2 FC
-			HWChannelPos3 LFE
+			HWChannelPos2 FL
+			HWChannelPos3 FR
 		}
 	}
 ]
@@ -31,8 +43,6 @@ SectionDevice."Line1" {
 	Comment "Headphone + Monitor Out"
 	Value {
 		PlaybackPriority 200
-		PlaybackMixer "default:${CardId}"
-		PlaybackMixerElem "Line A"
 	}
 	Macro.pcm_split.SplitPCMDevice {
 		Name "m4_stereo_out"
@@ -51,8 +61,6 @@ SectionDevice."Line2" {
 
 	Value {
 		PlaybackPriority 100
-		PlaybackMixer "default:${CardId}"
-		PlaybackMixerElem "Line B"
 	}
 	Macro.pcm_split.SplitPCMDevice {
 		Name "m4_stereo_out"
@@ -71,8 +79,6 @@ SectionDevice."Mic1" {
 
 	Value {
 		CapturePriority 200
-		CaptureMixer "default:${CardId}"
-		CaptureMixerElem "Input 1"
 	}
 	Macro.pcm_split.SplitPCMDevice {
 		Name "m4_mono_in"
@@ -89,8 +95,6 @@ SectionDevice."Mic2" {
 
 	Value {
 		CapturePriority 100
-		CaptureMixer "default:${CardId}"
-		CaptureMixerElem "Input 2"
 	}
 	Macro.pcm_split.SplitPCMDevice {
 		Name "m4_mono_in"
@@ -107,8 +111,6 @@ SectionDevice."Mic3" {
 
 	Value {
 		CapturePriority 100
-		CaptureMixer "default:${CardId}"
-		CaptureMixerElem "Input 3"
 	}
 	Macro.pcm_split.SplitPCMDevice {
 		Name "m4_mono_in"
@@ -125,8 +127,6 @@ SectionDevice."Mic4" {
 
 	Value {
 		CapturePriority 100
-		CaptureMixer "default:${CardId}"
-		CaptureMixerElem "Input 4"
 	}
 	Macro.pcm_split.SplitPCMDevice {
 		Name "m4_mono_in"
@@ -137,3 +137,40 @@ SectionDevice."Mic4" {
 		ChannelPos0 MONO
 	}
 }
+
+SectionDevice."Mic5" {
+	Comment "Stereo Mic In 1L+1R"
+
+	Value {
+		CapturePriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "m4_stereo_in"
+		Direction Capture
+		HWChannels 4
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Mic6" {
+	Comment "Stereo Line In L+R"
+
+	Value {
+		CapturePriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "m4_stereo_in"
+		Direction Capture
+		HWChannels 4
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+

--- a/ucm2/USB-Audio/MOTU/M4-HiFi.conf
+++ b/ucm2/USB-Audio/MOTU/M4-HiFi.conf
@@ -106,7 +106,7 @@ SectionDevice."Mic2" {
 	}
 }
 
-SectionDevice."Mic3" {
+SectionDevice."Line3" {
 	Comment "Line In L"
 
 	Value {
@@ -122,7 +122,7 @@ SectionDevice."Mic3" {
 	}
 }
 
-SectionDevice."Mic4" {
+SectionDevice."Line4" {
 	Comment "Line In R"
 
 	Value {
@@ -138,8 +138,13 @@ SectionDevice."Mic4" {
 	}
 }
 
-SectionDevice."Mic5" {
+SectionDevice."Mic3" {
 	Comment "Stereo Mic In 1L+1R"
+
+	ConflictingDevice [
+		"Mic1"
+		"Mic2"
+	]
 
 	Value {
 		CapturePriority 100
@@ -156,8 +161,13 @@ SectionDevice."Mic5" {
 	}
 }
 
-SectionDevice."Mic6" {
+SectionDevice."Line5" {
 	Comment "Stereo Line In L+R"
+
+	ConflictingDevice [
+		"Line3"
+		"Line4"
+	]
 
 	Value {
 		CapturePriority 100

--- a/ucm2/USB-Audio/MOTU/M4.conf
+++ b/ucm2/USB-Audio/MOTU/M4.conf
@@ -1,0 +1,12 @@
+Comment "MOTU M4"
+
+SectionUseCase."HiFi" {
+	Comment "Analog Stereo Outputs + Mono Inputs"
+	File "/USB-Audio/MOTU/M4-HiFi-Stereo-Mono.conf"
+}
+
+Define.DirectPlaybackChannels 4
+Define.DirectCaptureChannels 4
+
+Include.dhw.File "/common/direct.conf"
+

--- a/ucm2/USB-Audio/MOTU/M4.conf
+++ b/ucm2/USB-Audio/MOTU/M4.conf
@@ -1,8 +1,8 @@
 Comment "MOTU M4"
 
 SectionUseCase."HiFi" {
-	Comment "Analog Stereo Outputs + Mono Inputs"
-	File "/USB-Audio/MOTU/M4-HiFi-Stereo-Mono.conf"
+	Comment "Analog Stereo Outputs + Inputs"
+	File "/USB-Audio/MOTU/M4-HiFi.conf"
 }
 
 Define.DirectPlaybackChannels 4

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -145,6 +145,15 @@ If.id4 {
 	True.Define.ProfileName "Audient/Audient-iD4"
 }
 
+If.M4 {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB07fd:000b"
+	}
+	True.Define.ProfileName "MOTU/M4"
+}
+
 If.mixremap {
 	Condition {
 		Type String

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -61,6 +61,15 @@ If.steinberg-ur44 {
 	True.Define.ProfileName "Steinberg/UR44"
 }
 
+If.M4 {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB07fd:000b"
+	}
+	True.Define.ProfileName "MOTU/M4"
+}
+
 If.dell-wd15 {
 	Condition {
 		Type RegexMatch
@@ -143,15 +152,6 @@ If.id4 {
 		Needle "USB2708:0009"
 	}
 	True.Define.ProfileName "Audient/Audient-iD4"
-}
-
-If.M4 {
-	Condition {
-		Type String
-		Haystack "${CardComponents}"
-		Needle "USB07fd:000b"
-	}
-	True.Define.ProfileName "MOTU/M4"
 }
 
 If.mixremap {


### PR DESCRIPTION
This is the initial ucm2 profile for MOTU M4 interface. This creates a default profile with 2 separate line-outs and 4 line-ins/mic. The profile follows the device IO design and covers the most default use cases. For the rest, direct.conf is included so the pro profile in pipewire will be accessible for more complex use-cases.

MOTU M4 is a 4×4 interface. It has 4 simultaneous inputs and outputs.  For input, there are 2 combo jacks on the front that provide a preamp with XLR connectivity for microphones, as well as 1/4″ Hi-Z compatibility. Rounding out the inputs are a pair of Line Ins on the back of the interface.

For outputs, it has two pairs of DC-coupled 1/4″ balanced outs; one is labeled Monitor and the other Line Out. Line Out can be sent to another pair of monitors, PA speakers, or any destination. Each pair of outputs is independent.

Additionally, there are two pairs of mirrored RCA outputs. Mirrored, in this case, means that they receive the same output that the Monitor outs and the Line Outs get. You can route those to more speakers, or another audio source with RCA inputs. MIDI in and out expands this interface’s abilities even further.

