### PR TITLE
ucm2 profile for Behringer Flow8

### DIFF
--- a/ucm2/USB-Audio/Behringer/Flow8-Recording-Hifi.conf
+++ b/ucm2/USB-Audio/Behringer/Flow8-Recording-Hifi.conf
@@ -153,11 +153,92 @@ SectionDevice."Mic4" {
 	}
 }
 
-SectionDevice."Line1" {
-	Comment "Line-56 L/R"
+SectionDevice."Line5" {
+	Comment "Line/Inst 5 (L)"
+
+	ConflictingDevice [
+		"Line56"
+	]
 
 	Value {
 		CapturePriority 104
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "flow8_mono_in"
+		Direction Capture
+		HWChannels 10
+		Channels 1
+		Channel0 4
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Line6" {
+	Comment "Line/Inst(HiZ) 6 (R)"
+
+	ConflictingDevice [
+		"Line56"
+	]
+
+	Value {
+		CapturePriority 105
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "flow8_mono_in"
+		Direction Capture
+		HWChannels 10
+		Channels 1
+		Channel0 5
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Line7" {
+	Comment "Line/Inst 7 (L)"
+
+	ConflictingDevice [
+		"Line78"
+	]
+
+	Value {
+		CapturePriority 106
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "flow8_mono_in"
+		Direction Capture
+		HWChannels 10
+		Channels 1
+		Channel0 6
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Line8" {
+	Comment "Line/Inst(HiZ) 8 (R)"
+
+	ConflictingDevice [
+		"Line78"
+	]
+
+	Value {
+		CapturePriority 107
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "flow8_mono_in"
+		Direction Capture
+		HWChannels 10
+		Channels 1
+		Channel0 7
+		ChannelPos0 MONO
+	}
+}
+
+
+SectionDevice."Line56" {
+	Comment "Line-56 L/R"
+
+	Value {
+		CapturePriority 108
 	}
 	Macro.pcm_split.SplitPCMDevice {
 		Name "flow8_stereo_in"
@@ -165,17 +246,17 @@ SectionDevice."Line1" {
 		HWChannels 10
 		Channels 2
 		Channel0 4
-		Channel0 5
+		Channel1 5
 		ChannelPos0 FL
 		ChannelPos1 FR
 	}
 }
 
-SectionDevice."Line2" {
+SectionDevice."Line78" {
 	Comment "Line-78 L/R"
 
 	Value {
-		CapturePriority 105
+		CapturePriority 109
 	}
 	Macro.pcm_split.SplitPCMDevice {
 		Name "flow8_stereo_in"
@@ -183,17 +264,17 @@ SectionDevice."Line2" {
 		HWChannels 10
 		Channels 2
 		Channel0 6
-		Channel0 7
+		Channel1 7
 		ChannelPos0 FL
 		ChannelPos1 FR
 	}
 }
 
-SectionDevice."Line3" {
+SectionDevice."LineMaster" {
 	Comment "Master/Monitor L/R"
 
 	Value {
-		CapturePriority 104
+		CapturePriority 110
 	}
 	Macro.pcm_split.SplitPCMDevice {
 		Name "flow8_stereo_in"
@@ -201,7 +282,7 @@ SectionDevice."Line3" {
 		HWChannels 10
 		Channels 2
 		Channel0 8
-		Channel0 9
+		Channel1 9
 		ChannelPos0 FL
 		ChannelPos1 FR
 	}

--- a/ucm2/USB-Audio/Behringer/Flow8-Recording-Hifi.conf
+++ b/ucm2/USB-Audio/Behringer/Flow8-Recording-Hifi.conf
@@ -1,0 +1,208 @@
+Include.pcm_split.File "/common/pcm/split.conf"
+
+Macro [
+	{
+		SplitPCM {
+			Name "flow8_stereo_out"
+			Direction Playback
+			Channels 2
+			HWChannels 4
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 FL
+			HWChannelPos3 FR
+		}
+	}
+	{
+		SplitPCM {
+			Name "flow8_stereo_in"
+			Direction Capture
+			Channels 2
+			HWChannels 10
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 FL
+			HWChannelPos3 FR
+			HWChannelPos4 FL
+			HWChannelPos5 FR
+			HWChannelPos6 FL
+			HWChannelPos7 FR
+			HWChannelPos8 FL
+			HWChannelPos9 FR
+		}
+	}
+	{
+		SplitPCM {
+			Name "flow8_mono_in"
+			Direction Capture
+			Channels 1
+			HWChannels 10
+			HWChannelPos0 MONO
+			HWChannelPos1 MONO
+			HWChannelPos2 MONO
+			HWChannelPos3 MONO
+			HWChannelPos4 MONO
+			HWChannelPos5 MONO
+			HWChannelPos6 MONO
+			HWChannelPos7 MONO
+			HWChannelPos8 MONO
+			HWChannelPos9 MONO
+		}
+	}
+]
+
+SectionDevice."Line1" {
+	Comment "USB-12 L/R"
+
+	Value {
+		PlaybackPriority 100
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "flow8_stereo_out"
+		Direction Playback
+		HWChannels 4
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line2" {
+	Comment "USB-34 L/R"
+
+	Value {
+		PlaybackPriority 200
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "flow8_stereo_out"
+		Direction Playback
+		HWChannels 4
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Mic1" {
+	Comment "Mic 1"
+
+	Value {
+		CapturePriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "flow8_mono_in"
+		Direction Capture
+		HWChannels 10
+		Channels 1
+		Channel0 0
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Mic2" {
+	Comment "Mic 2"
+
+	Value {
+		CapturePriority 101
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "flow8_mono_in"
+		Direction Capture
+		HWChannels 10
+		Channels 1
+		Channel0 1
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Mic3" {
+	Comment "Mic 3"
+
+	Value {
+		CapturePriority 102
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "flow8_mono_in"
+		Direction Capture
+		HWChannels 10
+		Channels 1
+		Channel0 2
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Mic4" {
+	Comment "Mic 4"
+
+	Value {
+		CapturePriority 103
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "flow8_mono_in"
+		Direction Capture
+		HWChannels 10
+		Channels 1
+		Channel0 3
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Line1" {
+	Comment "Line-56 L/R"
+
+	Value {
+		CapturePriority 104
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "flow8_stereo_in"
+		Direction Capture
+		HWChannels 10
+		Channels 2
+		Channel0 4
+		Channel0 5
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line2" {
+	Comment "Line-78 L/R"
+
+	Value {
+		CapturePriority 105
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "flow8_stereo_in"
+		Direction Capture
+		HWChannels 10
+		Channels 2
+		Channel0 6
+		Channel0 7
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line3" {
+	Comment "Master/Monitor L/R"
+
+	Value {
+		CapturePriority 104
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "flow8_stereo_in"
+		Direction Capture
+		HWChannels 10
+		Channels 2
+		Channel0 8
+		Channel0 9
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}

--- a/ucm2/USB-Audio/Behringer/Flow8-Recording.conf
+++ b/ucm2/USB-Audio/Behringer/Flow8-Recording.conf
@@ -7,5 +7,3 @@ SectionUseCase."Recording" {
 
 Define.DirectPlaybackChannels 4
 Define.DirectCaptureChannels 10
-
-Include.dhw.File "/common/direct.conf"

--- a/ucm2/USB-Audio/Behringer/Flow8-Recording.conf
+++ b/ucm2/USB-Audio/Behringer/Flow8-Recording.conf
@@ -1,0 +1,11 @@
+Comment "Behringer Flow8 Recording Mode"
+
+SectionUseCase."Recording" {
+        Comment "Recording Mode (4 chan output, 10 chan input)"
+        File "/USB-Audio/Behringer/Flow8-Recording-Hifi.conf"
+}
+
+Define.DirectPlaybackChannels 4
+Define.DirectCaptureChannels 10
+
+Include.dhw.File "/common/direct.conf"

--- a/ucm2/USB-Audio/Behringer/Flow8-Streaming-Hifi.conf
+++ b/ucm2/USB-Audio/Behringer/Flow8-Streaming-Hifi.conf
@@ -17,8 +17,8 @@ LibraryConfig.pcm.Config {
 			}
 			channels 4
 			period_time 0
-            period_size 16
-            buffer_size 128
+			period_size 64
+			buffer_size 512
 			rate 48000
 		}
 		bindings.0 $CHN0
@@ -80,34 +80,34 @@ LibraryConfig.pcm.Config {
 
 
 SectionDevice."Line1" {
-    Comment "USB-12"
-    Value {
-        PlaybackPriority 100
-        PlaybackChannels 2
-        PlaybackPCM "flow8_usb12:${CardId}"
-        PlaybackMixerElem "Flow8-USB12"
-    }
+	Comment "USB-12"
+	Value {
+		PlaybackPriority 100
+		PlaybackChannels 2
+		PlaybackPCM "flow8_usb12:${CardId}"
+		PlaybackMixerElem "Flow8-USB12"
+	}
 }
 
 SectionDevice."Line2" {
-    Comment "USB-34"
+	Comment "USB-34"
 
-    Value {
-        PlaybackPriority 200
-        PlaybackChannels 2
-        PlaybackPCM "flow8_usb34:${CardId}"
-        PlaybackMixerElem "Flow8-USB34"
-    }
+	Value {
+		PlaybackPriority 200
+		PlaybackChannels 2
+		PlaybackPCM "flow8_usb34:${CardId}"
+		PlaybackMixerElem "Flow8-USB34"
+	}
 }
 
 SectionDevice."LineIn" {
-    Comment "Master"
+	Comment "Master"
 
-    Value {
-        CapturePriority 200
-        CaptureChannels 2
-        CapturePCM "flow8_master:${CardId}"
-        CaptureMixerElem "Flow8-Master"
-    }
+	Value {
+		CapturePriority 200
+		CaptureChannels 2
+		CapturePCM "flow8_master:${CardId}"
+		CaptureMixerElem "Flow8-Master"
+	}
 }
 

--- a/ucm2/USB-Audio/Behringer/Flow8-Streaming-Hifi.conf
+++ b/ucm2/USB-Audio/Behringer/Flow8-Streaming-Hifi.conf
@@ -1,113 +1,82 @@
+Include.pcm_split.File "/common/pcm/split.conf"
 
-LibraryConfig.pcm.Config {
-	pcm.flow8_usb_out {
-		@args [ CARD CHN0 CHN1 ]
-		@args {
-			CARD.type string
-			CHN0.type integer
-			CHN1.type integer
-		}
-		type dshare
-		ipc_key 572442
-		slave {
-			pcm {
-				type hw
-				card $CARD
-				device 0
-			}
-			channels 4
-			period_time 0
-			period_size 64
-			buffer_size 512
-			rate 48000
-		}
-		bindings.0 $CHN0
-		bindings.1 $CHN1
-	}
-
-	pcm.flow8_usb_input {
-		@args [ CARD CHN0 CHN1 ]
-		@args {
-			CARD.type string
-			CHN0.type integer
-			CHN1.type integer
-		}
-		type dsnoop
-		ipc_key 572542
-		slave {
-			pcm {
-				type hw
-				card $CARD
-				device 0
-			}
-			channels 2
-			rate 48000
-		}
-		bindings.0 $CHN0
-		bindings.1 $CHN1
-	}
-	pcm.flow8_usb12 {
-		@args [ CARD ]
-		@args.CARD.type string
-		type empty
-		slave.pcm {
-			@func concat
-			strings [ "flow8_usb_out:" $CARD ",0,1" ]
+Macro [
+	{
+		SplitPCM {
+			Name "flow8_stereo_out"
+			Direction Playback
+			Channels 2
+			HWChannels 4
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 FL
+			HWChannelPos3 FR
 		}
 	}
-
-	pcm.flow8_usb34 {
-		@args [ CARD ]
-		@args.CARD.type string
-		type empty
-		slave.pcm {
-			@func concat
-			strings [ "flow8_usb_out:" $CARD ",2,3" ]
+	{
+		SplitPCM {
+			Name "flow8_stereo_in"
+			Direction Capture
+			Channels 2
+			HWChannels 2
+			HWChannelPos0 FL
+			HWChannelPos1 FR
 		}
 	}
-
-	pcm.flow8_master {
-		@args [ CARD ]
-		@args.CARD.type string
-		type empty
-		slave.pcm {
-			@func concat
-			strings [ "flow8_usb_input:" $CARD ",0,1" ]
-		}
-	}
-
-}
-
+]
 
 SectionDevice."Line1" {
-	Comment "USB-12"
+	Comment "USB-12 L/R"
+
 	Value {
 		PlaybackPriority 100
-		PlaybackChannels 2
-		PlaybackPCM "flow8_usb12:${CardId}"
-		PlaybackMixerElem "Flow8-USB12"
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "flow8_stereo_out"
+		Direction Playback
+		HWChannels 4
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
 	}
 }
 
 SectionDevice."Line2" {
-	Comment "USB-34"
+	Comment "USB-34 L/R"
 
 	Value {
 		PlaybackPriority 200
-		PlaybackChannels 2
-		PlaybackPCM "flow8_usb34:${CardId}"
-		PlaybackMixerElem "Flow8-USB34"
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "flow8_stereo_out"
+		Direction Playback
+		HWChannels 4
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
 	}
 }
 
-SectionDevice."LineIn" {
-	Comment "Master"
+SectionDevice."Line3" {
+	Comment "Master/Mon L/R"
 
 	Value {
-		CapturePriority 200
-		CaptureChannels 2
-		CapturePCM "flow8_master:${CardId}"
-		CaptureMixerElem "Flow8-Master"
+		CapturePriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "flow8_stereo_in"
+		Direction Capture
+		HWChannels 2
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
 	}
 }
-

--- a/ucm2/USB-Audio/Behringer/Flow8-Streaming-Hifi.conf
+++ b/ucm2/USB-Audio/Behringer/Flow8-Streaming-Hifi.conf
@@ -1,0 +1,113 @@
+
+LibraryConfig.pcm.Config {
+	pcm.flow8_usb_out {
+		@args [ CARD CHN0 CHN1 ]
+		@args {
+			CARD.type string
+			CHN0.type integer
+			CHN1.type integer
+		}
+		type dshare
+		ipc_key 572442
+		slave {
+			pcm {
+				type hw
+				card $CARD
+				device 0
+			}
+			channels 4
+			period_time 0
+            period_size 16
+            buffer_size 128
+			rate 48000
+		}
+		bindings.0 $CHN0
+		bindings.1 $CHN1
+	}
+
+	pcm.flow8_usb_input {
+		@args [ CARD CHN0 CHN1 ]
+		@args {
+			CARD.type string
+			CHN0.type integer
+			CHN1.type integer
+		}
+		type dsnoop
+		ipc_key 572542
+		slave {
+			pcm {
+				type hw
+				card $CARD
+				device 0
+			}
+			channels 2
+			rate 48000
+		}
+		bindings.0 $CHN0
+		bindings.1 $CHN1
+	}
+	pcm.flow8_usb12 {
+		@args [ CARD ]
+		@args.CARD.type string
+		type empty
+		slave.pcm {
+			@func concat
+			strings [ "flow8_usb_out:" $CARD ",0,1" ]
+		}
+	}
+
+	pcm.flow8_usb34 {
+		@args [ CARD ]
+		@args.CARD.type string
+		type empty
+		slave.pcm {
+			@func concat
+			strings [ "flow8_usb_out:" $CARD ",2,3" ]
+		}
+	}
+
+	pcm.flow8_master {
+		@args [ CARD ]
+		@args.CARD.type string
+		type empty
+		slave.pcm {
+			@func concat
+			strings [ "flow8_usb_input:" $CARD ",0,1" ]
+		}
+	}
+
+}
+
+
+SectionDevice."Line1" {
+    Comment "USB-12"
+    Value {
+        PlaybackPriority 100
+        PlaybackChannels 2
+        PlaybackPCM "flow8_usb12:${CardId}"
+        PlaybackMixerElem "Flow8-USB12"
+    }
+}
+
+SectionDevice."Line2" {
+    Comment "USB-34"
+
+    Value {
+        PlaybackPriority 200
+        PlaybackChannels 2
+        PlaybackPCM "flow8_usb34:${CardId}"
+        PlaybackMixerElem "Flow8-USB34"
+    }
+}
+
+SectionDevice."LineIn" {
+    Comment "Master"
+
+    Value {
+        CapturePriority 200
+        CaptureChannels 2
+        CapturePCM "flow8_master:${CardId}"
+        CaptureMixerElem "Flow8-Master"
+    }
+}
+

--- a/ucm2/USB-Audio/Behringer/Flow8-Streaming.conf
+++ b/ucm2/USB-Audio/Behringer/Flow8-Streaming.conf
@@ -1,6 +1,11 @@
 Comment "Behringer Flow8 Streaming Mode"
 
 SectionUseCase."Streaming" {
-        Comment "Streaming Mode (4 chan input, 2 chan output)"
+        Comment "Streaming Mode (4 chan output, 2 chan input)"
         File "/USB-Audio/Behringer/Flow8-Streaming-Hifi.conf"
 }
+
+Define.DirectPlaybackChannels 4
+Define.DirectCaptureChannels 2
+
+Include.dhw.File "/common/direct.conf"

--- a/ucm2/USB-Audio/Behringer/Flow8-Streaming.conf
+++ b/ucm2/USB-Audio/Behringer/Flow8-Streaming.conf
@@ -7,5 +7,3 @@ SectionUseCase."Streaming" {
 
 Define.DirectPlaybackChannels 4
 Define.DirectCaptureChannels 2
-
-Include.dhw.File "/common/direct.conf"

--- a/ucm2/USB-Audio/Behringer/Flow8-Streaming.conf
+++ b/ucm2/USB-Audio/Behringer/Flow8-Streaming.conf
@@ -1,0 +1,6 @@
+Comment "Behringer Flow8 Streaming Mode"
+
+SectionUseCase."Streaming" {
+        Comment "Streaming Mode (4 chan input, 2 chan output)"
+        File "/USB-Audio/Behringer/Flow8-Streaming-Hifi.conf"
+}

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -118,6 +118,15 @@ If.behringer-Flow8-Streaming {
 	True.Define.ProfileName "Behringer/Flow8-Streaming"
 }
 
+If.behringer-Flow8-Recording {
+	Condition {
+	Type String
+	Haystack "${CardComponents}"
+		Needle "USB1397:050c"
+	}
+	True.Define.ProfileName "Behringer/Flow8-Recording"
+}
+
 If.lenovo-p620-rear {
 	Condition {
 		Type String

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -109,6 +109,15 @@ If.behringer-umc204hd {
 	}
 }
 
+If.behringer-Flow8-Streaming {
+	Condition {
+	Type String
+	Haystack "${CardComponents}"
+		Needle "USB1397:050d"
+	}
+	True.Define.ProfileName "Behringer/Flow8-Streaming"
+}
+
 If.lenovo-p620-rear {
 	Condition {
 		Type String


### PR DESCRIPTION
- kudos to Pekka Oinas for supporting me finding the right settings
- provides an UCM2 profile for Behringer's digital mixer Flow8
  configured into "streaming" mode
- 2 stereo outputs, 1 stereo input, when vendor ID product ID are `1397:050d`
- prepare filenames for Flow8's recording mode `1397:050c` (10 chan input, 4 chan output)