### PR TITLE
ucm2: rk3399-gru-sound: Add missing symlink from conf.d tree

### DIFF
--- a/ucm2/conf.d/rk3399-gru-soun/rk3399-gru-soun.conf
+++ b/ucm2/conf.d/rk3399-gru-soun/rk3399-gru-soun.conf
@@ -1,0 +1,1 @@
+../../Rockchip/rk3399-gru-sound/rk3399-gru-sound.conf


### PR DESCRIPTION
Since V2Module lookup was disabled my rk3399-gru-kevin chromebook can't find the UCM it's supposed to use. This adds a `conf.d/rk3399-gru-soun/rk3399-gru-soun.conf` symlink for it. The name is not a typo:

    $ cat /proc/asound/cards
     0 [rk3399grusound ]: rk3399-gru-soun - rk3399-gru-sound
                          Unknown-UnknownProduct-

    $ strace -e trace=file pulseaudio 2>&1 | grep -i ucm2
    faccessat(AT_FDCWD, "/usr/share/alsa/ucm2/ucm.conf", R_OK) = 0
    openat(AT_FDCWD, "/usr/share/alsa/ucm2/ucm.conf", O_RDONLY) = 16
    openat(AT_FDCWD, "/usr/share/alsa/ucm2/lib/generic.conf", O_RDONLY) = 16
    faccessat(AT_FDCWD, "/usr/share/alsa/ucm2/conf.d/rk3399-gru-soun/Unknown-UnknownProduct-.conf", R_OK) = -1 ENOENT (No such file or directory)
    faccessat(AT_FDCWD, "/usr/share/alsa/ucm2/conf.d/rk3399-gru-soun/rk3399-gru-soun.conf", R_OK) = -1 ENOENT (No such file or directory)
    faccessat(AT_FDCWD, "/usr/share/alsa/ucm2/ucm.conf", R_OK) = 0
    openat(AT_FDCWD, "/usr/share/alsa/ucm2/ucm.conf", O_RDONLY) = 16
    openat(AT_FDCWD, "/usr/share/alsa/ucm2/lib/generic.conf", O_RDONLY) = 16
    faccessat(AT_FDCWD, "/usr/share/alsa/ucm2/conf.d/rk3399-gru-soun/Unknown-UnknownProduct-.conf", R_OK) = -1 ENOENT (No such file or directory)
    faccessat(AT_FDCWD, "/usr/share/alsa/ucm2/conf.d/rk3399-gru-soun/rk3399-gru-soun.conf", R_OK) = -1 ENOENT (No such file or directory)

(Ignore the `Unknown-UnknownProduct-`, that's because I'm using a custom unfinished U-Boot build. For more info there's an [older alsa-info output](https://alsa-project.org/db/?f=9b4102975fa9c0f109af6ad687c856c620d76909) I had uploaded)