### PR TITLE
Fixes for veyron chromebooks

### DIFF
--- a/ucm2/Rockchip/max98090/HiFi.conf
+++ b/ucm2/Rockchip/max98090/HiFi.conf
@@ -47,6 +47,7 @@ SectionDevice."Speaker" {
 	Value {
 		PlaybackPriority 100
 		PlaybackPCM "hw:${CardId}"
+		PlaybackVolume "Speaker Volume"
 	}
 
 	EnableSequence [
@@ -81,6 +82,8 @@ SectionDevice."Headphones" {
 	Value {
 		PlaybackPriority 200
 		PlaybackPCM "hw:${CardId}"
+		JackControl "Headphone Jack"
+		PlaybackVolume "Headphone Volume"
 	}
 
 	EnableSequence [

--- a/ucm2/conf.d/VEYRON-I2S/VEYRON-I2S.conf
+++ b/ucm2/conf.d/VEYRON-I2S/VEYRON-I2S.conf
@@ -1,0 +1,1 @@
+../../Rockchip/max98090/max98090.conf


### PR DESCRIPTION
Add PlaybackVolume and JackControl. I didn't add JackControl for headset mic because internal mic breaks after switching to headset and back

Add symlink to VEYRON-I2S, so ucm config will get probed