### PR TITLE
Add basic support for ALC4082 on ASUS ROG Maximus Z690 Hero

### DIFF
--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -35,10 +35,11 @@ If.realtek-alc4080 {
 		Type RegexMatch
 		String "${CardComponents}"
 		# 0b05:1996 ASUS on multiple boards (including ASUS ROG Maximus XIII)
+		# 0b05:1a27 ALC4082 on ASUS ROG Maximus Z690 Hero
 		# 0db0:1feb MSI Edge Wifi Z690
 		# 0db0:419c MSI MPG X570S Carbon Max Wifi
 		# 0db0:a073 MSI MAG X570S Torpedo Max
-		Regex "USB((0b05:1996)|(0db0:1feb)|(0db0:419c)|(0db0:a073))"
+		Regex "USB((0b05:(1996|1a27))|(0db0:1feb)|(0db0:419c)|(0db0:a073))"
 	}
 	True.Define.ProfileName "Realtek/ALC4080"
 }


### PR DESCRIPTION
This enables Microphone In in the rear jack and Headphones Out in the front panel jack on ASUS ROG Maximus Z690 Hero with Realtek ALC4082.

Things that still don't work:

- Microphone In on the front panel
- Side channel output on the Line In jack in 7.1 mode
- Rear channels and Center/Sub are swapped

Line In on the rear panel detects microphone plugged in. Actual input not tested (no line out device available; no input from microphone). S/PDIF not tested.

Related to https://github.com/alsa-project/alsa-ucm-conf/issues/165.