### PR TITLE
ucm2: add ALC4080 ID for Asus Z690-I Gaming Wifi

### DIFF
--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -36,10 +36,11 @@ If.realtek-alc4080 {
 		String "${CardComponents}"
 		# 0b05:1996 ASUS on multiple boards (including ASUS ROG Maximus XIII)
 		# 0b05:1a27 ALC4082 on ASUS ROG Maximus Z690 Hero
+		# 0b05:1a20 ASUS ROG STRIX Z690-I Gaming Wifi
 		# 0db0:1feb MSI Edge Wifi Z690
 		# 0db0:419c MSI MPG X570S Carbon Max Wifi
 		# 0db0:a073 MSI MAG X570S Torpedo Max
-		Regex "USB((0b05:(1996|1a27))|(0db0:1feb)|(0db0:419c)|(0db0:a073))"
+		Regex "USB((0b05:(1996|1a27|1a20))|(0db0:1feb)|(0db0:419c)|(0db0:a073))"
 	}
 	True.Define.ProfileName "Realtek/ALC4080"
 }


### PR DESCRIPTION
```
inxi -M
Machine:
  Type: Desktop System: ASUS product: N/A v: N/A serial: <superuser required>
  Mobo: ASUSTeK model: ROG STRIX Z690-I GAMING WIFI v: Rev 1.xx
    serial: <superuser required> UEFI: American Megatrends v: 1403
    date: 03/30/2022
```
```
aplay -l
**** List of PLAYBACK Hardware Devices ****
card 1: HDMI [HDA ATI HDMI], device 3: HDMI 0 [27GL850]
  Subdevices: 1/1
  Subdevice #0: subdevice #0
card 1: HDMI [HDA ATI HDMI], device 7: HDMI 1 [HDMI 1]
  Subdevices: 1/1
  Subdevice #0: subdevice #0
card 1: HDMI [HDA ATI HDMI], device 8: HDMI 2 [HDMI 2]
  Subdevices: 1/1
  Subdevice #0: subdevice #0
card 1: HDMI [HDA ATI HDMI], device 9: HDMI 3 [HDMI 3]
  Subdevices: 1/1
  Subdevice #0: subdevice #0
card 1: HDMI [HDA ATI HDMI], device 10: HDMI 4 [HDMI 4]
  Subdevices: 1/1
  Subdevice #0: subdevice #0
card 1: HDMI [HDA ATI HDMI], device 11: HDMI 5 [HDMI 5]
  Subdevices: 1/1
  Subdevice #0: subdevice #0
card 3: Audio [USB Audio], device 0: USB Audio [USB Audio]
  Subdevices: 1/1
  Subdevice #0: subdevice #0
card 3: Audio [USB Audio], device 1: USB Audio [USB Audio #1]
  Subdevices: 0/1
  Subdevice #0: subdevice #0
card 3: Audio [USB Audio], device 2: USB Audio [USB Audio #2]
  Subdevices: 1/1
  Subdevice #0: subdevice #0
card 3: Audio [USB Audio], device 3: USB Audio [USB Audio #3]
  Subdevices: 1/1
  Subdevice #0: subdevice #0
```
Card 3 is ALC4080
```
udevadm info -a -p /sys/class/sound/card3 | grep idVendor -m1
ATTRS{idVendor}=="0b05"
udevadm info -a -p /sys/class/sound/card3 | grep idProduct -m1
ATTRS{idProduct}=="1a20"
```

Rear panel line out and front panel headphone now work. Jack detection also working properly. Haven't tested any of the other inputs/outputs as I don't have suitable devices.