### PR TITLE
Add support for the Traktor Kontrol Z1

### DIFF
--- a/ucm2/USB-Audio/NativeInstruments/Traktor-Kontrol-Z1-Mixer.conf
+++ b/ucm2/USB-Audio/NativeInstruments/Traktor-Kontrol-Z1-Mixer.conf
@@ -1,0 +1,52 @@
+Include.pcm_split.File "/common/pcm/split.conf"
+
+Macro [
+	{
+		SplitPCM {
+			Name "z1_stereo_out"
+			Direction Playback
+			Channels 2
+			HWChannels 4
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 FL
+			HWChannelPos3 FR
+		}
+	}
+]
+
+SectionDevice."Line" {
+	Comment "Line Out"
+
+	Value {
+		PlaybackPriority 200
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "z1_stereo_out"
+		Direction Playback
+		HWChannels 4
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Headphone" {
+	Comment "Headphone Out"
+	Value {
+		PlaybackPriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "z1_stereo_out"
+		Direction Playback
+		HWChannels 4
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+

--- a/ucm2/USB-Audio/NativeInstruments/Traktor-Kontrol-Z1.conf
+++ b/ucm2/USB-Audio/NativeInstruments/Traktor-Kontrol-Z1.conf
@@ -1,0 +1,11 @@
+Comment "Traktor Kontrol Z1"
+
+SectionUseCase."Mixer" {
+	Comment "Default"
+	File "/USB-Audio/NativeInstruments/Traktor-Kontrol-Z1-Mixer.conf"
+}
+
+Define.DirectPlaybackChannels 2
+
+Include.dhw.File "/common/direct.conf"
+

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -157,6 +157,15 @@ If.lenovo-p620-main {
 	True.Define.ProfileName "Lenovo/ThinkStation-P620-Main"
 }
 
+If.kontrolz1 {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB17cc:1210"
+	}
+	True.Define.ProfileName "NativeInstruments/Traktor-Kontrol-Z1"
+}
+
 If.minifuse2 {
 	Condition {
 		Type String

--- a/ucm2/common/direct-verb.conf
+++ b/ucm2/common/direct-verb.conf
@@ -4,7 +4,7 @@ SectionDevice."Direct" {
 		If.p {
 			Condition {
 				Type String
-				Empty "${var:DirectPlaybackChannels}"
+				Empty "${var:-DirectPlaybackChannels}"
 			}
 			False {
 				PlaybackPriority 1000
@@ -15,7 +15,7 @@ SectionDevice."Direct" {
 		If.c {
 			Condition {
 				Type String
-				Empty "${var:DirectCaptureChannels}"
+				Empty "${var:-DirectCaptureChannels}"
 			}
 			False {
 				CapturePriority 1000


### PR DESCRIPTION
This is a small DJ mixer with a main output and a monitor output.
The outputs appear as a single subdevice, we use the SplitPCM macros to present separate outputs.
    
https://www.native-instruments.com/en/products/traktor/dj-controllers/traktor-kontrol-z1/specifications/