### PR TITLE
Add correct support for Rane SL-1

### DIFF
--- a/ucm2/USB-Audio/Rane/SL-1-HiFi.conf
+++ b/ucm2/USB-Audio/Rane/SL-1-HiFi.conf
@@ -1,0 +1,45 @@
+SectionDevice."Line1" {
+	Comment "Line out 1"
+
+	Value {
+		PlaybackPriority 200
+		PlaybackPCM "hw:${CardId},0"
+	}
+}
+
+SectionDevice."Line2" {
+	Comment "Line out 2"
+
+	Value {
+		PlaybackPriority 100
+		PlaybackPCM "hw:${CardId},1"
+	}
+}
+
+SectionDevice."Mic1" {
+	Comment "Input 1"
+
+	Value {
+		CapturePriority 300
+		CapturePCM "hw:${CardId},0"
+	}
+}
+
+SectionDevice."Mic2" {
+	Comment "Input 2"
+
+	Value {
+		CapturePriority 200
+		CapturePCM "hw:${CardId},1"
+	}
+}
+
+SectionDevice."Mic3" {
+	Comment "Mic"
+
+	Value {
+		CapturePriority 100
+		CapturePCM "hw:${CardId},2"
+		CaptureChannels 1
+	}
+}

--- a/ucm2/USB-Audio/Rane/SL-1.conf
+++ b/ucm2/USB-Audio/Rane/SL-1.conf
@@ -1,0 +1,6 @@
+Comment "Rane SL-1"
+
+SectionUseCase."HiFi" {
+	Comment "Default Alsa Profile"
+	File "/USB-Audio/Rane/SL-1-HiFi.conf"
+}

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -184,6 +184,15 @@ If.id4-0009 {
 	True.Define.ProfileName "Audient/Audient-iD4-0009"
 }
 
+If.Rane-SL-1 {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB13e5:0001"
+	}
+	True.Define.ProfileName "Rane/SL-1"
+}
+
 If.mixremap {
 	Condition {
 		Type String


### PR DESCRIPTION
Following [this ticket](https://bugzilla.kernel.org/show_bug.cgi?id=216082) on kernel bugzilla, I'm trying to add corect support for [Rane SL-1](https://cdn.korn.eu/pictures/product/400/040506_3.jpg), an old USB soundcard featuring 2 stereo output (RCA) and 3 stereo input (2 RCA, 1 6.3mm jack).

Currently, `alsa-info.sh` does show the correct number of inputs and outputs But neither `pavucontrol` nor Mixxx do. I was told complex hardware should be described via UCM but the syntax is unfortunately very poorly documented so I can get my head around it and get `pavucontrol` to show all the inputs and outputs.

Here's what I have so far which, to my disappointment, does not work. If I put only 1 `SectionDevice` section in the file, I can display 1 ouput under `pavucontrol`. With 2 `SectionDevice`, nothing shows.

Without any UCM file, `pavucontrol` shows 2 outputs, 1 intputs (instead of 3) and Mixxx shows 2 outputs and not input.

[The result of `alsa-info.sh` is available here](https://bugzilla.kernel.org/attachment.cgi?id=301351).