### PR TITLE
ucm2 profile for MOTU M2 

### DIFF
--- a/ucm2/USB-Audio/MOTU/M2-HiFi.conf
+++ b/ucm2/USB-Audio/MOTU/M2-HiFi.conf
@@ -1,0 +1,148 @@
+Include.pcm_split.File "/common/pcm/split.conf"
+
+Macro [
+	{
+		SplitPCM {
+			Name "m2_stereo_out"
+			Direction Playback
+			Channels 2
+			HWChannels 2
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+		}
+	}
+	{
+		SplitPCM {
+			Name "m2_mono_in"
+			Direction Capture
+			Channels 1
+			HWChannels 2
+			HWChannelPos0 MONO
+			HWChannelPos1 MONO
+		}
+	}
+	{
+		SplitPCM {
+			Name "m2_stereo_in"
+			Direction Capture
+			Channels 2
+			HWChannels 2
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+		}
+	}
+]
+
+SectionDevice."Line1" {
+	Comment "Headphone + Monitor Out"
+	Value {
+		PlaybackPriority 200
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "m2_stereo_out"
+		Direction Playback
+		HWChannels 2
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line2" {
+	Comment "Line Out"
+
+	Value {
+		PlaybackPriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "m2_stereo_out"
+		Direction Playback
+		HWChannels 2
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Mic1" {
+	Comment "Mic In 1L"
+
+	Value {
+		CapturePriority 200
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "m2_mono_in"
+		Direction Capture
+		HWChannels 2
+		Channels 1
+		Channel0 0
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Mic2" {
+	Comment "Mic In 2R"
+
+	Value {
+		CapturePriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "m2_mono_in"
+		Direction Capture
+		HWChannels 2
+		Channels 1
+		Channel0 1
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Mic3" {
+	Comment "Stereo Mic In 1L+1R"
+
+	ConflictingDevice [
+		"Mic1"
+		"Mic2"
+	]
+
+	Value {
+		CapturePriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "m2_stereo_in"
+		Direction Capture
+		HWChannels 2
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line3" {
+	Comment "Stereo Line In L+R"
+
+	ConflictingDevice [
+		"Line1"
+		"Line2"
+	]
+
+	Value {
+		CapturePriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "m2_stereo_in"
+		Direction Capture
+		HWChannels 2
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+

--- a/ucm2/USB-Audio/MOTU/M2-HiFi.conf
+++ b/ucm2/USB-Audio/MOTU/M2-HiFi.conf
@@ -37,7 +37,7 @@ SectionDevice."Line1" {
 	Comment "Headphone + Monitor Out"
 	Value {
 		PlaybackPriority 200
-    PlaybackPCM "hw:${CardId}"
+		PlaybackPCM "hw:${CardId}"
 	}
 }
 

--- a/ucm2/USB-Audio/MOTU/M2-HiFi.conf
+++ b/ucm2/USB-Audio/MOTU/M2-HiFi.conf
@@ -74,7 +74,7 @@ SectionDevice."Mic2" {
 }
 
 SectionDevice."Mic3" {
-	Comment "Stereo Mic In 1L+1R"
+	Comment "Stereo Mic In 1L+2R"
 
 	ConflictingDevice [
 		"Mic1"

--- a/ucm2/USB-Audio/MOTU/M2-HiFi.conf
+++ b/ucm2/USB-Audio/MOTU/M2-HiFi.conf
@@ -37,34 +37,7 @@ SectionDevice."Line1" {
 	Comment "Headphone + Monitor Out"
 	Value {
 		PlaybackPriority 200
-	}
-	Macro.pcm_split.SplitPCMDevice {
-		Name "m2_stereo_out"
-		Direction Playback
-		HWChannels 2
-		Channels 2
-		Channel0 0
-		Channel1 1
-		ChannelPos0 FL
-		ChannelPos1 FR
-	}
-}
-
-SectionDevice."Line2" {
-	Comment "Line Out"
-
-	Value {
-		PlaybackPriority 100
-	}
-	Macro.pcm_split.SplitPCMDevice {
-		Name "m2_stereo_out"
-		Direction Playback
-		HWChannels 2
-		Channels 2
-		Channel0 2
-		Channel1 3
-		ChannelPos0 FL
-		ChannelPos1 FR
+    PlaybackPCM "hw:${CardId}"
 	}
 }
 
@@ -106,29 +79,6 @@ SectionDevice."Mic3" {
 	ConflictingDevice [
 		"Mic1"
 		"Mic2"
-	]
-
-	Value {
-		CapturePriority 100
-	}
-	Macro.pcm_split.SplitPCMDevice {
-		Name "m2_stereo_in"
-		Direction Capture
-		HWChannels 2
-		Channels 2
-		Channel0 0
-		Channel1 1
-		ChannelPos0 FL
-		ChannelPos1 FR
-	}
-}
-
-SectionDevice."Line3" {
-	Comment "Stereo Line In L+R"
-
-	ConflictingDevice [
-		"Line1"
-		"Line2"
 	]
 
 	Value {

--- a/ucm2/USB-Audio/MOTU/M2.conf
+++ b/ucm2/USB-Audio/MOTU/M2.conf
@@ -1,0 +1,12 @@
+Comment "MOTU M2"
+
+SectionUseCase."HiFi" {
+	Comment "Analog Stereo Outputs + Inputs"
+	File "/USB-Audio/MOTU/M2-HiFi.conf"
+}
+
+Define.DirectPlaybackChannels 2
+Define.DirectCaptureChannels 2
+
+Include.dhw.File "/common/direct.conf"
+

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -67,11 +67,20 @@ If.steinberg-ur44 {
 
 If.M4 {
 	Condition {
-		Type String
-		Haystack "${CardComponents}"
-		Needle "USB07fd:000b"
+		Type RegexMatch
+		String "${CardName}"
+		Regex "M4"
 	}
 	True.Define.ProfileName "MOTU/M4"
+}
+
+If.M2 {
+	Condition {
+		Type RegexMatch 
+		String "${CardName}"
+		Regex "M2"
+	}
+	True.Define.ProfileName "MOTU/M2"
 }
 
 If.dell-wd15 {

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -65,22 +65,21 @@ If.steinberg-ur44 {
 	True.Define.ProfileName "Steinberg/UR44"
 }
 
-If.M4 {
-	Condition {
-		Type RegexMatch
-		String "${CardName}"
-		Regex "M4"
-	}
-	True.Define.ProfileName "MOTU/M4"
-}
-
-If.M2 {
-	Condition {
-		Type RegexMatch 
-		String "${CardName}"
-		Regex "M2"
-	}
-	True.Define.ProfileName "MOTU/M2"
+If.Motu {
+  Condition {
+    Type String
+    Haystack "${CardComponents}"
+    Needle "USB07fd:000b"
+  }
+  True.If.M4 {
+    Condition {
+      Type String
+      Haystack "${CardLongName}"
+      Needle "MOTU M4"
+    }
+    True.Define.ProfileName "MOTU/M4"
+    False.Define.ProfileName "MOTU/M2"
+  }
 }
 
 If.dell-wd15 {


### PR DESCRIPTION
With Release v1.2.7.2 my Audio Interface Motu M2 stopped working as discussed in #190. It looks like that the Motu M4 config #158 is loaded as they use the same (?) ID

Those changes work for me.

[alsa-info.txt](https://github.com/alsa-project/alsa-ucm-conf/files/9128719/alsa-info.txt)


