### PR TITLE
rt715-sdca: use sensible capture gain value

### DIFF
--- a/ucm2/codecs/rt715-sdca/init.conf
+++ b/ucm2/codecs/rt715-sdca/init.conf
@@ -5,7 +5,7 @@ BootSequence [
 	cset "name='rt714 ADC 22 Mux' 'DMIC3'"
 	cset "name='rt714 ADC 23 Mux' 'DMIC4'"
 	cset "name='rt714 FU02 Capture Switch' 1"
-	cset "name='rt714 FU02 Capture Volume' 124"
+	cset "name='rt714 FU02 Capture Volume' 47"
 ]
 
 FixedBootSequence [


### PR DESCRIPTION
The value of 124 used for FU02 is way too much, with saturation even in low-volume cases. The 0dB value (47) is a much better initialization value.

BugLink: https://github.com/thesofproject/linux/issues/3766
Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>