### PR TITLE
USB-Audio: Add profile for MSI MEG Z690I Unify

### DIFF
--- a/ucm2/USB-Audio/Realtek/ALC4080-HiFi.conf
+++ b/ucm2/USB-Audio/Realtek/ALC4080-HiFi.conf
@@ -1,5 +1,8 @@
 Define.SPDIFIndex "3"
 Define.Mic1Name "Microphone"
+Define.SpeakerPlaybackChannels 8
+Define.AddHeadphone "1"
+Define.AddSPDIF "1"
 
 If.asus-rog-usb {
 	Condition {
@@ -24,10 +27,23 @@ If.asus-rog-usb {
 	}
 }
 
+If.msi-meg-unify {
+  Condition {
+		Type RegexMatch
+		String "${CardComponents}"
+		Regex "USB(0db0:82c7)"
+  }
+	True {
+    SpeakerPlaybackChannels 2
+    AddHeadphone "0"
+    AddSPDIF "0"
+	}
+}
+
 SectionDevice."Speaker" {
 	Comment "Speakers"
 	Value {
-		PlaybackChannels 8
+		PlaybackChannels SpeakerPlaybackChannels
 		PlaybackPriority 200
 		PlaybackPCM "hw:${CardId}"
 		JackControl "Speaker - Output Jack"
@@ -35,23 +51,37 @@ SectionDevice."Speaker" {
 	}
 }
 
-SectionDevice."Headphones" {
-	Comment "Front Headphones"
-	Value {
-		PlaybackPriority 300
-		PlaybackPCM "hw:${CardId},1"
-		JackControl "Headphone - Output Jack"
-		PlaybackMixerElem "Front Headphone"
-	}
+If.1 {
+  Condition {
+    Type String
+    Haystack AddHeadphone
+    Needle "1"
+  }
+  SectionDevice."Headphones" {
+    Comment "Front Headphones"
+    Value {
+      PlaybackPriority 300
+      PlaybackPCM "hw:${CardId},1"
+      JackControl "Headphone - Output Jack"
+      PlaybackMixerElem "Front Headphone"
+    }
+  }
 }
 
-SectionDevice."SPDIF" {
-	Comment "S/PDIF Out"
-	Value {
-		PlaybackPriority 100
-		PlaybackPCM "hw:${CardId},${var:SPDIFIndex}"
-		PlaybackMixerElem "IEC958"
-	}
+If.1 {
+  Condition {
+    Type String
+    Haystack AddSPDIF
+    Needle "1"
+  }
+  SectionDevice."SPDIF" {
+    Comment "S/PDIF Out"
+    Value {
+      PlaybackPriority 100
+      PlaybackPCM "hw:${CardId},${var:SPDIFIndex}"
+      PlaybackMixerElem "IEC958"
+    }
+  }
 }
 
 SectionDevice."Line" {

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -42,7 +42,7 @@ If.realtek-alc4080 {
 		# 0db0:1feb MSI Edge Wifi Z690
 		# 0db0:419c MSI MPG X570S Carbon Max Wifi
 		# 0db0:a073 MSI MAG X570S Torpedo Max
-		Regex "USB((0b05:(1996|1a2[07]))|(0db0:(1feb|419c|a073)))"
+		Regex "USB((0b05:(1996|1a2[07]))|(0db0:(1feb|419c|a073|82c7)))"
 	}
 	True.Define.ProfileName "Realtek/ALC4080"
 }


### PR DESCRIPTION
This is tested and works, though I am not a fan of my `Needle` and `Haystack` solution here, but before also making a PR to alsa-utils I wanted direction. Would it be better to add a `Type Bool` condition, or a `skip` modifier to `SectionDevice`? I prefer the later, because it skips the `If {} Condition {} true {}` lines, but I would like an alsa maintainer's opinion.