### PR TITLE
ucm2: Add intial acpes8336 support

### DIFF
--- a/ucm2/conf.d/HiFi.conf
+++ b/ucm2/conf.d/HiFi.conf
@@ -1,0 +1,108 @@
+SectionVerb {
+	Value {
+		FullySpecifiedUCM "1"
+	}
+	EnableSequence [
+		cdev "hw:acpes8336"
+		exec "echo Main Verb Config EnableSequence"
+		cset "name='Left Headphone Mixer Left DAC Switch' on"
+		cset "name='Right Headphone Mixer Right DAC Switch' on"
+		cset "name='Headphone Playback Volume' 100%"
+		cset "name='Headphone Mixer Volume' 100%"
+		cset "name='DAC Playback Volume' 100%"
+		cset "name='ADC PGA Gain Volume' 100%"
+		cset "name='ADC Capture Volume' 100%"
+	]
+	DisableSequence [
+		cdev "hw:acpes8336"
+		exec "echo Main Verb Config DisableSequence"
+
+	]
+}
+
+SectionDevice."Headphones".0 {
+	Comment "Headphones"
+	
+	Value {
+		PlaybackPriority 200
+		PlaybackPCM "hw:acpes8336,0"
+		JackControl "Headphone Jack"		
+	}
+	ConflictingDevice [
+	]
+	EnableSequence [
+		cdev "hw:acpes8336"
+		exec "echo Headphones EnableSequence"
+		cset "name='Headphone Switch' on"		
+	]
+	DisableSequence [
+		cdev "hw:acpes8336"
+		exec "echo Headphones DisableSequence"
+		cset "name='Headphone Switch' off"		
+	]
+}
+
+SectionDevice."Speaker".0 {
+	Comment "Speaker"
+
+	Value {
+		PlaybackPriority 100
+		PlaybackPCM "hw:acpes8336,0"
+	}
+	ConflictingDevice [
+	]
+	EnableSequence [
+		cdev "hw:acpes8336"
+		exec "echo Speaker EnableSequence"
+		cset "name='Speaker Switch' on"
+	]
+	DisableSequence [
+		cdev "hw:acpes8336"
+		exec "echo Speaker DisableSequence"
+		cset "name='Speaker Switch' off"
+	]
+}
+
+SectionDevice."Internal Mic".0 {
+	Comment "Internal Microphone"
+	
+	Value {
+		CapturePriority 200
+		CapturePCM "hw:acpes8336,0"
+	}
+	ConflictingDevice [
+		"Headset"
+	]
+	EnableSequence [
+		cdev "hw:acpes8336"
+		cset "name='Internal Mic Switch' on"
+		cset "name='Differential Mux' 'lin1-rin1'"
+	]
+	DisableSequence [
+		cdev "hw:acpes8336"
+
+	]
+}
+
+SectionDevice."Headset" {
+	Comment "Headset Microphone"
+	
+	Value {
+		CapturePriority 300
+		CapturePCM "hw:acpes8336,0"
+		JackControl "Headset Mic Jack"
+	}
+	ConflictingDevice [
+		"Internal Mic"
+	]
+	EnableSequence [
+		cdev "hw:acpes8336"
+		cset "name='Headset Mic Switch' on"
+		cset "name='Differential Mux' 'lin2-rin2'"
+	]
+	DisableSequence [
+		cdev "hw:acpes8336"
+		cset "name='Headset Mic Switch' off"
+	]
+}
+

--- a/ucm2/conf.d/acpes8336.conf
+++ b/ucm2/conf.d/acpes8336.conf
@@ -1,0 +1,9 @@
+Syntax 2
+
+Comment "Stoney internal card"
+
+SectionUseCase."HiFi" {
+	File "HiFi.conf"
+	Comment "Default"
+}
+


### PR DESCRIPTION
This add support for es8336 on AMD  Jadeite platform.

ASLAINFO http://alsa-project.org/db/?f=b5aae41350b63c40c7743ba43ff8a7178ee93229
