### PR TITLE
Rockchip/rk3399-gru-sound: Use 48KHz sample rate for all devices

### DIFF
--- a/ucm2/Rockchip/rk3399-gru-sound/HiFi.conf
+++ b/ucm2/Rockchip/rk3399-gru-sound/HiFi.conf
@@ -37,6 +37,7 @@ SectionDevice."Speaker" {
 		PlaybackPriority 100
 		PlaybackPCM "hw:${CardId}"
 		PlaybackMixerElem "Speakers"
+		PlaybackRate 48000
 	}
 
 	EnableSequence [
@@ -59,6 +60,7 @@ SectionDevice."Mic" {
 		CapturePriority 100
 		CapturePCM "hw:${CardId},1"
 		CaptureMixerElem "ADC1"
+		CaptureRate 48000
 	}
 
 	EnableSequence [
@@ -82,6 +84,7 @@ SectionDevice."Headphones" {
 		PlaybackPCM "hw:${CardId},2"
 		PlaybackMixerElem "Headphone"
 		JackControl "Headphones Jack"
+		PlaybackRate 48000
 	}
 
 	EnableSequence [
@@ -109,6 +112,7 @@ SectionDevice."Headset" {
 		CapturePCM "hw:${CardId},2"
 		CaptureMixerElem "Mic"
 		JackControl "Headset Mic Jack"
+		CaptureRate 48000
 	}
 
 	EnableSequence [


### PR DESCRIPTION
The rk3399-gru-kevin board has problems when trying to simultaneously playback and record audio with the default PulseAudio sample rate of 44.1KHz. When the following command is run, the playback starts a few seconds after the recording finishes.

    arecord -vvv -d 4 /dev/null & sleep 0.2; speaker-test -l 1 -p 100000 -t sine

When the sample rates are set to 48KHz either with PA configuration or in the UCM, playback and recording both start immediately. Another example is when a music player is running and we start `arecord`, the music starts stuttering but `arecord` can't record anything either.

Apparently, this is a hardware limitation due to the I2S lines being shared between the devices. Set all the device rates to 48KHz like Chrome OS does to make things work smoothly.

[1] https://chromium-review.googlesource.com/389695
[2] https://chromium-review.googlesource.com/898682