### PR TITLE
bug: Fix verbose logging in GitHub Workflow

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -24,8 +24,8 @@ jobs:
     - name: Validate syntax
       run: |
         cd alsa-tests/python/ucm-validator
-        make LOGLEVEL=2 verify
+        make V=2 verify
     - name: Validate configurations
       run: |
         cd alsa-tests/python/ucm-validator
-        make LOGLEVEL=2 configs
+        make V=2 configs


### PR DESCRIPTION
I noticed the GitHub Workflow `ucm_validate` was setting `LOGLEVEL` instead of `V` which is used in the `Makefile` to set the log level. The tests in this repo are still failing, but fixing the logging first should help.