### PR TITLE
Adding Focusrite Scarlett 2i4 gen2

### DIFF
--- a/ucm2/USB-Audio/Focusrite/Scarlett-2i4-gen2-HiFi.conf
+++ b/ucm2/USB-Audio/Focusrite/Scarlett-2i4-gen2-HiFi.conf
@@ -27,15 +27,13 @@ Macro [
 	}
 ]
 
-Define.PCMCTLName "PCM Playback"
-
 Include.ctl_remap.File "/common/ctl/remap.conf"
 
 Macro [
 	{
 		CtlRemapStereoVolSw {
 			Dst "Line 1-2 Playback"
-			Src "${var:PCMCTLName}"
+			Src "PCM Playback"
 			Index0 0
 			Index1 1
 		}
@@ -43,7 +41,7 @@ Macro [
 	{
 		CtlRemapStereoVolSw {
 			Dst "Line 3-4 Playback"
-			Src "${var:PCMCTLName}"
+			Src "PCM Playback"
 			Index0 2
 			Index1 3
 		}

--- a/ucm2/USB-Audio/Focusrite/Scarlett-2i4-gen2-HiFi.conf
+++ b/ucm2/USB-Audio/Focusrite/Scarlett-2i4-gen2-HiFi.conf
@@ -1,0 +1,140 @@
+Include.pcm_split.File "/common/pcm/split.conf"
+
+Macro [
+	{
+		SplitPCM {
+			Name "scarlett2i4_stereo_out"
+			Direction Playback
+			Format S32_LE
+			Channels 2
+			HWChannels 4
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 FL
+			HWChannelPos3 FR
+		}
+	}
+	{
+		SplitPCM {
+			Name "scarlett2i4_mono_in"
+			Direction Capture
+			Format S32_LE
+			Channels 1
+			HWChannels 2
+			HWChannelPos0 MONO
+			HWChannelPos1 MONO
+		}
+	}
+]
+
+Define.PCMCTLName "PCM Playback"
+
+Include.ctl_remap.File "/common/ctl/remap.conf"
+
+Macro [
+	{
+		CtlRemapStereoVolSw {
+			Dst "Line 1-2 Playback"
+			Src "${var:PCMCTLName}"
+			Index0 0
+			Index1 1
+		}
+	}
+	{
+		CtlRemapStereoVolSw {
+			Dst "Line 3-4 Playback"
+			Src "${var:PCMCTLName}"
+			Index0 2
+			Index1 3
+		}
+	}
+	{
+		CtlRemapMonoVolSw {
+			Dst "Input 1 Capture"
+			Src "Mic Capture"
+			Index 0
+		}
+	}
+	{
+		CtlRemapMonoVolSw {
+			Dst "Input 2 Capture"
+			Src "Mic Capture"
+			Index 1
+		}
+	}
+]
+
+SectionDevice."Line1" {
+	Comment "Line 1-2"
+	Value {
+		PlaybackPriority 200
+		PlaybackMixer "default:${CardId}"
+		PlaybackMixerElem "Line 1-2"
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "scarlett2i4_stereo_out"
+		Direction Playback
+		HWChannels 4
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line2" {
+	Comment "Line 3-4"
+
+	Value {
+		PlaybackPriority 100
+		PlaybackMixer "default:${CardId}"
+		PlaybackMixerElem "Line 3-4"
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "scarlett2i4_stereo_out"
+		Direction Playback
+		HWChannels 4
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Mic1" {
+	Comment "Input 1"
+
+	Value {
+		CapturePriority 200
+		CaptureMixer "default:${CardId}"
+		CaptureMixerElem "Input 1"
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "scarlett2i4_mono_in"
+		Direction Capture
+		HWChannels 2
+		Channels 1
+		Channel0 0
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Mic2" {
+	Comment "Input 2"
+
+	Value {
+		CapturePriority 100
+		CaptureMixer "default:${CardId}"
+		CaptureMixerElem "Input 2"
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "scarlett2i4_mono_in"
+		Direction Capture
+		HWChannels 2
+		Channels 1
+		Channel0 1
+		ChannelPos0 MONO
+	}
+}

--- a/ucm2/USB-Audio/Focusrite/Scarlett-2i4-gen2.conf
+++ b/ucm2/USB-Audio/Focusrite/Scarlett-2i4-gen2.conf
@@ -1,0 +1,11 @@
+Comment "Focusrite Scarlett 2i4 Gen 2"
+
+SectionUseCase."HiFi" {
+    Comment "Default"
+    File "/USB-Audio/Focusrite/Scarlett-2i4-gen2-HiFi.conf"
+}
+
+Define.DirectPlaybackChannels 4
+Define.DirectCaptureChannels 2
+
+Include.dhw.File "/common/direct.conf"

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -202,6 +202,17 @@ If.id4-0009 {
 	True.Define.ProfileName "Audient/Audient-iD4-0009"
 }
 
+If.focusrite-scarlett-2i4-gen2 {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB1235:8200"
+	}
+	True.Define {
+		ProfileName "Focusrite/Scarlett-2i4-gen2"
+	}
+}
+
 If.mixremap {
 	Condition {
 		Type String


### PR DESCRIPTION
This cleans up the Focusrite Scarlett 2i4 Gen2 device a bit. This device is split into two stereo pairs for output, and has 2 mic/line/instrument inputs. There are no toggles or mixer controls exposed to Alsa.

It has hardware switches for:
- Headphones - can monitor line outputs 1+2 or 3+4
- Headphone input/playback mix
- Monitor out (Line 1+2)
- Each input has a level pot, and switches for pad and Z (line/inst)
- There is 1 physical +48v switch

Please let me know if any more info would be helpful. I have captured some more notes showing before/after state at https://gist.github.com/PatrickLang/79a3090eea6f2d640179457b5d428134#scarlett-2i4-2nd-gen---initial-state

I'm planning to write a UCM2 profile for the more complicated Focusrite Scarlett 18i8 Gen2 next which has more inputs, but also multiple mix busses controllable through Alsa