### PR TITLE
Update USB-Audio.conf

### DIFF
--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -42,7 +42,8 @@ If.realtek-alc4080 {
 		# 0db0:1feb MSI Edge Wifi Z690
 		# 0db0:419c MSI MPG X570S Carbon Max Wifi
 		# 0db0:a073 MSI MAG X570S Torpedo Max
-		Regex "USB((0b05:(1996|1a2[07]))|(0db0:(1feb|419c|a073)))"
+		# 0b05:1a16 ASUS ROG Strix B660-F Gaming WiFi
+		Regex "USB((0b05:(1996|1a2[07]|1a16))|(0db0:(1feb|419c|a073)))"
 	}
 	True.Define.ProfileName "Realtek/ALC4080"
 }


### PR DESCRIPTION
Fix for ALC4080 (ASUS ROG Strix B660-F Gaming WiFi)