### PR TITLE
ucm2: HDA - add support for Internal Mic

### DIFF
--- a/ucm2/HDA/HiFi-analog.conf
+++ b/ucm2/HDA/HiFi-analog.conf
@@ -1,5 +1,6 @@
 # Generic HDA devices for analog I/O
 
+Define.FrontMicName ""
 Define.DeviceFrontMic ""
 Define.LineDevice ""
 Define.hpvol "Headphone"
@@ -7,12 +8,32 @@ Define.hpjack "Headphone Jack"
 Define.loctl "Line"
 Define.lovol "Line"
 
-If.fmic {
+If.imicname {
+	Condition {
+		Type ControlExists
+		Control "name='Internal Mic Boost Volume'"
+	}
+	True.Define {
+		FrontMicName "Internal"
+	}
+}
+
+If.fmicname {
 	Condition {
 		Type ControlExists
 		Control "name='Front Mic Playback Switch'"
 	}
-	True {
+	True.Define {
+		FrontMicName "Front"
+	}
+}
+
+If.fmic {
+	Condition {
+		Type String
+		Empty "${var:FrontMicName}"
+	}
+	False {
 		If.mic2 {
 			Condition {
 				Type String
@@ -213,7 +234,7 @@ If.frontmic {
 		Empty "${var:DeviceFrontMic}"
 	}
 	False.SectionDevice."${var:DeviceFrontMic}" {
-		Comment "Front Stereo Microphone"
+		Comment "${var:FrontMicName} Stereo Microphone"
 
 		ConflictingDevice [
 			"${var:DeviceMic}"
@@ -222,8 +243,8 @@ If.frontmic {
 		Value {
 			CapturePriority 400
 			Include.value.File "/HDA/HDA-Capture-value.conf"
-			CaptureMasterElem "Front Mic Boost"
-			JackControl "Front Mic Jack"
+			CaptureMasterElem "${var:FrontMicName} Mic Boost"
+			JackControl "${var:FrontMicName} Mic Jack"
 		}
 	}
 }


### PR DESCRIPTION
Simple patch to support also "Internal Mic".

Everything seems to be working fine after this change, except that I don't have "Internal Mic Jack", I'm lying there a little to set it as such. Everything switches nicely when connecting/disconnecting headphones mic. But there are two input devices to select and selection doesn't have effect. When headphone mic is connected the internal one should be hidden (it is handled somehow when using HDA driver), but there is no Jack and I don't know how to handle it properly. (It is marked as conflicting device with the other one though) Except this minor annoyance it is fine.  

For reference: [alsa-info.txt](https://github.com/alsa-project/alsa-ucm-conf/files/9439697/alsa-info.txt)