### PR TITLE
mt8195-demo: redefine soundcard initialization

### DIFF
--- a/ucm2/MediaTek/mt8195_demo/HiFi.conf
+++ b/ucm2/MediaTek/mt8195_demo/HiFi.conf
@@ -1,3 +1,61 @@
+SectionVerb {
+
+       EnableSequence [
+		cset "name='HDMI_OUT_MUX' Connect"
+		cset "name='DPTX_OUT_MUX' Connect"
+		cset "name='O176 I070 Switch' on"
+		cset "name='O177 I071 Switch' on"
+		cset "name='O034 I168 Switch' on"
+		cset "name='O035 I169 Switch' on"
+		cset "name='O036 I012 Switch' on"
+		cset "name='O037 I013 Switch' on"
+		cset "name='O072 I022 Switch' on"
+		cset "name='O073 I023 Switch' on"
+		cset "name='O074 I024 Switch' on"
+		cset "name='O075 I025 Switch' on"
+		cset "name='O076 I026 Switch' on"
+		cset "name='O077 I027 Switch' on"
+		cset "name='O078 I028 Switch' on"
+		cset "name='O079 I029 Switch' on"
+		cset "name='O002 I004 Switch' on"
+		cset "name='O003 I005 Switch' on"
+		cset "name='O004 I006 Switch' on"
+		cset "name='O005 I007 Switch' on"
+		cset "name='O006 I008 Switch' on"
+		cset "name='O007 I009 Switch' on"
+		cset "name='O008 I010 Switch' on"
+		cset "name='O009 I011 Switch' on"
+       ]
+       
+      DisableSequence [
+		cset "name='HDMI_OUT_MUX' Disconnect"
+		cset "name='DPTX_OUT_MUX' Disconnect"
+		cset "name='O176 I070 Switch' off"
+		cset "name='O177 I071 Switch' off"
+		cset "name='O034 I168 Switch' off"
+		cset "name='O035 I169 Switch' off"
+		cset "name='O036 I012 Switch' off"
+		cset "name='O037 I013 Switch' off"
+		cset "name='O072 I022 Switch' off"
+		cset "name='O073 I023 Switch' off"
+		cset "name='O074 I024 Switch' off"
+		cset "name='O075 I025 Switch' off"
+		cset "name='O076 I026 Switch' off"
+		cset "name='O077 I027 Switch' off"
+		cset "name='O078 I028 Switch' off"
+		cset "name='O079 I029 Switch' off"
+		cset "name='O002 I004 Switch' off"
+		cset "name='O003 I005 Switch' off"
+		cset "name='O004 I006 Switch' off"
+		cset "name='O005 I007 Switch' off"
+		cset "name='O006 I008 Switch' off"
+		cset "name='O007 I009 Switch' off"
+		cset "name='O008 I010 Switch' off"
+		cset "name='O009 I011 Switch' off"
+      ]
+	
+}
+
 SectionDevice."HDMI" {
 	Comment "Hdmi/DP output"
 

--- a/ucm2/MediaTek/mt8195_demo/mt8195_demo.conf
+++ b/ucm2/MediaTek/mt8195_demo/mt8195_demo.conf
@@ -1,4 +1,4 @@
-Syntax 3
+Syntax 2
 
 SectionUseCase."HiFi" {
 	File "/MediaTek/mt8195_demo/HiFi.conf"
@@ -16,12 +16,12 @@ BootSequence [
 	cset "name='PGA_L_Mux' AIN1"
 	cset "name='HDMI_OUT_MUX' Connect"
 	cset "name='DPTX_OUT_MUX' Connect"
+	# we need to enable all devices before starting PA.
+	# In our driver we use PCM, which means that we have
+	# to route Front End to a BackEnd and then only we can
+	# open a device. Without linking to BE it will fail.
 	cset "name='O176 I070 Switch' on"
 	cset "name='O177 I071 Switch' on"
-	cset "name='O034 I168 Switch' on"
-	cset "name='O035 I169 Switch' on"
-	cset "name='O036 I012 Switch' on"
-	cset "name='O037 I013 Switch' on"
 	cset "name='O072 I022 Switch' on"
 	cset "name='O073 I023 Switch' on"
 	cset "name='O074 I024 Switch' on"
@@ -30,6 +30,10 @@ BootSequence [
 	cset "name='O077 I027 Switch' on"
 	cset "name='O078 I028 Switch' on"
 	cset "name='O079 I029 Switch' on"
+	cset "name='O034 I168 Switch' on"
+	cset "name='O035 I169 Switch' on"
+	cset "name='O036 I012 Switch' on"
+	cset "name='O037 I013 Switch' on"
 	cset "name='O002 I004 Switch' on"
 	cset "name='O003 I005 Switch' on"
 	cset "name='O004 I006 Switch' on"
@@ -38,26 +42,4 @@ BootSequence [
 	cset "name='O007 I009 Switch' on"
 	cset "name='O008 I010 Switch' on"
 	cset "name='O009 I011 Switch' on"
-	cset "name='O176 I070 Switch' off"
-	cset "name='O177 I071 Switch' off"
-	cset "name='O034 I168 Switch' off"
-	cset "name='O035 I169 Switch' off"
-	cset "name='O036 I012 Switch' off"
-	cset "name='O037 I013 Switch' off"
-	cset "name='O072 I022 Switch' off"
-	cset "name='O073 I023 Switch' off"
-	cset "name='O074 I024 Switch' off"
-	cset "name='O075 I025 Switch' off"
-	cset "name='O076 I026 Switch' off"
-	cset "name='O077 I027 Switch' off"
-	cset "name='O078 I028 Switch' off"
-	cset "name='O079 I029 Switch' off"
-	cset "name='O002 I004 Switch' off"
-	cset "name='O003 I005 Switch' off"
-	cset "name='O004 I006 Switch' off"
-	cset "name='O005 I007 Switch' off"
-	cset "name='O006 I008 Switch' off"
-	cset "name='O007 I009 Switch' off"
-	cset "name='O008 I010 Switch' off"
-	cset "name='O009 I011 Switch' off"
 ]


### PR DESCRIPTION
The previous initialization in Bootsequence set all Switch to off after boot. Whithout alsactl, alsa-ucm-conf does't work.
So remove the setting off of the Switch in the BootSequence and define Enable/DisableSequence in each device section for a proper setting.

Signed-off-by: Fadwa Chiby <fchiby@baylibre.com>