### PR TITLE
ucm2: Add support for MT8195 Cherry Tomato Chromebook with SOF

### DIFF
--- a/ucm2/MediaTek/mt8195-sof/init.conf
+++ b/ucm2/MediaTek/mt8195-sof/init.conf
@@ -1,0 +1,20 @@
+# mt8195 specific boot sequence
+
+BootSequence [
+	# eTDM
+	cset "name='ETDM_IN1_Clock_Source' a1sys_a2sys"
+	cset "name='ETDM_OUT1_Clock_Source' a1sys_a2sys"
+
+	# mt6359 audio
+	cset "name='UL_SRC_MUX' DMIC"
+
+	# AFE
+	cset "name='O048 I070 Switch' 1"
+	cset "name='O049 I071 Switch' 1"
+	cset "name='O072 I020 Switch' 1"
+	cset "name='O073 I021 Switch' 1"
+	cset "name='O036 I012 Switch' 1"
+	cset "name='O037 I013 Switch' 1"
+	cset "name='O034 I168 Switch' 1"
+	cset "name='O035 I169 Switch' 1"
+]

--- a/ucm2/MediaTek/mt8195-sof/mt6359-rt1019-rt5682/HiFi.conf
+++ b/ucm2/MediaTek/mt8195-sof/mt6359-rt1019-rt5682/HiFi.conf
@@ -1,0 +1,94 @@
+# Use case configuration for mt8195-mt6359-rt1019-rt5682
+
+SectionVerb {
+	EnableSequence [
+		disdevall ""
+	]
+
+	Value.TQ "HiFi"
+}
+
+SectionDevice."Speaker" {
+	Comment "Speaker"
+
+	EnableSequence [
+		cset "name='Ext Spk Switch' 1"
+	]
+
+	DisableSequence [
+		cset "name='Ext Spk Switch' 0"
+	]
+
+	Value {
+		PlaybackChannels 2
+		PlaybackPCM "hw:${CardId},16"
+		PlaybackPriority 100
+		PlaybackMixerElem "Speaker"
+		PlaybackVolume "Speaker Playback Volume"
+	}
+}
+
+SectionDevice."Headphones" {
+	Comment "Headphones"
+
+	EnableSequence [
+		cset "name='Headphone Switch' on"
+		cset "name='HPOL Playback Switch' 1"
+		cset "name='HPOR Playback Switch' 1"
+	]
+
+	DisableSequence [
+		cset "name='HPOL Playback Switch' 0"
+		cset "name='HPOR Playback Switch' 0"
+		cset "name='Headphone Switch' off"
+	]
+
+	Value {
+		PlaybackPriority 200
+		PlaybackPCM "hw:${CardId},17"
+		JackControl "sof-mt8195_r1019_5682 Headset Jack"
+	}
+}
+
+SectionDevice."Headset" {
+	Comment "Headset Microphone"
+
+	EnableSequence [
+		cset "name='Headset Mic Switch' on"
+		cset "name='STO1 ADC Capture Switch' 1"
+		cset "name='RECMIX1L CBJ Switch' 1"
+		cset "name='Stereo1 ADC MIXL ADC1 Switch' 1"
+		cset "name='Stereo1 ADC MIXR ADC1 Switch' 1"
+	]
+
+	DisableSequence [
+		cset "name='STO1 ADC Capture Switch' 0"
+		cset "name='RECMIX1L CBJ Switch' 0"
+		cset "name='Stereo1 ADC MIXL ADC1 Switch' 0"
+		cset "name='Stereo1 ADC MIXR ADC1 Switch' 0"
+		cset "name='Headset Mic Switch' off"
+	]
+
+	Value {
+		CapturePriority 200
+		CapturePCM "hw:${CardId},19"
+		JackControl "Headset Mic Jack"
+	}
+}
+
+SectionDevice."Mic" {
+	Comment "Internal Microphone"
+
+	EnableSequence [
+		cset "name='MTKAIF_DMIC' On"
+	]
+
+	DisableSequence [
+		cset "name='MTKAIF_DMIC' Off"
+	]
+
+	Value {
+		CapturePCM "hw:${CardId},18"
+		CapturePriority 100
+	}
+}

--- a/ucm2/MediaTek/mt8195-sof/mt6359-rt1019-rt5682/init.conf
+++ b/ucm2/MediaTek/mt8195-sof/mt6359-rt1019-rt5682/init.conf
@@ -1,0 +1,22 @@
+# rt1019-rt5682 specific boot sequence
+BootSequence [
+	cset "name='Stereo1 DAC MIXL DAC L1 Switch' 1"
+	cset "name='Stereo1 DAC MIXR DAC R1 Switch' 1"
+	cset "name='DAC L Mux' IF1"
+	cset "name='DAC R Mux' IF1"
+	cset "name='IF1 01 ADC Swap Mux' 2"
+	cset "name='CBJ Boost Volume' 3"
+	cset "name='Stereo1 ADC L Mux' 'ADC1 L'"
+	cset "name='Stereo1 ADC R Mux' 'ADC1 R'"
+	cset "name='Stereo1 ADC L1 Mux' 1"
+	cset "name='Stereo1 ADC R1 Mux' 1"
+
+	cset "name='DAC1 MIXL DAC1 Switch' 1"
+	cset "name='DAC1 MIXR DAC1 Switch' 1"
+
+	cset "name='DAC1 MIXL Stereo ADC Switch' 0"
+	cset "name='DAC1 MIXR Stereo ADC Switch' 0"
+
+	cset "name='Stereo1 ADC MIXL ADC2 Switch' 0"
+	cset "name='Stereo1 ADC MIXR ADC2 Switch' 0"
+]

--- a/ucm2/MediaTek/mt8195-sof/mt6359-rt1019-rt5682/sof-mt8195-mt6359-rt1019-rt5682.conf
+++ b/ucm2/MediaTek/mt8195-sof/mt6359-rt1019-rt5682/sof-mt8195-mt6359-rt1019-rt5682.conf
@@ -1,0 +1,12 @@
+Comment "MT8195 MT6359 RT1019 RT5682 sound card"
+Syntax 4
+
+SectionUseCase."HiFi" {
+	File "/MediaTek/mt8195-sof/mt6359-rt1019-rt5682/HiFi.conf"
+	Comment "Default"
+}
+
+Include.card-init.File "/lib/card-init.conf"
+Include.ctl-remap.File "/lib/ctl-remap.conf"
+Include.init.File "/MediaTek/mt8195-sof/init.conf"
+Include.init-rt1019-rt5682.File "/MediaTek/mt8195-sof/mt6359-rt1019-rt5682/init.conf"

--- a/ucm2/conf.d/sof-mt8195_r101/sof-mt8195_r1019_5682.conf
+++ b/ucm2/conf.d/sof-mt8195_r101/sof-mt8195_r1019_5682.conf
@@ -1,0 +1,1 @@
+../../MediaTek/mt8195-sof/mt6359-rt1019-rt5682/sof-mt8195-mt6359-rt1019-rt5682.conf


### PR DESCRIPTION
Add support for the Acer Chromebook Spin 513 CP513-2H, powered by MediaTek Kompanio 1380 (MT8195) with a HiFi 4 Audio DSP running SoundOpenFirmware.
This machine uses MT6359 PMIC, with RT1019 and RT5682 as headphones and speaker codecs/amps.

This configuration has been successfully tested on Debian 11 with PipeWire 0.3.56 + wireplumber.

`Signed-off-by: AngeloGioacchino Del Regno <angelogioacchino.delregno@collabora.com>`