### PR TITLE
ucm2: Add support for MT8192 Asurada Spherion Chromebook

### DIFF
--- a/ucm2/MediaTek/mt8192/mt6359-rt1015p-rt5682/HiFi.conf
+++ b/ucm2/MediaTek/mt8192/mt6359-rt1015p-rt5682/HiFi.conf
@@ -1,0 +1,88 @@
+SectionVerb {
+	EnableSequence [
+		disdevall ""
+	]
+
+	Value {
+		TQ "HiFi"
+	}
+}
+
+SectionDevice."Speaker" {
+	Comment "Speaker"
+
+	EnableSequence [
+		cset "name='Speakers Switch' 1"
+	]
+
+	DisableSequence [
+		cset "name='Speakers Switch' 0"
+	]
+
+	Value {
+		PlaybackPCM "hw:${CardId},0"
+		PlaybackPriority 100
+	}
+}
+
+SectionDevice."Headphones" {
+	Comment "Headphones"
+
+	EnableSequence [
+		cset "name='Headphone Jack Switch' 1"
+	]
+
+	DisableSequence [
+		cset "name='Headphone Jack Switch' 0"
+	]
+
+	Value {
+		PlaybackPCM "hw:${CardId},3"
+		JackControl "Headphone Jack"
+		PlaybackMixerElem "DAC1"
+		PlaybackPriority 200
+	}
+}
+
+SectionDevice."Mic" {
+	Comment "Internal Microphone"
+
+	EnableSequence [
+		cset "name='MTKAIF_DMIC Switch' 1"
+	]
+
+	DisableSequence [
+		cset "name='MTKAIF_DMIC Switch' 0"
+	]
+
+	Value {
+		CapturePCM "hw:${CardId},10"
+		CapturePriority 100
+	}
+}
+
+SectionDevice."Headset" {
+	Comment "Headset Microphone"
+
+	EnableSequence [
+		cset "name='Headset Mic Switch' 1"
+		cset "name='STO1 ADC Capture Switch' 1"
+		cset "name='RECMIX1L CBJ Switch' 1"
+		cset "name='Stereo1 ADC MIXL ADC1 Switch' 1"
+		cset "name='Stereo1 ADC MIXR ADC1 Switch' 1"
+	]
+
+	DisableSequence [
+		cset "name='STO1 ADC Capture Switch' 0"
+		cset "name='RECMIX1L CBJ Switch' 0"
+		cset "name='Stereo1 ADC MIXL ADC1 Switch' 0"
+		cset "name='Stereo1 ADC MIXR ADC1 Switch' 0"
+		cset "name='Headset Mic Switch' 0"
+	]
+
+	Value {
+		CapturePCM  "hw:${CardId},11"
+		JackControl "Headset Mic Jack"
+		CapturePriority 200
+	}
+}

--- a/ucm2/MediaTek/mt8192/mt6359-rt1015p-rt5682/init.conf
+++ b/ucm2/MediaTek/mt8192/mt6359-rt1015p-rt5682/init.conf
@@ -1,0 +1,24 @@
+BootSequence [
+	# Speaker
+	cset "name='I2S3_CH1 DL1_CH1' 1"
+	cset "name='I2S3_CH2 DL1_CH2' 1"
+	cset "name='I2S3_HD_Mux' 1"
+
+	# Headphone
+	cset "name='I2S9_CH1 DL3_CH1' 1"
+	cset "name='I2S9_CH2 DL3_CH2' 1"
+	cset "name='I2S9_HD_Mux' 1"
+
+	# Internal Mic
+	cset "name='UL1_CH1 ADDA_UL_CH1' 1"
+	cset "name='UL1_CH2 ADDA_UL_CH2' 1"
+	cset "name='UL_SRC_MUX' DMIC"
+
+	# Headset Mic
+	cset "name='UL2_CH1 I2S8_CH1' 1"
+	cset "name='UL2_CH2 I2S8_CH2' 1"
+	cset "name='I2S8_HD_Mux' 1"
+	cset "name='Stereo1 ADC L1 Mux' 1"
+	cset "name='Stereo1 ADC R1 Mux' 1"
+	cset "name='CBJ Boost Volume' 3"
+]

--- a/ucm2/MediaTek/mt8192/mt6359-rt1015p-rt5682/mt8192_mt6359_rt1015p_rt5682.conf
+++ b/ucm2/MediaTek/mt8192/mt6359-rt1015p-rt5682/mt8192_mt6359_rt1015p_rt5682.conf
@@ -1,0 +1,11 @@
+Comment "MT8192 MT6359 RT1015P RT5682 sound card"
+Syntax 4
+
+SectionUseCase."HiFi" {
+  File "HiFi.conf"
+  Comment "Default"
+}
+
+Include.card-init.File "/lib/card-init.conf"
+Include.ctl-remap.File "/lib/ctl-remap.conf"
+Include.init.File "init.conf"

--- a/ucm2/conf.d/mt8192_mt6359/mt8192_mt6359_rt1015p_rt5682.conf
+++ b/ucm2/conf.d/mt8192_mt6359/mt8192_mt6359_rt1015p_rt5682.conf
@@ -1,0 +1,1 @@
+../../MediaTek/mt8192/mt6359-rt1015p-rt5682/mt8192_mt6359_rt1015p_rt5682.conf


### PR DESCRIPTION
Add support for the Acer Chromebook 514 CP514-2H, powered by MediaTek Kompanio 820 (MT8192). This machine uses a MT6359 PMIC, with RT1015P as speaker codec and RT5682 as headphone codec.

Signed-off-by: Nícolas F. R. A. Prado <nfraprado@collabora.com>