### PR TITLE
ucm2: mt8195-sof: Fix wrong JackControl for headphone

### DIFF
--- a/ucm2/MediaTek/mt8195-sof/mt6359-rt1019-rt5682/HiFi.conf
+++ b/ucm2/MediaTek/mt8195-sof/mt6359-rt1019-rt5682/HiFi.conf
@@ -46,7 +46,7 @@ SectionDevice."Headphones" {
 	Value {
 		PlaybackPriority 200
 		PlaybackPCM "hw:${CardId},17"
-		JackControl "sof-mt8195_r1019_5682 Headset Jack"
+		JackControl "Headphone Jack"
 	}
 }
 


### PR DESCRIPTION
The value set for the headphone's JackControl doesn't match any jack control available. Change it to the right one.

Signed-off-by: Nícolas F. R. A. Prado <nfraprado@collabora.com>

This jack control isn't actually exposed by the driver yet, but the patch doing that is on the mailing list for review [1].

[1] https://lore.kernel.org/all/20220922235951.252532-3-nfraprado@collabora.com/