### PR TITLE
USB-Audio: UR24C - add Steinberg UR24C (USB0499:174d)

### DIFF
--- a/ucm2/USB-Audio/Steinberg/UR24C-HiFi.conf
+++ b/ucm2/USB-Audio/Steinberg/UR24C-HiFi.conf
@@ -1,0 +1,94 @@
+Include.pcm_split.File "/common/pcm/split.conf"
+
+Macro [
+	{
+		SplitPCM {
+			Name "steinberg_ur24c_stereo_out"
+			Direction Playback
+			Channels 2
+			HWChannels 4
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 FL
+			HWChannelPos3 FR
+		}
+	}
+	{
+		SplitPCM {
+			Name "steinberg_ur24c_mono_in"
+			Direction Capture
+			Channels 1
+			HWChannels 2
+			HWChannelPos0 MONO
+			HWChannelPos1 MONO
+		}
+	}
+]
+
+SectionDevice."Line 1" {
+	Comment "Stereo Line (outputs 1 and 2)"
+
+	Value {
+		PlaybackPriority 200
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "steinberg_ur24c_stereo_out"
+		Direction Playback
+		HWChannels 4
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line 2" {
+	Comment "Stereo Line (outputs 3 and 4)"
+
+	Value {
+		PlaybackPriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "steinberg_ur24c_stereo_out"
+		Direction Playback
+		HWChannels 4
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line 3" {
+	Comment "Mono Line (input 1)"
+
+	Value {
+		CapturePriority 600
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "steinberg_ur24c_mono_in"
+		Direction Capture
+		HWChannels 2
+		Channels 1
+		Channel0 0
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Line 4" {
+	Comment "Mono Line (input 2)"
+
+	Value {
+		CapturePriority 500
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "steinberg_ur24c_mono_in"
+		Direction Capture
+		HWChannels 2
+		Channels 1
+		Channel0 1
+		ChannelPos0 MONO
+	}
+}

--- a/ucm2/USB-Audio/Steinberg/UR24C.conf
+++ b/ucm2/USB-Audio/Steinberg/UR24C.conf
@@ -1,0 +1,11 @@
+Comment "Steinberg UR24C USB-Audio"
+
+SectionUseCase."HiFi" {
+	Comment "HiFi"
+	File "/USB-Audio/Steinberg/UR24C-HiFi.conf"
+}
+
+Define.DirectPlaybackChannels 4
+Define.DirectCaptureChannels 2
+
+Include.dhw.File "/common/direct.conf"

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -63,6 +63,15 @@ If.gigabyte-aorus-main {
 	True.Define.ProfileName "Gigabyte/Aorus-Master-Main-Audio"
 }
 
+If.steinberg-ur24c {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB0499:174d"
+	}
+	True.Define.ProfileName "Steinberg/UR24C"
+}
+
 If.steinberg-ur44 {
 	Condition {
 		Type String


### PR DESCRIPTION
[Yamaha Steinberg UR24C 2x4 USB 3.0 Audio Interface](https://www.steinberg.net/audio-interfaces/ur24c/)
[UR24C_Operation_Manual_English.pdf](https://download.steinberg.net/downloads_hardware/UR-C/Manuals/UR24C_Operation_Manual_English.pdf)

Add UCM2 profiles for UR24C (USB0499:174d):
1. Direct: 4.0 out (FL,FR,RL,RR) + 2.0 in (FL,FR)
2. HiFi: 2x stereo out (FL1,FR1,FL2,FR2) + 2x mono in (MONO1,MONO2)

[alsa-info.sh](https://alsa-project.org/db/?f=0c5414fb5d96287c51a6479b537123440f4b35b8)

