### PR TITLE
Draft: Add Arturia Minifuse 1 Support

### DIFF
--- a/ucm2/USB-Audio/Arturia/Minifuse-1-HiFi.conf
+++ b/ucm2/USB-Audio/Arturia/Minifuse-1-HiFi.conf
@@ -89,10 +89,6 @@ SectionDevice."Line2" {
 SectionDevice."Mic1" {
 	Comment "Mic/Line/Inst 1 (L)"
 
-	ConflictingDevice [
-		"Line3"
-	]
-
 	Value {
 		CapturePriority 400
 	}

--- a/ucm2/USB-Audio/Arturia/Minifuse-1-HiFi.conf
+++ b/ucm2/USB-Audio/Arturia/Minifuse-1-HiFi.conf
@@ -1,0 +1,107 @@
+Include.pcm_split.File "/common/pcm/split.conf"
+
+Macro [
+	{
+		SplitPCM {
+			Name "minifuse1_stereo_out"
+			Direction Playback
+			Channels 2
+			HWChannels 4
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 FL
+			HWChannelPos3 FR
+		}
+	}
+	{
+		SplitPCM {
+			Name "minifuse1_stereo_in"
+			Direction Capture
+			Channels 2
+			HWChannels 4
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 FL
+			HWChannelPos3 FR
+		}
+	}
+	{
+		SplitPCM {
+			Name "minifuse1_mono_in"
+			Direction Capture
+			Channels 1
+			HWChannels 4
+			HWChannelPos0 MONO
+			HWChannelPos1 MONO
+			HWChannelPos2 MONO
+			HWChannelPos3 MONO
+		}
+	}
+]
+
+SectionDevice."Line1" {
+	Comment "Main Output L/R"
+
+	Value {
+		PlaybackPriority 300
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "minifuse1_stereo_out"
+		Direction Playback
+		HWChannels 4
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line2" {
+	Comment "Loopback L/R"
+
+	Value {
+		PlaybackPriority 200
+		CapturePriority 200
+	}
+	Macro.pcm_split1.SplitPCMDevice {
+		Name "minifuse1_stereo_out"
+		Direction Playback
+		HWChannels 4
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+	Macro.pcm_split2.SplitPCMDevice {
+		Name "minifuse1_stereo_in"
+		Direction Capture
+		HWChannels 4
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Mic1" {
+	Comment "Mic/Line/Inst 1 (L)"
+
+	ConflictingDevice [
+		"Line3"
+	]
+
+	Value {
+		CapturePriority 400
+	}
+	Macro.pcm_split2.SplitPCMDevice {
+		Name "minifuse1_mono_in"
+		Direction Capture
+		HWChannels 4
+		Channels 1
+		Channel0 0
+		ChannelPos0 MONO
+	}
+}

--- a/ucm2/USB-Audio/Arturia/Minifuse-1.conf
+++ b/ucm2/USB-Audio/Arturia/Minifuse-1.conf
@@ -1,0 +1,11 @@
+Comment "Arturia Minifuse 1"
+
+SectionUseCase."HiFi" {
+	Comment "Default Alsa Profile"
+	File "/USB-Audio/Arturia/Minifuse-1-HiFi.conf"
+}
+
+Define.DirectPlaybackChannels 4
+Define.DirectCaptureChannels 4
+
+Include.dhw.File "/common/direct.conf"

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -223,6 +223,15 @@ If.kontrolz1 {
 	True.Define.ProfileName "NativeInstruments/Traktor-Kontrol-Z1"
 }
 
+If.minifuse1 {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB1c75:af80"
+	}
+	True.Define.ProfileName "Arturia/Minifuse-1"
+}
+
 If.minifuse2 {
 	Condition {
 		Type String


### PR DESCRIPTION
Arturia Minifuse 1 is a stripped-down version of Minifuse 2:
- 1 Input
- 2 Outputs
- Loopback interface to ease recording of the computer output

(attempt at fixing #220) 