### PR TITLE
If system has Dmic, variable DeviceDmic will be empty

### DIFF
--- a/ucm2/Intel/sof-hda-dsp/sof-hda-dsp.conf
+++ b/ucm2/Intel/sof-hda-dsp/sof-hda-dsp.conf
@@ -66,7 +66,7 @@ If.dmic {
 		Type String
 		Empty "${var:DeviceDmic}"
 	}
-	False.If.Dmic0 {
+	True.If.Dmic0 {
 		Condition {
 			Type ControlExists
 			Control "name='Dmic0 Capture Volume'"


### PR DESCRIPTION
change condition from False to True to configure Dmic0 correctly