### PR TITLE
add --wildcards to tar options in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ files are extra (only informational).
 Example:
 
 ```
-tar xvjf alsa-ucm-conf-1.2.6.2.tar.bz2 -C /usr/share/alsa --strip-components=1 "*/ucm" "*/ucm2"
+tar xvjf alsa-ucm-conf-1.2.6.2.tar.bz2 -C /usr/share/alsa --strip-components=1 --wildcards "*/ucm" "*/ucm2"
 ```
 
 The latest configuration can be obtained with those commands:


### PR DESCRIPTION
Without it, at least on some recent tar version, it won't work: --wildcards is the default only for exclusions, not for member selection. This tends to confuse users, even though it's just an example (e.g #220)