### PR TITLE
Add Focusrite Scarlett 2i2 gen2

### DIFF
--- a/ucm2/USB-Audio/Focusrite/Scarlett-2i2-gen2-HiFi.conf
+++ b/ucm2/USB-Audio/Focusrite/Scarlett-2i2-gen2-HiFi.conf
@@ -1,0 +1,75 @@
+Include.pcm_split.File "/common/pcm/split.conf"
+
+Macro [
+	{
+		SplitPCM {
+			Name "scarlett2i2_stereo_out"
+			Direction Playback
+			Format S32_LE
+			Channels 2
+			HWChannels 2
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+		}
+	}
+	{
+		SplitPCM {
+			Name "scarlett2i2_mono_in"
+			Direction Capture
+			Format S32_LE
+			Channels 1
+			HWChannels 2
+			HWChannelPos0 MONO
+			HWChannelPos1 MONO
+		}
+	}
+]
+
+SectionDevice."Line1" {
+	Comment "Line 1-2"
+	Value {
+		PlaybackPriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "scarlett2i2_stereo_out"
+		Direction Playback
+		HWChannels 4
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Mic1" {
+	Comment "Input 1"
+
+	Value {
+		CapturePriority 200
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "scarlett2i2_mono_in"
+		Direction Capture
+		HWChannels 2
+		Channels 1
+		Channel0 0
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Mic2" {
+	Comment "Input 2"
+
+	Value {
+		CapturePriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "scarlett2i2_mono_in"
+		Direction Capture
+		HWChannels 2
+		Channels 1
+		Channel0 1
+		ChannelPos0 MONO
+	}
+}

--- a/ucm2/USB-Audio/Focusrite/Scarlett-2i2-gen2.conf
+++ b/ucm2/USB-Audio/Focusrite/Scarlett-2i2-gen2.conf
@@ -1,0 +1,11 @@
+Comment "Focusrite Scarlett 2i2 Gen 2"
+
+SectionUseCase."HiFi" {
+    Comment "Default"
+    File "/USB-Audio/Focusrite/Scarlett-2i2-gen2-HiFi.conf"
+}
+
+Define.DirectPlaybackChannels 2
+Define.DirectCaptureChannels 2
+
+Include.dhw.File "/common/direct.conf"

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -135,6 +135,17 @@ If.goxlr {
 	True.Define.ProfileName "GoXLR/GoXLR"
 }
 
+If.focusrite-scarlett-2i2-gen2 {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB1235:8202"
+	}
+	True.Define {
+		ProfileName "Focusrite/Scarlett-2i2-gen2"
+	}
+}
+
 If.focusrite-scarlett-2i4-gen2 {
 	Condition {
 		Type String


### PR DESCRIPTION
This is basically #203 but for the 2i2.

I don't really know what I'm doing, but with these changes, I get two separate mono inputs in Pipewire, which is what I was looking for.