### PR TITLE
feat: add support for ASUS ROG Strix Z790-E Gaming Wifi

### DIFF
--- a/ucm2/USB-Audio/Realtek/ALC4080-HiFi.conf
+++ b/ucm2/USB-Audio/Realtek/ALC4080-HiFi.conf
@@ -68,7 +68,7 @@ If.spdif_dev2 {
 	Condition {
 		Type RegexMatch
 		String "${CardComponents}"
-		Regex "USB(0b05:1996|0db0:1feb)"
+		Regex "USB(0b05:1996|0b05:1a52|0db0:1feb)"
 	}
 	True.Define.SpdifPCM "hw:${CardId},2"
 }

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -41,6 +41,7 @@ If.realtek-alc4080 {
 		# 0b05:1a16 ASUS ROG Strix B660-F Gaming WiFi
 		# 0b05:1a20 ASUS ROG STRIX Z690-I Gaming Wifi
 		# 0b05:1a27 ALC4082 on ASUS ROG Maximus Z690 Hero
+		# 0b05:1a52 ASUS ROG Strix Z790-E Gaming Wifi
 		# 0db0:005a MSI MPG Z690 CARBON WIFI
 		# 0db0:151f MSI X570S EDGE MAX WIFI
 		# 0db0:1feb MSI Edge Wifi Z690
@@ -50,7 +51,7 @@ If.realtek-alc4080 {
 		# 0db0:a47c MSI MEG X570S Ace Max
 		# 0db0:b202 MSI MAG Z690 Tomahawk Wifi
 		# 0db0:d6e7 MSI MPG X670E Carbon Wifi
-		Regex "USB((0414:a00e)|(0b05:(1996|1a(16|2[07])))|(0db0:(005a|151f|1feb|419c|82c7|a073|a47c|b202|d6e7)))"
+		Regex "USB((0414:a00e)|(0b05:(1996|1a(16|2[07]|52)))|(0db0:(005a|151f|1feb|419c|82c7|a073|a47c|b202|d6e7)))"
 	}
 	True.Define.ProfileName "Realtek/ALC4080"
 }


### PR DESCRIPTION
I've verified this profile on my motherboard, and both back- and front jacks seem to work fine, including SPDIF.