### PR TITLE
ucm2: add support for "Digidesign Mbox 3"

### DIFF
--- a/ucm2/USB-Audio/Digidesign/Digidesign-Mbox-3-Mixer.conf
+++ b/ucm2/USB-Audio/Digidesign/Digidesign-Mbox-3-Mixer.conf
@@ -1,0 +1,126 @@
+Include.pcm_split.File "/common/pcm/split.conf"
+
+Macro [
+	{
+		SplitPCM {
+			Name "mbox3_stereo_out"
+			Direction Playback
+			Channels 2
+			HWChannels 4
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 FL
+			HWChannelPos3 FR
+		}
+	}
+	{
+		SplitPCM {
+			Name "mbox3_stereo_in"
+			Direction Capture
+			Channels 2
+			HWChannels 4
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 FL
+			HWChannelPos3 FR
+		}
+	}
+	{
+		SplitPCM {
+			Name "mbox3_mono_in"
+			Direction Capture
+			Channels 1
+			HWChannels 4
+			HWChannelPos0 MONO
+			HWChannelPos1 MONO
+			HWChannelPos2 MONO
+			HWChannelPos3 MONO
+		}
+	}
+]
+
+SectionDevice."Line1" {
+	Comment "Main Output L/R"
+
+	Value {
+		PlaybackPriority 300
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "mbox3_stereo_out"
+		Direction Playback
+		HWChannels 4
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+
+SectionDevice."line2SPDIF" {
+	Comment "SPDIF Out"
+	Value {
+		PlaybackPriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "mbox3_stereo_out"
+		Direction Playback
+		HWChannels 4
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."mic1" {
+	Comment "Mic/Line 1"
+
+	Value {
+		CapturePriority 300
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "mbox3_mono_in"
+		Direction Capture
+		HWChannels 4
+		Channels 1
+		Channel0 0
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."mic2" {
+	Comment "Mic/Line 2"
+
+	Value {
+		CapturePriority 200
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "mbox3_mono_in"
+		Direction Capture
+		HWChannels 4
+		Channels 1
+		Channel0 1
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."mic3SPDIF" {
+	Comment "SPDIF In"
+
+	Value {
+		CapturePriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "mbox3_stereo_in"
+		Direction Capture
+		HWChannels 4
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR		
+	}
+}

--- a/ucm2/USB-Audio/Digidesign/Digidesign-Mbox-3.conf
+++ b/ucm2/USB-Audio/Digidesign/Digidesign-Mbox-3.conf
@@ -1,0 +1,11 @@
+Comment "Digidesign Mbox 3"
+
+SectionUseCase."Mixer" {
+	Comment "Stereo Duplex"
+	File "/USB-Audio/Digidesign/Digidesign-Mbox-3-Mixer.conf"
+}
+
+Define.DirectPlaybackChannels 4
+Define.DirectCaptureChannels 4
+
+Include.dhw.File "/common/direct.conf"

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -224,6 +224,15 @@ If.kontrolz1 {
 	True.Define.ProfileName "NativeInstruments/Traktor-Kontrol-Z1"
 }
 
+If.mbox3 {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB0dba:5000"
+	}
+	True.Define.ProfileName "Digidesign/Digidesign-Mbox-3"
+}
+
 If.minifuse12 {
 	Condition {
 		Type RegexMatch


### PR DESCRIPTION
Add ucm2 support for "Digidesign Mbox 3", 
without it, alsa detects as analog-surround4.0, instead of 2 line and 2 spdif in/out.

[alsa-info.txt](https://github.com/alsa-project/alsa-ucm-conf/files/9944813/alsa-info.txt)
