### PR TITLE
ucm2: [Digidesign MBox3] Added default SplitPCMPeriodTime and reordered

### DIFF
--- a/ucm2/USB-Audio/Digidesign/Digidesign-Mbox-3-HiFi.conf
+++ b/ucm2/USB-Audio/Digidesign/Digidesign-Mbox-3-HiFi.conf
@@ -39,6 +39,23 @@ Macro [
 	}
 ]
 
+SectionDevice."line2SPDIF" {
+	Comment "SPDIF Out"
+	Value {
+		PlaybackPriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "mbox3_stereo_out"
+		Direction Playback
+		HWChannels 4
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
 SectionDevice."Line1" {
 	Comment "Main Output L/R"
 
@@ -57,37 +74,21 @@ SectionDevice."Line1" {
 	}
 }
 
+SectionDevice."mic3SPDIF" {
+	Comment "SPDIF In"
 
-SectionDevice."line2SPDIF" {
-	Comment "SPDIF Out"
 	Value {
-		PlaybackPriority 100
+		CapturePriority 100
 	}
 	Macro.pcm_split.SplitPCMDevice {
-		Name "mbox3_stereo_out"
-		Direction Playback
+		Name "mbox3_stereo_in"
+		Direction Capture
 		HWChannels 4
 		Channels 2
 		Channel0 2
 		Channel1 3
 		ChannelPos0 FL
-		ChannelPos1 FR
-	}
-}
-
-SectionDevice."mic1" {
-	Comment "Mic/Line 1"
-
-	Value {
-		CapturePriority 300
-	}
-	Macro.pcm_split.SplitPCMDevice {
-		Name "mbox3_mono_in"
-		Direction Capture
-		HWChannels 4
-		Channels 1
-		Channel0 0
-		ChannelPos0 MONO
+		ChannelPos1 FR		
 	}
 }
 
@@ -107,20 +108,18 @@ SectionDevice."mic2" {
 	}
 }
 
-SectionDevice."mic3SPDIF" {
-	Comment "SPDIF In"
+SectionDevice."mic1" {
+	Comment "Mic/Line 1"
 
 	Value {
-		CapturePriority 100
+		CapturePriority 300
 	}
 	Macro.pcm_split.SplitPCMDevice {
-		Name "mbox3_stereo_in"
+		Name "mbox3_mono_in"
 		Direction Capture
 		HWChannels 4
-		Channels 2
-		Channel0 2
-		Channel1 3
-		ChannelPos0 FL
-		ChannelPos1 FR
+		Channels 1
+		Channel0 0
+		ChannelPos0 MONO
 	}
 }

--- a/ucm2/USB-Audio/Digidesign/Digidesign-Mbox-3.conf
+++ b/ucm2/USB-Audio/Digidesign/Digidesign-Mbox-3.conf
@@ -1,5 +1,7 @@
 Comment "Digidesign Mbox 3"
 
+Include.dhw.File "/common/direct.conf"
+
 SectionUseCase."Mixer" {
 	Comment "Stereo Duplex"
 	File "/USB-Audio/Digidesign/Digidesign-Mbox-3-HiFi.conf"
@@ -7,5 +9,3 @@ SectionUseCase."Mixer" {
 
 Define.DirectPlaybackChannels 4
 Define.DirectCaptureChannels 4
-
-Include.dhw.File "/common/direct.conf"

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -134,6 +134,7 @@ If.mbox3 {
 		Needle "USB0dba:5000"
 	}
 	True.Define.ProfileName "Digidesign/Digidesign-Mbox-3"
+	True.Define.SplitPCMPeriodTime 500		# 0.5ms
 }
 
 If.goxlr {


### PR DESCRIPTION
Added default SplitPCMPeriodTime of 500 (0.5ms): to solve latency issues https://github.com/alsa-project/alsa-ucm-conf/issues/238
Reordered configs: to make pulseaudio select the correct default card profile, input and ourputs (pavucontrol)