### PR TITLE
ucm2: alc4080 - add support for MSI PRO Z790-A WIFI

### DIFF
--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -59,8 +59,9 @@ If.realtek-alc4080 {
 		# 0db0:a073 MSI MAG X570S Torpedo Max
 		# 0db0:a47c MSI MEG X570S Ace Max
 		# 0db0:b202 MSI MAG Z690 Tomahawk Wifi
+		# 0db0:d1d7 MSI PRO Z790-A WIFI
 		# 0db0:d6e7 MSI MPG X670E Carbon Wifi
-		Regex "USB((0414:a00e)|(0b05:(1996|1a(16|2[07]|52)))|(0db0:(005a|151f|1feb|419c|6cc9|82c7|a073|a47c|b202|d6e7)))"
+		Regex "USB((0414:a00e)|(0b05:(1996|1a(16|2[07]|52)))|(0db0:(005a|151f|1feb|419c|6cc9|82c7|a073|a47c|b202|d1d7|d6e7)))"
 	}
 	True.Define.ProfileName "Realtek/ALC4080"
 }


### PR DESCRIPTION
Frontpanel did not work, with this change, back and frontpanel work correctly.