### PR TITLE
ucm2: sof-essx8336: don't use disdevall for this device

### DIFF
--- a/ucm2/Intel/sof-essx8336/HiFi.conf
+++ b/ucm2/Intel/sof-essx8336/HiFi.conf
@@ -1,8 +1,7 @@
 SectionVerb {
 	EnableSequence [
-		disdevall ""
-		# Disable all inputs / outputs
-		#   (may be duplicated with disdevall)
+		# Using disdevall cause troubles here, as it
+		# breaks microphone detection.
 		cset "name='Headphone Switch' off"
 		cset "name='Headset Mic Switch' off"
 		cset "name='Internal Mic Switch' off"


### PR DESCRIPTION
disdevall causes undesired side effects on this device, as it breaks main microphone's detection, and makes hdmi outputs invisible at pavucontrol (tested with pipewire-pulse).

So, rely on cset to disable what's not needed at the enable sequence.

Fixes: 15a12508003c ("ucm2: put disdevall to HDA/Soundwire configs")
Signed-off-by: Mauro Carvalho Chehab <mchehab@kernel.org>