### PR TITLE
sof-hda-dsp: Set Dmic0 Capture Switch on

### DIFF
--- a/ucm2/Intel/sof-hda-dsp/sof-hda-dsp.conf
+++ b/ucm2/Intel/sof-hda-dsp/sof-hda-dsp.conf
@@ -83,6 +83,7 @@ If.dmic {
 		}
 		True.BootSequence [
 			cset "name='Dmic0 Capture Volume' 70%"
+			cset "name='Dmic0 Capture Switch' on"
 		]
 	}
 }


### PR DESCRIPTION
Internal microphone default is off after fresh installation. Add operation to set the control on to align with other sound architecture.