### PR TITLE
ucm2: MediaTek: mt8365-evk: Add alsa-ucm support

### DIFF
--- a/ucm2/MediaTek/mt8365-evk/HiFi.conf
+++ b/ucm2/MediaTek/mt8365-evk/HiFi.conf
@@ -1,0 +1,142 @@
+SectionDevice."HDMI" {
+	Comment "Hdmi output"
+
+        Value {
+                PlaybackPriority 250
+                PlaybackChannels 2
+                PlaybackPCM "hw:${CardId},1"
+        }
+
+	EnableSequence [
+		cset "name='O00 I07 Switch' on"
+		cset "name='O01 I08 Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='O00 I07 Switch' off"
+		cset "name='O01 I08 Switch' off"
+	]
+}
+
+SectionDevice."Speaker" {
+	Comment "Line-out Jack "
+
+	ConflictingDevice [
+		"Headphones"
+        ]
+
+	Value {
+		PlaybackPriority 300
+		PlaybackChannels 2
+		PlaybackPCM "hw:${CardId},0"
+		PlaybackVolume "name='Lineout_PGAL_GAIN'"
+        }
+
+	EnableSequence [
+		cset "name='Audio_Amp_L_Switch' Off"
+		cset "name='Audio_Amp_R_Switch' Off"
+		cset "name='Lineout_PGAL_GAIN' 0"
+		cset "name='Speaker_Amp_Switch' On"
+	]
+
+	DisableSequence [
+		cset "name='Audio_Amp_L_Switch' On"
+		cset "name='Audio_Amp_R_Switch' On"
+		cset "name='Speaker_Amp_Switch' Off"
+        ]
+}
+
+SectionDevice."Headphones" {
+        Comment "Headset speakers"
+
+        ConflictingDevice [
+                "Speaker"
+        ]
+
+        Value {
+                PlaybackPriority 300
+                PlaybackChannels 2
+                PlaybackPCM "hw:${CardId},0"
+                PlaybackVolume "name='Headset_PGAL_GAIN'"
+        }
+
+        EnableSequence [
+                cset "name='Audio_Amp_L_Switch' On"
+                cset "name='Audio_Amp_R_Switch' On"
+                cset "name='Headset_PGAL_GAIN' 1"
+                cset "name='Speaker_Amp_Switch' Off"
+        ]
+
+        DisableSequence [
+                cset "name='Audio_Amp_L_Switch' Off"
+                cset "name='Audio_Amp_R_Switch' Off"
+                cset "name='Speaker_Amp_Switch' On"
+        ]
+}
+
+SectionDevice."Mic1" {
+	Comment "Amic"
+
+	ConflictingDevice [
+		"Mic2"
+        ]
+
+	Value {
+		CapturePriority 300
+		CaptureChannels 1
+		CapturePCM "hw:${CardId},2"
+        }
+
+	EnableSequence [
+		cset "name='Audio_MicSource1_Setting' ADC1"
+		cset "name='Audio_MICBIAS0_Switch' Off"
+        ]
+
+	DisableSequence [
+		cset "name='Audio_MicSource1_Setting' ADC2"
+		cset "name='Audio_MICBIAS0_Switch' On"
+        ]
+}
+
+SectionDevice."Mic2" {
+        Comment "Headset microphone"
+
+        ConflictingDevice [
+                "Mic1"
+        ]
+
+        Value {
+                CapturePriority 350
+                CaptureChannels 1
+                CapturePCM "hw:${CardId},2"
+        }
+
+        EnableSequence [
+		cset "name='Audio_MicSource1_Setting' ADC2"
+		cset "name='Audio_MICBIAS0_Switch' On"
+        ]
+
+        DisableSequence [
+		cset "name='Audio_MicSource1_Setting' ADC1"
+		cset "name='Audio_MICBIAS0_Switch' Off"
+        ]
+}
+
+SectionDevice."Mic3" {
+	Comment "PDM microphones"
+
+	Value {
+                CapturePriority 100
+                CaptureChannels 2
+                CapturePCM "hw:${CardId},3"
+        }
+
+	EnableSequence [
+		cset "name='Audio_MICBIAS0_Switch' On"
+        ]
+
+	DisableSequence [
+		cset "name='Audio_MICBIAS0_Switch' Off"
+        ]
+}
+

--- a/ucm2/MediaTek/mt8365-evk/mt8365-evk.conf
+++ b/ucm2/MediaTek/mt8365-evk/mt8365-evk.conf
@@ -1,0 +1,39 @@
+Syntax 4
+
+SectionUseCase."HiFi" {
+	File "/MediaTek/mt8365-evk/HiFi.conf"
+	Comment "Play high quality music"
+}
+
+BootSequence [
+	#Audio volume
+	cset "name='Headset_PGAL_GAIN' 0"
+	cset "name='Lineout_PGAL_GAIN' 0"
+
+	#Audio amp
+	cset "name='Audio_Amp_R_Switch' On"
+	cset "name='Audio_Amp_L_Switch' On"
+
+	#Headset out
+	cset "name='Speaker_Amp_Switch' Off"
+
+	#Dmic
+	cset "name='Audio_MICBIAS0_Switch' On"
+
+	#HDMI audio (I2S3 Out)
+	cset "name='O00 I07 Switch' on"
+	cset "name='O01 I08 Switch' on"
+
+	#jack_mic Headset In
+	cset "name='Audio_MicSource1_Setting' ADC2"
+
+	cset "name='O03 I05 Switch' on"
+	cset "name='O04 I06 Switch' on"
+	cset "name='O05 I03 Switch' on"
+	cset "name='O06 I04 Switch' on"
+	cset "name='O09 I14 Switch' on"
+	cset "name='O10 I15 Switch' on"
+	cset "name='AUD_CLK_BUF_Switch' On"
+	cset "name='Audio_ADC_1_Switch' On"
+	cset "name='INT ADDA O03_O04 Switch' on"
+]

--- a/ucm2/conf.d/mt8365-evk/mt8365-evk.conf
+++ b/ucm2/conf.d/mt8365-evk/mt8365-evk.conf
@@ -1,0 +1,1 @@
+../../MediaTek/mt8365-evk/mt8365-evk.conf


### PR DESCRIPTION
Add alsa-ucm support for the Mediatek mt8365-evk platform.

Signed-off-by: Fadwa Chiby <fchiby@baylibre.com>