### PR TITLE
ucm2: sof-soundwire: Update Mic LED settings

### DIFF
--- a/ucm2/sof-soundwire/sof-soundwire.conf
+++ b/ucm2/sof-soundwire/sof-soundwire.conf
@@ -70,5 +70,6 @@ If.mic_init_rt715 {
 	}
 	True.BootSequence [
 		cset "name='PGA5.0 5 Master Capture Switch' 1"
+		sysw "-/class/sound/ctl-led/mic/card${CardNumber}/detach:PGA5.0 5 Master Capture Switch"
 	]
 }


### PR DESCRIPTION
Test on XPS 9320 with Ubuntu Jammy 22.04.
[kernel]
6.0.0-1009-oem

After apply this patch, mic mute led works.

Signed-off-by: Andy Chi <andy.chi@canonical.com>