### PR TITLE
USB-Audio: ALC4082 - add MSI MEG X670E ACE (0db0:961e)

### DIFF
--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -59,12 +59,13 @@ If.realtek-alc4080 {
 		# 0db0:419c MSI MPG X570S Carbon Max Wifi
 		# 0db0:6cc9 MSI MPG Z590 Gaming Plus
 		# 0db0:82c7 MSI MEG Z690I Unify
+		# 0db0:961e ALC4082 on MSI MEG X670E ACE
 		# 0db0:a073 MSI MAG X570S Torpedo Max
 		# 0db0:a47c MSI MEG X570S Ace Max
 		# 0db0:b202 MSI MAG Z690 Tomahawk Wifi
 		# 0db0:d1d7 MSI PRO Z790-A WIFI
 		# 0db0:d6e7 MSI MPG X670E Carbon Wifi
-		Regex "USB((0414:a00e)|(0b05:(199[69]|1a(16|2[07]|5[23])))|(0db0:(005a|151f|1feb|36e7|419c|6cc9|82c7|a073|a47c|b202|d1d7|d6e7)))"
+		Regex "USB((0414:a00e)|(0b05:(199[69]|1a(16|2[07]|5[23])))|(0db0:(005a|151f|1feb|36e7|419c|6cc9|82c7|961e|a073|a47c|b202|d1d7|d6e7)))"
 	}
 	True.Define.ProfileName "Realtek/ALC4080"
 }


### PR DESCRIPTION
I am currently using this board and not afraid to experiment so if any more details are desired just let me know.

I'm assuming the 4082 also belongs here due to the other boards also using it.