### PR TITLE
USB-Audio: ALC4080 - add MSI MPG Z790I Edge WiFi (ID: 0db0:62a4)

### DIFF
--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -58,13 +58,14 @@ If.realtek-alc4080 {
 		# 0db0:36e7 MSI MAG B650I Edge WiFi
 		# 0db0:419c MSI MPG X570S Carbon Max Wifi
 		# 0db0:6cc9 MSI MPG Z590 Gaming Plus
+		# 0db0:62a4 MSI MPG Z790I Edge WiFi
 		# 0db0:82c7 MSI MEG Z690I Unify
 		# 0db0:a073 MSI MAG X570S Torpedo Max
 		# 0db0:a47c MSI MEG X570S Ace Max
 		# 0db0:b202 MSI MAG Z690 Tomahawk Wifi
 		# 0db0:d1d7 MSI PRO Z790-A WIFI
 		# 0db0:d6e7 MSI MPG X670E Carbon Wifi
-		Regex "USB((0414:a00e)|(0b05:(199[69]|1a(16|2[07]|5[23])))|(0db0:(005a|151f|1feb|36e7|419c|6cc9|82c7|a073|a47c|b202|d1d7|d6e7)))"
+		Regex "USB((0414:a00e)|(0b05:(199[69]|1a(16|2[07]|5[23])))|(0db0:(005a|151f|1feb|36e7|419c|6cc9|82c7|a073|a47c|b202|d1d7|d6e7|62a4)))"
 	}
 	True.Define.ProfileName "Realtek/ALC4080"
 }


### PR DESCRIPTION
This motherboard is recognized as the thelio-b5 by System76