### PR TITLE
USB-Audio: ALC4080 - Add support for MSI MAG Z590 Tomahawk WiFi mothe…

### DIFF
--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -70,7 +70,8 @@ If.realtek-alc4080 {
 		# 0db0:b202 MSI MAG Z690 Tomahawk Wifi
 		# 0db0:d1d7 MSI PRO Z790-A WIFI
 		# 0db0:d6e7 MSI MPG X670E Carbon Wifi
-		Regex "USB((0414:a0(0e|12))|(0b05:(199[69]|1a(16|2[07]|5[23])))|(0db0:(005a|151f|1feb|36e7|419c|422d|62a4|6c[0c]9|82c7|961e|a073|a47c|a74b|b202|d1d7|d6e7)))"
+		# 0db0:4240 MSI MAG Z590 Tomahawk Wifi
+		Regex "USB((0414:a0(0e|12))|(0b05:(199[69]|1a(16|2[07]|5[23])))|(0db0:(005a|151f|1feb|36e7|419c|422d|62a4|6c[0c]9|82c7|961e|a073|a47c|a74b|b202|d1d7|d6e7|4240)))"
 	}
 	True.Define.ProfileName "Realtek/ALC4080"
 }


### PR DESCRIPTION
…rboard

USB ID: 0db0:4240

Adds support for Z590 Tomahawk WiFi, microphone jack is now working