### PR TITLE
fix: Adds Support For GIGABYTE Z590 Vision G Intel Z590

### DIFF
--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -46,6 +46,7 @@ If.realtek-alc4080 {
 		String "${CardComponents}"
 		# 0414:a00e Gigabyte Z590 Aorus Pro AX
 		# 0414:a012 Gigabyte Z690 AERO G DDR4
+		# 0414:a010 Giga-Byte Technology Co., Ltd USB Audio
 		# 0b05:1996 ASUS on multiple boards (including ASUS ROG Maximus XIII)
 		# 0b05:1999 ASUS ROG Strix Z590-A Gaming WiFi
 		# 0b05:1a16 ASUS ROG Strix B660-F Gaming WiFi
@@ -71,7 +72,7 @@ If.realtek-alc4080 {
 		# 0db0:b202 MSI MAG Z690 Tomahawk Wifi
 		# 0db0:d1d7 MSI PRO Z790-A WIFI
 		# 0db0:d6e7 MSI MPG X670E Carbon Wifi
-		Regex "USB((0414:a0(0e|12))|(0b05:(199[69]|1a(16|2[07]|5[23])))|(0db0:(005a|151f|1feb|36e7|419c|422d|4240|62a4|6c[0c]9|82c7|961e|a073|a47c|a74b|b202|d1d7|d6e7)))"
+		Regex "USB((0414:a0(0e|12|10))|(0b05:(199[69]|1a(16|2[07]|5[23])))|(0db0:(005a|151f|1feb|36e7|419c|422d|4240|62a4|6c[0c]9|82c7|961e|a073|a47c|a74b|b202|d1d7|d6e7)))"
 	}
 	True.Define.ProfileName "Realtek/ALC4080"
 }

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -46,7 +46,7 @@ If.realtek-alc4080 {
 		String "${CardComponents}"
 		# 0414:a00e Gigabyte Z590 Aorus Pro AX
 		# 0414:a012 Gigabyte Z690 AERO G DDR4
-		# 0414:a010 Giga-Byte Technology Co., Ltd USB Audio
+		# 0414:a010 GIGABYTE Z590 Vision G Intel Z590
 		# 0b05:1996 ASUS on multiple boards (including ASUS ROG Maximus XIII)
 		# 0b05:1999 ASUS ROG Strix Z590-A Gaming WiFi
 		# 0b05:1a16 ASUS ROG Strix B660-F Gaming WiFi


### PR DESCRIPTION
The [GIGABYTE Z590 Vision G Intel Z590](https://www.gigabyte.com/Motherboard/Z590-VISION-G-rev-10/sp#sp) motherboard contains a Realtek ALC4080 souncard that was missing from the available UCMs. 

The change works on my machine and the HiFi profile seems to be fully functional