### PR TITLE
sof-hda-dsp: Add speaker led support

### DIFF
--- a/ucm2/Intel/sof-hda-dsp/sof-hda-dsp.conf
+++ b/ucm2/Intel/sof-hda-dsp/sof-hda-dsp.conf
@@ -61,6 +61,16 @@ If.speaker {
 	]
 }
 
+If.speakersw {
+        Condition {
+                Type ControlExists
+                Control "name='Master Playback Switch'"
+        }
+        True.FixedBootSequence [
+                sysw "-/class/sound/ctl-led/speaker/card1/attach:Master Playback Switch"
+        ]
+}
+
 If.headphone {
 	Condition {
 		Type ControlExists


### PR DESCRIPTION
There's a speaker led on Dell G16 and use sof-hda-dsp to control.