### PR TITLE
Use case for the Arturia Minifuse 4 Audiointerface 

### DIFF
--- a/ucm2/USB-Audio/Arturia/Minifuse-4-HiFi.conf
+++ b/ucm2/USB-Audio/Arturia/Minifuse-4-HiFi.conf
@@ -1,0 +1,180 @@
+Include.pcm_split.File "/common/pcm/split.conf"
+Macro [
+	{
+		SplitPCM {
+			Name "minifuse4_stereo_out"
+			Direction Playback
+			Channels 2
+			HWChannels 6
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 FL
+			HWChannelPos3 FR
+                        HWChannelPos4 FL
+                        HWChannelPos5 FR
+		}
+	}
+	{
+		SplitPCM {
+			Name "minifuse4_stereo_in"
+			Direction Capture
+			Channels 2
+			HWChannels 6
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 FL
+			HWChannelPos3 FR
+                        HWChannelPos4 FL
+                        HWChannelPos5 FR
+		}
+	}
+	{
+		SplitPCM {
+			Name "minifuse4_mono_in"
+			Direction Capture
+			Channels 1
+			HWChannels 6
+			HWChannelPos0 MONO
+			HWChannelPos1 MONO
+			HWChannelPos2 MONO
+			HWChannelPos3 MONO
+                        HWChannelPos4 MONO
+                        HWChannelPos5 MONO
+		}
+	}
+]
+
+SectionDevice."Line1" {
+	Comment "Main Output 1L/2R"
+
+	Value {
+		PlaybackPriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "minifuse4_stereo_out"
+		Direction Playback
+		HWChannels 6
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+
+SectionDevice."Line2" {
+        Comment "Stereo Output 3/4"
+
+        Value {
+                PlaybackPriority 300
+        }
+        Macro.pcm_split.SplitPCMDevice {
+                Name "minifuse4_stereo_out"
+                Direction Playback
+                HWChannels 6
+                Channels 2
+                Channel0 2
+                Channel1 3
+                ChannelPos0 FL
+                ChannelPos1 FR
+        }
+}
+
+
+SectionDevice."Line3" {
+	Comment "Loopback L/R"
+
+	Value {
+		PlaybackPriority 200
+		CapturePriority 200
+	}
+	Macro.pcm_split1.SplitPCMDevice {
+		Name "minifuse4_stereo_out"
+		Direction Playback
+		HWChannels 6
+		Channels 2
+		Channel0 4
+		Channel1 5
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+	Macro.pcm_split2.SplitPCMDevice {
+		Name "minifuse4_stereo_in"
+		Direction Capture
+		HWChannels 6
+		Channels 2
+		Channel0 4
+		Channel1 5
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line4" {
+		Comment "Stereo Input 1+2 L/R"
+
+		Value {
+			CapturePriority 100
+		}
+		Macro.pcm_split.SplitPCMDevice {
+			Name "minifuse4_stereo_in"
+			Direction Capture
+			HWChannels 6
+			Channels 2
+			Channel0 0
+			Channel1 1
+			ChannelPos0 FL
+			ChannelPos1 FR
+		}
+}
+
+SectionDevice."Line5" {
+                Comment "Stereo Input 3+4 L/R"
+
+                Value {
+                        CapturePriority 200
+                }
+                Macro.pcm_split.SplitPCMDevice {
+                        Name "minifuse4_stereo_in"
+                        Direction Capture
+                        HWChannels 6
+                        Channels 2
+                        Channel0 2
+                        Channel1 3
+                        ChannelPos0 FL
+                        ChannelPos1 FR
+                }
+}
+
+SectionDevice."Mic1" {
+		Comment "Mic/Line/Inst 1 (L)"
+
+		Value {
+			CapturePriority 400
+		}
+		Macro.pcm_split2.SplitPCMDevice {
+			Name "minifuse4_mono_in"
+			Direction Capture
+			HWChannels 6
+			Channels 1
+			Channel0 0
+			ChannelPos0 MONO
+		}
+}
+
+SectionDevice."Mic2" {
+		Comment "Mic/Line/Inst 2 (R)"
+
+		Value {
+			CapturePriority 300
+		}
+		Macro.pcm_split2.SplitPCMDevice {
+			Name "minifuse4_mono_in"
+			Direction Capture
+			HWChannels 6
+			Channels 1
+			Channel0 1
+			ChannelPos0 MONO
+		}
+}

--- a/ucm2/USB-Audio/Arturia/Minifuse-4.conf
+++ b/ucm2/USB-Audio/Arturia/Minifuse-4.conf
@@ -1,0 +1,11 @@
+Comment "Arturia Minifuse 4"
+
+SectionUseCase."HiFi" {
+	Comment "Default Alsa Profile"
+	File "/USB-Audio/Arturia/Minifuse-4-HiFi.conf"
+}
+
+Define.DirectPlaybackChannels 6
+Define.DirectCaptureChannels 6
+
+Include.dhw.File "/common/direct.conf"

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -265,6 +265,15 @@ If.minifuse12 {
 	True.Define.ProfileName "Arturia/Minifuse-12"
 }
 
+If.minifuse4 {
+        Condition {
+                Type RegexMatch
+                String "${CardComponents}"
+                Regex "USB1c75:af[7]0"
+        }
+        True.Define.ProfileName "Arturia/Minifuse-4"
+}
+
 If.id4-0003 {
 	Condition {
 		Type String


### PR DESCRIPTION
Use case for the Arturia Minifuse 4 Audiointerface 
https://www.arturia.com/products/audio/minifuse/minifuse4

Based on the existing Minifuse 2 Profile.
#145 

I created a separate file because of the additional input- and output-Pairs result in different loopback channels.

Without the usecase outputs threated as surround channels.