### PR TITLE
USB-Audio: ALC4080 - Add MSI MAG B650M MORTAR WIFI

### DIFF
--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -65,6 +65,7 @@ If.realtek-alc4080 {
 		# 0db0:62a4 MSI MPG Z790I Edge WiFi
 		# 0db0:6c09 MSI MPG Z790 Carbon Wifi
 		# 0db0:6cc9 MSI MPG Z590 Gaming Plus
+		# 0db0:7696 MSI MAG B650M Mortar Wifi
 		# 0db0:82c7 MSI MEG Z690I Unify
 		# 0db0:961e MSI MEG X670E ACE
 		# 0db0:a073 MSI MAG X570S Torpedo Max
@@ -73,7 +74,7 @@ If.realtek-alc4080 {
 		# 0db0:b202 MSI MAG Z690 Tomahawk Wifi
 		# 0db0:d1d7 MSI PRO Z790-A WIFI
 		# 0db0:d6e7 MSI MPG X670E Carbon Wifi
-		Regex "USB((0414:a0(0e|1[02]))|(0b05:(19(84|9[69])|1a(16|2[07]|5[23])))|(0db0:(005a|151f|1feb|36e7|419c|422d|4240|62a4|6c[0c]9|82c7|961e|a073|a47c|a74b|b202|d1d7|d6e7)))"
+		Regex "USB((0414:a0(0e|1[02]))|(0b05:(19(84|9[69])|1a(16|2[07]|5[23])))|(0db0:(005a|151f|1feb|36e7|419c|422d|4240|62a4|6c[0c]9|7696|82c7|961e|a073|a47c|a74b|b202|d1d7|d6e7)))"
 	}
 	True.Define.ProfileName "Realtek/ALC4080"
 }


### PR DESCRIPTION
USB ID: 0db0:7696

Adds support for the MSI MAG B650M MORTAR WIFI motherboard front & back 3.5mm jacks.