### PR TITLE
Tegra: add UCM configuration for RT5631, WM8903 and MAX98089 based devices

### DIFF
--- a/ucm2/Tegra/max98089/lge-x3-HiFi.conf
+++ b/ucm2/Tegra/max98089/lge-x3-HiFi.conf
@@ -1,0 +1,148 @@
+# Use case Configuration for MAX98089 on LG Optimus 4X HD/Vu P880/P895
+
+SectionDevice."Speaker" {
+	Comment "Speaker"
+
+	ConflictingDevice [
+		"Headphones"
+	]
+
+	EnableSequence [
+		cset "name='Speaker Switch' on"
+		cset "name='Int Spk Switch' on"
+
+		cset "name='Left SPK Mixer Left DAC1 Switch' on"
+		cset "name='Left SPK Mixer Left DAC2 Switch' on"
+		cset "name='Left SPK Mixer Right DAC1 Switch' on"
+		cset "name='Left SPK Mixer Right DAC2 Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Speaker Switch' off"
+		cset "name='Int Spk Switch' off"
+
+		cset "name='Left SPK Mixer Left DAC1 Switch' off"
+		cset "name='Left SPK Mixer Left DAC2 Switch' off"
+		cset "name='Left SPK Mixer Right DAC1 Switch' off"
+		cset "name='Left SPK Mixer Right DAC2 Switch' off"
+	]
+
+	Value {
+		PlaybackPCM "hw:${CardId}"
+		PlaybackChannels 2
+		PlaybackPriority 300
+
+		PlaybackMixerElem "Speaker"
+	}
+}
+
+SectionDevice."Headphones" {
+	Comment "Headphones"
+
+	ConflictingDevice [
+		"Speaker"
+	]
+
+	EnableSequence [
+		cset "name='Headphone Switch' on"
+
+		cset "name='Left HP Mixer Left DAC1 Switch' on"
+		cset "name='Left HP Mixer Left DAC2 Switch' on"
+		cset "name='Right HP Mixer Right DAC1 Switch' on"
+		cset "name='Right HP Mixer Right DAC2 Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Headphone Switch' off"
+
+		cset "name='Left HP Mixer Left DAC1 Switch' off"
+		cset "name='Left HP Mixer Left DAC2 Switch' off"
+		cset "name='Right HP Mixer Right DAC1 Switch' off"
+		cset "name='Right HP Mixer Right DAC2 Switch' off"
+	]
+
+	Value {
+		PlaybackPCM "hw:${CardId}"
+		PlaybackChannels 2
+		PlaybackPriority 100
+
+		PlaybackMixerElem "Headphone"
+
+		JackControl "Headphone Jack"
+	}
+}
+
+SectionDevice."Mic1" {
+	Comment "Internal Microphone"
+
+	ConflictingDevice [
+		"Mic2"
+	]
+
+	EnableSequence [
+		# Main MIC
+		cset "name='Internal Mic 1 Switch' on"
+		cset "name='DAI1 ADC Filter' fc=258/fs=16k"
+
+		cset "name='Left ADC Mixer MIC1 Switch' on"
+		cset "name='Right ADC Mixer MIC1 Switch' on"
+
+		# Secondary MIC
+		cset "name='Int Mic Switch' on"
+		cset "name='Internal Mic 2 Switch' on"
+
+		cset "name='Left ADC Mixer MIC2 Switch' on"
+		cset "name='Right ADC Mixer MIC2 Switch' on"
+	]
+
+	DisableSequence [
+		# Main MIC
+		cset "name='Internal Mic 1 Switch' off"
+		cset "name='DAI1 ADC Filter' off"
+
+		cset "name='Left ADC Mixer MIC1 Switch' off"
+		cset "name='Right ADC Mixer MIC1 Switch' off"
+
+		# Secondary MIC
+		cset "name='Int Mic Switch' off"
+		cset "name='Internal Mic 2 Switch' off"
+
+		cset "name='Left ADC Mixer MIC2 Switch' off"
+		cset "name='Right ADC Mixer MIC2 Switch' off"
+	]
+
+	Value {
+		CapturePCM "hw:${CardId}"
+		CaptureChannels 2
+		CapturePriority 200
+	}
+}
+
+SectionDevice."Mic2" {
+	Comment "External Microphone"
+
+	ConflictingDevice [
+		"Mic1"
+	]
+
+	EnableSequence [
+		cset "name='Mic Jack Switch' on"
+
+		cset "name='Left ADC Mixer INA1 Switch' on"
+		cset "name='Right ADC Mixer INA1 Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Mic Jack Switch' off"
+
+		cset "name='Left ADC Mixer INA1 Switch' off"
+		cset "name='Right ADC Mixer INA1 Switch' off"
+	]
+
+	Value {
+		CapturePCM "hw:${CardId}"
+		CapturePriority 100
+
+		JackControl "Mic Jack"
+	}
+}

--- a/ucm2/Tegra/max98089/lge-x3-VoiceCall.conf
+++ b/ucm2/Tegra/max98089/lge-x3-VoiceCall.conf
@@ -1,0 +1,125 @@
+# Use case Configuration for MAX98089 on LG Optimus 4X HD/Vu P880/P895
+
+SectionDevice."Speaker" {
+	Comment "Speaker"
+
+	ConflictingDevice [
+		"Earpiece"
+	]
+
+	EnableSequence [
+		cset "name='Speaker Switch' on"
+		cset "name='Int Spk Switch' on"
+
+		cset "name='Left SPK Mixer Left DAC1 Switch' on"
+		cset "name='Left SPK Mixer Left DAC2 Switch' on"
+		cset "name='Left SPK Mixer Right DAC1 Switch' on"
+		cset "name='Left SPK Mixer Right DAC2 Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Speaker Switch' off"
+		cset "name='Int Spk Switch' off"
+
+		cset "name='Left SPK Mixer Left DAC1 Switch' off"
+		cset "name='Left SPK Mixer Left DAC2 Switch' off"
+		cset "name='Left SPK Mixer Right DAC1 Switch' off"
+		cset "name='Left SPK Mixer Right DAC2 Switch' off"
+	]
+
+	Value {
+		PlaybackPCM "hw:${CardId}"
+		PlaybackChannels 2
+		PlaybackPriority 100
+
+		PlaybackMixerElem "Speaker"
+	}
+}
+
+SectionDevice."Earpiece" {
+	Comment "Earpiece"
+
+	ConflictingDevice [
+		"Speaker"
+	]
+
+	EnableSequence [
+		cset "name='Receiver Switch' on"
+		cset "name='Earpiece Switch' on"
+
+		cset "name='Left REC Mixer Left DAC1 Switch' on"
+		cset "name='Left REC Mixer Left DAC2 Switch' on"
+		cset "name='Left REC Mixer Right DAC1 Switch' on"
+		cset "name='Left REC Mixer Right DAC2 Switch' on"
+
+		cset "name='Right REC Mixer Left DAC1 Switch' on"
+		cset "name='Right REC Mixer Left DAC2 Switch' on"
+		cset "name='Right REC Mixer Right DAC1 Switch' on"
+		cset "name='Right REC Mixer Right DAC2 Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Receiver Switch' off"
+		cset "name='Earpiece Switch' off"
+
+		cset "name='Left REC Mixer Left DAC1 Switch' off"
+		cset "name='Left REC Mixer Left DAC2 Switch' off"
+		cset "name='Left REC Mixer Right DAC1 Switch' off"
+		cset "name='Left REC Mixer Right DAC2 Switch' off"
+
+		cset "name='Right REC Mixer Left DAC1 Switch' off"
+		cset "name='Right REC Mixer Left DAC2 Switch' off"
+		cset "name='Right REC Mixer Right DAC1 Switch' off"
+		cset "name='Right REC Mixer Right DAC2 Switch' off"
+	]
+
+	Value {
+		PlaybackPCM "hw:${CardId}"
+		PlaybackChannels 2
+		PlaybackPriority 200
+
+		PlaybackMixerElem "Receiver"
+	}
+}
+
+SectionDevice."Mic1" {
+	Comment "Internal Microphone"
+
+	EnableSequence [
+		# Main MIC
+		cset "name='Internal Mic 1 Switch' on"
+		cset "name='DAI1 ADC Filter' fc=258/fs=16k"
+
+		cset "name='Left ADC Mixer MIC1 Switch' on"
+		cset "name='Right ADC Mixer MIC1 Switch' on"
+
+		# Secondary MIC
+		cset "name='Int Mic Switch' on"
+		cset "name='Internal Mic 2 Switch' on"
+
+		cset "name='Left ADC Mixer MIC2 Switch' on"
+		cset "name='Right ADC Mixer MIC2 Switch' on"
+	]
+
+	DisableSequence [
+		# Main MIC
+		cset "name='Internal Mic 1 Switch' off"
+		cset "name='DAI1 ADC Filter' off"
+
+		cset "name='Left ADC Mixer MIC1 Switch' off"
+		cset "name='Right ADC Mixer MIC1 Switch' off"
+
+		# Secondary MIC
+		cset "name='Int Mic Switch' off"
+		cset "name='Internal Mic 2 Switch' off"
+
+		cset "name='Left ADC Mixer MIC2 Switch' off"
+		cset "name='Right ADC Mixer MIC2 Switch' off"
+	]
+
+	Value {
+		CapturePCM "hw:${CardId}"
+		CaptureChannels 2
+		CapturePriority 200
+	}
+}

--- a/ucm2/Tegra/max98089/lge-x3.conf
+++ b/ucm2/Tegra/max98089/lge-x3.conf
@@ -1,0 +1,47 @@
+# Use case Configuration for MAX98089 on LG Optimus 4X HD/Vu P880/P895
+
+Syntax 4
+
+BootSequence [
+	cset "name='MIC1 Volume' 10"
+	cset "name='MIC1 Boost Volume' 1"
+	cset "name='MIC2 Volume' 10"
+	cset "name='MIC2 Boost Volume' 1"
+
+	cset "name='INA Volume' 5"
+	cset "name='INB Volume' 5"
+
+	cset "name='ADCL Volume' 15"
+	cset "name='ADCR Volume' 15"
+
+	cset "name='DAI1 Filter Mode' Music"
+
+	cset "name='EQ1 Switch' off"
+	cset "name='EQ2 Switch' off"
+
+	cset "name='Speaker Switch' off"
+	cset "name='Int Spk Switch' off"
+	cset "name='Headphone Switch' off"
+	cset "name='Earpiece Switch' off"
+	cset "name='Receiver Switch' off"
+
+	cset "name='Int Mic Switch' off"
+	cset "name='Internal Mic 1 Switch' off"
+	cset "name='Internal Mic 2 Switch' off"
+	cset "name='Mic Jack Switch' off"
+
+	cset "name='Right SPK Mixer Left DAC1 Switch' on"
+	cset "name='Right SPK Mixer Left DAC2 Switch' on"
+	cset "name='Right SPK Mixer Right DAC1 Switch' on"
+	cset "name='Right SPK Mixer Right DAC2 Switch' on"
+]
+
+SectionUseCase."HiFi" {
+    File "/Tegra/max98089/lge-x3-HiFi.conf"
+    Comment "Play HiFi quality Music"
+}
+
+SectionUseCase."Voice Call" {
+    File "/Tegra/max98089/lge-x3-VoiceCall.conf"
+    Comment "Make a phone call"
+}

--- a/ucm2/Tegra/rt5631/Asus-Transformer-HiFi.conf
+++ b/ucm2/Tegra/rt5631/Asus-Transformer-HiFi.conf
@@ -1,0 +1,101 @@
+# Use case Configuration for RT5631 based ASUS Transformers
+
+SectionDevice."Speaker" {
+	Comment "Speaker"
+
+	ConflictingDevice [
+		"Headphones"
+	]
+
+	EnableSequence [
+		cset "name='Speaker Playback Switch' on"
+		cset "name='Int Spk Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Int Spk Switch' off"
+		cset "name='Speaker Playback Switch' off"
+	]
+
+	Value {
+		PlaybackPCM "hw:${CardId}"
+		PlaybackChannels 2
+		PlaybackPriority 200
+
+		PlaybackMixerElem "Speaker"
+	}
+}
+
+SectionDevice."Headphones" {
+	Comment "Headphones"
+
+	ConflictingDevice [
+		"Speaker"
+	]
+
+	EnableSequence [
+		cset "name='HP Playback Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='HP Playback Switch' off"
+	]
+
+	Value {
+		PlaybackPCM "hw:${CardId}"
+		PlaybackChannels 2
+		PlaybackPriority 100
+
+		PlaybackMixerElem "HP"
+
+		JackControl "Headphone Jack"
+	}
+}
+
+SectionDevice."Mic1" {
+	Comment "Internal Microphone"
+
+	ConflictingDevice [
+		"Mic2"
+	]
+
+	EnableSequence [
+		cset "name='DMIC Capture Switch' on"
+		cset "name='DMIC Switch' on"
+		cset "name='Int Mic Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='DMIC Capture Switch' off"
+		cset "name='DMIC Switch' off"
+		cset "name='Int Mic Switch' off"
+	]
+
+	Value {
+		CapturePCM "hw:${CardId}"
+		CapturePriority 200
+	}
+}
+
+SectionDevice."Mic2" {
+	Comment "External Microphone"
+
+	ConflictingDevice [
+		"Mic1"
+	]
+
+	EnableSequence [
+		cset "name='Mic Jack Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Mic Jack Switch' off"
+	]
+
+	Value {
+		CapturePCM "hw:${CardId}"
+		CapturePriority 100
+
+		JackControl "Mic Jack"
+	}
+}

--- a/ucm2/Tegra/rt5631/Asus-Transformer.conf
+++ b/ucm2/Tegra/rt5631/Asus-Transformer.conf
@@ -1,0 +1,65 @@
+# Use case Configuration for RT5631 based ASUS Transformers
+
+Syntax 4
+
+BootSequence [
+	cset "name='HP Playback Switch' off"
+	cset "name='Speaker Playback Switch' off"
+
+	cset "name='PCM Playback Switch' on"
+	cset "name='PCM Playback Volume' 255"
+	cset "name='AXI Capture Volume' 23"
+
+	cset "name='AXO2 Playback Switch' on"
+	cset "name='AXO2MIX Mixer OUTVOLL Playback Switch' on"
+
+	cset "name='DMIC Switch' off"
+	cset "name='DMIC Capture Switch' off"
+
+	cset "name='HPL Mux' Left HPVOL"
+	cset "name='HPR Mux' Right HPVOL"
+
+	cset "name='Mic Jack Switch' off"
+	cset "name='Int Mic Switch' off"
+	cset "name='Int Spk Switch' on"
+
+	cset "name='Left HPVOL Mux' OUTMIXL"
+	cset "name='Left OUTVOL Mux' OUTMIXL"
+	cset "name='Left SPKVOL Mux' SPKMIXL"
+
+	cset "name='MIC1 Boost Volume' 6"
+	cset "name='MIC1 Mode Control' Differential"
+	cset "name='MIC2 Boost Volume' 6"
+	cset "name='MIC2 Mode Control' Single ended"
+
+	cset "name='MONO Playback Switch' off"
+	cset "name='MONO Mux' MONOMIX"
+	cset "name='MONOIN Mode Control' Differential"
+	cset "name='MONOIN_RX Capture Volume' 25"
+
+	cset "name='OUTMIXL Mixer DACL Playback Switch' on"
+	cset "name='OUTMIXR Mixer DACR Playback Switch' on"
+
+	cset "name='OUTVOL Channel Switch' on"
+	cset "name='RECMIXL Mixer MIC1_BST1 Capture Switch' on"
+
+	cset "name='Right HPVOL Mux' OUTMIXR"
+	cset "name='Right OUTVOL Mux' OUTMIXR"
+	cset "name='Right SPKVOL Mux' SPKMIXR"
+
+	cset "name='SPK Ratio Control' 1.99x"
+
+	cset "name='SPKMIXL Mixer DACL Playback Switch' on"
+	cset "name='SPKMIXR Mixer DACR Playback Switch' on"
+
+	cset "name='SPOL Mux' SPOLMIX"
+	cset "name='SPOLMIX Mixer SPKVOLL Playback Switch' on"
+
+	cset "name='SPOR Mux' SPORMIX"
+	cset "name='SPORMIX Mixer SPKVOLR Playback Switch' on"
+]
+
+SectionUseCase."HiFi" {
+    File "/Tegra/rt5631/Asus-Transformer-HiFi.conf"
+    Comment "Play HiFi quality Music"
+}

--- a/ucm2/Tegra/wm8903/Asus-Transformer-HiFi.conf
+++ b/ucm2/Tegra/wm8903/Asus-Transformer-HiFi.conf
@@ -1,0 +1,108 @@
+# Use case Configuration for WM8903 based ASUS Transformers
+
+SectionDevice."Speaker" {
+	Comment "Speaker"
+
+	ConflictingDevice [
+		"Headphones"
+	]
+
+	EnableSequence [
+		cset "name='Speaker Switch' on"
+		cset "name='Int Spk Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Int Spk Switch' off"
+		cset "name='Speaker Switch' off"
+	]
+
+	Value {
+		PlaybackPCM "hw:${CardId}"
+		PlaybackChannels 2
+		PlaybackPriority 200
+
+		PlaybackMixerElem "Speaker"
+	}
+}
+
+SectionDevice."Headphones" {
+	Comment "Headphones"
+
+	ConflictingDevice [
+		"Speaker"
+	]
+
+	EnableSequence [
+		cset "name='Headphone Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Headphone Switch' off"
+	]
+
+	Value {
+		PlaybackPCM "hw:${CardId}"
+		PlaybackChannels 2
+		PlaybackPriority 100
+
+		PlaybackMixerElem "Headphone"
+
+		JackControl "Headphone Jack"
+	}
+}
+
+SectionDevice."Mic1" {
+	Comment "Internal Microphone"
+
+	ConflictingDevice [
+		"Mic2"
+	]
+
+	EnableSequence [
+		cset "name='Int Mic Switch' on"
+		cset "name='ADC Input' DMIC"
+	]
+
+	DisableSequence [
+		cset "name='Int Mic Switch' off"
+	]
+
+	Value {
+		CapturePCM "hw:${CardId}"
+		CapturePriority 200
+	}
+}
+
+SectionDevice."Mic2" {
+	Comment "External Microphone"
+
+	ConflictingDevice [
+		"Mic1"
+	]
+
+	EnableSequence [
+		cset "name='Mic Jack Switch' on"
+		cset "name='ADC Input' ADC"
+
+		cset "name='Left Capture Mux' Left"
+
+		cset "name='Left Input Mux' IN1L"
+		cset "name='Left Input Inverting Mux' IN2L"
+		cset "name='Left Input Mode Mux' Differential Mic"
+
+		cset "name='Left Input PGA Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Mic Jack Switch' off"
+		cset "name='Left Input PGA Switch' off"
+	]
+
+	Value {
+		CapturePCM "hw:${CardId}"
+		CapturePriority 100
+
+		JackControl "Mic Jack"
+	}
+}

--- a/ucm2/Tegra/wm8903/Asus-Transformer.conf
+++ b/ucm2/Tegra/wm8903/Asus-Transformer.conf
@@ -1,0 +1,37 @@
+# Use case Configuration for WM8903 based ASUS Transformers
+
+Syntax 4
+
+BootSequence [
+	cset "name='HPF Switch' on"
+	cset "name='HPF Mode' Voice 1"
+
+	cset "name='DRC Switch' on"
+	cset "name='Digital Capture Volume' 127"
+
+	cset "name='Headphone Switch' off"
+	cset "name='Headphone ZC Switch' off"
+	cset "name='Headphone Volume' 45"
+
+	cset "name='Line Out Switch' on"
+	cset "name='Line Out ZC Switch' off"
+	cset "name='Line Out Volume' 57"
+
+	cset "name='Speaker Switch' off"
+	cset "name='Speaker ZC Switch' off"
+	cset "name='Speaker Volume' 60"
+
+	cset "name='Int Spk Switch' on"
+	cset "name='Int Mic Switch' off"
+	cset "name='Mic Jack Switch' off"
+
+	cset "name='ADC Input' DMIC"
+
+	cset "name='Left Speaker Mixer DACL Switch' on"
+	cset "name='Right Speaker Mixer DACR Switch' on"
+]
+
+SectionUseCase."HiFi" {
+    File "/Tegra/wm8903/Asus-Transformer-HiFi.conf"
+    Comment "Play HiFi quality Music"
+}

--- a/ucm2/conf.d/tegra/Asus EeePad Slider WM8903.conf
+++ b/ucm2/conf.d/tegra/Asus EeePad Slider WM8903.conf
@@ -1,0 +1,1 @@
+../../Tegra/wm8903/Asus-Transformer.conf

--- a/ucm2/conf.d/tegra/Asus EeePad Transformer WM8903.conf
+++ b/ucm2/conf.d/tegra/Asus EeePad Transformer WM8903.conf
@@ -1,0 +1,1 @@
+../../Tegra/wm8903/Asus-Transformer.conf

--- a/ucm2/conf.d/tegra/Asus Transformer Infinity TF700T RT5631.conf
+++ b/ucm2/conf.d/tegra/Asus Transformer Infinity TF700T RT5631.conf
@@ -1,0 +1,1 @@
+../../Tegra/rt5631/Asus-Transformer.conf

--- a/ucm2/conf.d/tegra/Asus Transformer Pad TF300T WM8903.conf
+++ b/ucm2/conf.d/tegra/Asus Transformer Pad TF300T WM8903.conf
@@ -1,0 +1,1 @@
+../../Tegra/wm8903/Asus-Transformer.conf

--- a/ucm2/conf.d/tegra/Asus Transformer Pad TF300TG RT5631.conf
+++ b/ucm2/conf.d/tegra/Asus Transformer Pad TF300TG RT5631.conf
@@ -1,0 +1,1 @@
+../../Tegra/rt5631/Asus-Transformer.conf

--- a/ucm2/conf.d/tegra/Asus Transformer Pad TF300TL RT5631.conf
+++ b/ucm2/conf.d/tegra/Asus Transformer Pad TF300TL RT5631.conf
@@ -1,0 +1,1 @@
+../../Tegra/rt5631/Asus-Transformer.conf

--- a/ucm2/conf.d/tegra/Asus Transformer Prime TF201 RT5631.conf
+++ b/ucm2/conf.d/tegra/Asus Transformer Prime TF201 RT5631.conf
@@ -1,0 +1,1 @@
+../../Tegra/rt5631/Asus-Transformer.conf

--- a/ucm2/conf.d/tegra/LG Optimus 4X HD MAX98089.conf
+++ b/ucm2/conf.d/tegra/LG Optimus 4X HD MAX98089.conf
@@ -1,0 +1,1 @@
+../../Tegra/max98089/lge-x3.conf

--- a/ucm2/conf.d/tegra/LG Optimus Vu MAX98089.conf
+++ b/ucm2/conf.d/tegra/LG Optimus Vu MAX98089.conf
@@ -1,0 +1,1 @@
+../../Tegra/max98089/lge-x3.conf


### PR DESCRIPTION
Proposed UCM configurations were tested for a while on wide range of devices.
Did not cause any issues so far.

List of supported devices using RT5631:
- ASUS TF201
- ASUS TF300TG
- ASUS TF300TL
- ASUS TF700T 

using WM8903:
- ASUS TF101
- ASUS SL101
- ASUS TF300T

using MAX98089
- LG P880
- LG P895