### PR TITLE
USB-Audio: Add Sony inzone H7/H9 headset default/HiFi usecase

### DIFF
--- a/ucm2/USB-Audio/Sony/Inzone-H9-H7-HiFi.conf
+++ b/ucm2/USB-Audio/Sony/Inzone-H9-H7-HiFi.conf
@@ -1,0 +1,17 @@
+SectionDevice."Headset" {
+	Comment "Chat"
+	Value {
+		PlaybackChannels 2
+		PlaybackPCM "hw:${CardId},DEV=0"
+		CaptureChannels 1
+		CapturePCM "hw:${CardId},DEV=0"
+	}
+}
+
+SectionDevice."Headphones" {
+	Comment "Game"
+	Value {
+		PlaybackChannels 2
+		PlaybackPCM "hw:${CardId},DEV=1"
+	}
+}

--- a/ucm2/USB-Audio/Sony/Inzone-H9-H7.conf
+++ b/ucm2/USB-Audio/Sony/Inzone-H9-H7.conf
@@ -1,0 +1,6 @@
+Comment "Sony Corp. INZONE H9 / INZONE H7"
+
+SectionUseCase."HiFi" {
+	Comment "Default"
+	File "/USB-Audio/Sony/Inzone-H9-H7-HiFi.conf"
+}

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -286,6 +286,16 @@ If.id4-0009 {
 	True.Define.ProfileName "Audient/Audient-iD4-0009"
 }
 
+If.sony-inzone-h9-h7 {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		# 054c:0e53 Sony Corp. INZONE H9 / INZONE H7
+		Needle "USB054c:0e53"
+	}
+	True.Define.ProfileName "Sony/Inzone-H9-H7"
+}
+
 If.mixremap {
 	Condition {
 		Type String


### PR DESCRIPTION
The Sony inzone H7/H9 headset has two usb audio outputs and one usb audio input.

One pair of audio output and input is the 'chat' interface which is normally connected to a chat client.

The remaining audio ouput is the 'game' interface, which is normally connected to the actual game you're playing.

The 'game' interface lists as a separate USB subdevice in alsa.

This commit adds the HiFi usecase for the Sony headset which is as follows:
- One chat device
  - One audio output
  - One audio input
- One game device
  - One audio output

Tested with pipewire and pulseaudio, verified with pavucontrol, both devices are listed and audio can be played on both. The audio is mixed in the headset itself.

Control wise there isn't much, the only thing that is reported in alsamixer is a volume control for the CAPTURE channel. However, changing the volume of this does not seem to affect the actual audio that is recorded, so I don't see a need to change this when enabling the device.