### PR TITLE
ucm2: codecs: va-macro: fix dmic1 mux setting

### DIFF
--- a/ucm2/codecs/qcom-lpass/va-macro/DMIC1EnableSeq.conf
+++ b/ucm2/codecs/qcom-lpass/va-macro/DMIC1EnableSeq.conf
@@ -1,6 +1,6 @@
 EnableSequence [
 	cset "name='VA DEC1 MUX' VA_DMIC"
-	cset "name='VA DMIC MUX0' DMIC1"
+	cset "name='VA DMIC MUX1' DMIC1"
 	cset "name='VA_AIF1_CAP Mixer DEC1' 1"
 	cset "name='VA_DEC1 Volume' 100"
 ]


### PR DESCRIPTION
Looks like there was a typo in setting up dmic1 mux. Without this dmic01 selection would only do single channel record instead of 2 channel recording.