### PR TITLE
[V2] sof-hda-dsp: Add speaker led support

### DIFF
--- a/ucm2/Intel/sof-hda-dsp/sof-hda-dsp.conf
+++ b/ucm2/Intel/sof-hda-dsp/sof-hda-dsp.conf
@@ -61,6 +61,19 @@ If.speaker {
 	]
 }
 
+If.DellMuteLed {
+	Condition {
+                Type String
+                Haystack "$${sys:class/leds/platform::mute/device}"
+                Needle "dell-laptop"
+        }
+        True {
+                FixedBootSequence [
+                        sysw "-/class/sound/ctl-led/speaker/card${CardNumber}/attach:Master Playback Switch"
+                ]
+        }
+}
+
 If.headphone {
 	Condition {
 		Type ControlExists


### PR DESCRIPTION
Replace hard code with variable.
before: sysw "-/class/sound/ctl-led/speaker/card1/attach:Master Playback Switch"
after:    sysw "-/class/sound/ctl-led/speaker/card${CardNumber}/attach:Master Playback Switch"

