### PR TITLE
Fix gigabyte z690i aorus ultra ALC-4080

### DIFF
--- a/ucm2/USB-Audio/Realtek/ALC4080-HiFi.conf
+++ b/ucm2/USB-Audio/Realtek/ALC4080-HiFi.conf
@@ -73,6 +73,20 @@ If.spdif_dev2 {
 	True.Define.SpdifPCM "hw:${CardId},2"
 }
 
+If.gigabyte-aorus-ultra {
+	Condition {
+		Type RegexMatch
+		String "${CardComponents}"
+		Regex "USB(0414:a014)"
+	}
+	True.Define {
+		Mic1Name "Front Microphone"
+		Mic1PCM "hw:${CardId},0"
+		SpdifName ""
+		Line1Name ""
+	}
+}
+
 If.asus-rog-usb {
 	Condition {
 		Type RegexMatch

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -47,6 +47,7 @@ If.realtek-alc4080 {
 		# 0414:a00e Gigabyte Z590 Aorus Pro AX
 		# 0414:a010 Gigabyte Z590 Vision G Intel
 		# 0414:a012 Gigabyte Z690 AERO G DDR4
+		# 0414:a014 Gigabyte Z690I AORUS ULTRA DDR4
 		# 0b05:1984 ASUS Pro WS WRX80E-SAGE SE WIFI
 		# 0b05:1996 ASUS on multiple boards (including ASUS ROG Maximus XIII)
 		# 0b05:1999 ASUS ROG Strix Z590-A Gaming WiFi
@@ -76,7 +77,7 @@ If.realtek-alc4080 {
 		# 0db0:b202 MSI MAG Z690 Tomahawk Wifi
 		# 0db0:d1d7 MSI PRO Z790-A WIFI
 		# 0db0:d6e7 MSI MPG X670E Carbon Wifi
-		Regex "USB((0414:a0(0e|1[02]))|(0b05:(19(84|9[69])|1a(16|2[07]|5[23])))|(0db0:(005a|151f|1feb|3130|36e7|419c|422d|4240|62a4|6c[0c]9|7696|82c7|8af7|961e|a073|a47c|a74b|b202|d1d7|d6e7)))"
+		Regex "USB((0414:a0(0e|1[024]))|(0b05:(19(84|9[69])|1a(16|2[07]|5[23])))|(0db0:(005a|151f|1feb|3130|36e7|419c|422d|4240|62a4|6c[0c]9|7696|82c7|8af7|961e|a073|a47c|a74b|b202|d1d7|d6e7)))"
 	}
 	True.Define.ProfileName "Realtek/ALC4080"
 }


### PR DESCRIPTION
Currently the board is not matched by the regex.
Once matched the config still isn't valid.
I've got it stable with the following changes, disabling spdif and line1 and updating Mic1PCM value.

The front headphone and microphone jacks are working now, as is the rear audio out. That does leave 1 jack on the back I haven't had any luck with.

There is no spdif on the board.