### PR TITLE
Update USB-Audio.conf for ASUS ROG Strix B650E-I Gaming WiFi and ALC4080

### DIFF
--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -52,6 +52,7 @@ If.realtek-alc4080 {
 		# 0b05:1984 ASUS Pro WS WRX80E-SAGE SE WIFI
 		# 0b05:1996 ASUS on multiple boards (including ASUS ROG Maximus XIII)
 		# 0b05:1999 ASUS ROG Strix Z590-A Gaming WiFi
+		# 0b05:1a5c ASUS ROG Strix B650E-I Gaming WiFi
 		# 0b05:1a16 ASUS ROG Strix B660-F Gaming WiFi
 		# 0b05:1a20 ASUS ROG STRIX Z690-I Gaming Wifi
 		# 0b05:1a27 ALC4082 on ASUS ROG Maximus Z690 Hero
@@ -78,7 +79,7 @@ If.realtek-alc4080 {
 		# 0db0:b202 MSI MAG Z690 Tomahawk Wifi
 		# 0db0:d1d7 MSI PRO Z790-A WIFI
 		# 0db0:d6e7 MSI MPG X670E Carbon Wifi
-		Regex "USB((0414:a0(0e|1[0124]))|(0b05:(19(84|9[69])|1a(16|2[07]|5[23])))|(0db0:(005a|151f|1feb|3130|36e7|419c|422d|4240|62a4|6c[0c]9|7696|82c7|8af7|961e|a073|a47c|a74b|b202|d1d7|d6e7)))"
+		Regex "USB((0414:a0(0e|1[0124]))|(0b05:(19(84|9[69])|1a(16|2[07]|5[23]|5c)))|(0db0:(005a|151f|1feb|3130|36e7|419c|422d|4240|62a4|6c[0c]9|7696|82c7|8af7|961e|a073|a47c|a74b|b202|d1d7|d6e7)))"
 	}
 	True.Define.ProfileName "Realtek/ALC4080"
 }


### PR DESCRIPTION
Added configuration for ASUS ROG Strix B650E-I Gaming WiFi and ALC4080

Edit: Added Information from ALSA Information Script

[https://alsa-project.org/db/?f=fe7e76a335dc8f1009ecaac9aa341fb68231aee5](https://alsa-project.org/db/?f=fe7e76a335dc8f1009ecaac9aa341fb68231aee5)


```
Bus 001 Device 002: ID 0b05:1a5c ASUSTek Computer, Inc. USB Audio
Device Descriptor:
  bLength                18
  bDescriptorType         1
  bcdUSB               2.00
  bDeviceClass          239 Miscellaneous Device
  bDeviceSubClass         2 
  bDeviceProtocol         1 Interface Association
  bMaxPacketSize0        64
  idVendor           0x0b05 ASUSTek Computer, Inc.
  idProduct          0x1a5c 
  bcdDevice            0.02
  iManufacturer           3 Generic
  iProduct                1 USB Audio
  iSerial                 0 
```