### PR TITLE
ucm2: Rockchip: Add UCM support for ES8316 on Rock 5B

### DIFF
--- a/ucm2/Rockchip/rk3588-es8316/HiFi.conf
+++ b/ucm2/Rockchip/rk3588-es8316/HiFi.conf
@@ -1,0 +1,42 @@
+SectionDevice."Headphones" {
+	Comment "Headphones"
+
+	EnableSequence [
+		cset "name='Playback Polarity' 'Normal'"
+	]
+
+	DisableSequence [
+		cset "name='Playback Polarity' 'R Invert'"
+	]
+
+	Value {
+		PlaybackPriority 200
+		PlaybackPCM "hw:${CardId}"
+		PlaybackMixerElem "Headphone Mixer"
+		PlaybackMasterElem "DAC"
+		JackControl "Headphones Jack"
+	}
+}
+
+SectionDevice."Headset" {
+	Comment "Headset Microphone on IN2"
+
+	EnableSequence [
+		cset "name='Differential Mux' lin2-rin2"
+		cset "name='Left Headphone Mux' lin2-rin2"
+		cset "name='Right Headphone Mux' lin2-rin2"
+	]
+
+	DisableSequence [
+		cset "name='Differential Mux' lin1-rin1"
+		cset "name='Left Headphone Mux' lin1-rin1"
+		cset "name='Right Headphone Mux' lin1-rin1"
+	]
+
+	Value {
+		CapturePriority 200
+		CapturePCM "hw:${CardId}"
+		CaptureMixerElem "ADC PGA Gain"
+		CaptureMasterElem "ADC"
+	}
+}

--- a/ucm2/Rockchip/rk3588-es8316/rk3588-es8316.conf
+++ b/ucm2/Rockchip/rk3588-es8316/rk3588-es8316.conf
@@ -1,0 +1,26 @@
+Syntax 3
+
+SectionUseCase."HiFi" {
+	File "/Rockchip/rk3588-es8316/HiFi.conf"
+	Comment "Play HiFi quality Music"
+}
+
+BootSequence [
+	# Set HP vol to 0 dB (3/3)
+	cset "name='Headphone Playback Volume' 3"
+	# Set HP mixer vol to 0 dB
+	cset "name='Headphone Mixer Volume' 11"
+	# Set DAC vol to 0 dB (192/192)
+	cset "name='DAC Playback Volume' 192"
+
+	# Disable Auto Level Control
+	cset "name='ALC Capture Switch' off"
+	# Set ADC vol to 0 dB (192/192)
+	cset "name='ADC Capture Volume' 192"
+	# Set Mic amplifier to +16 dB
+	cset "name='ADC PGA Gain Volume' 7"
+
+	# Setup muxes / switches
+	cset "name='Left Headphone Mixer Left DAC Switch' on"
+	cset "name='Right Headphone Mixer Right DAC Switch' on"
+]

--- a/ucm2/conf.d/rk3588-es8316/rk3588-es8316.conf
+++ b/ucm2/conf.d/rk3588-es8316/rk3588-es8316.conf
@@ -1,0 +1,1 @@
+../../Rockchip/rk3588-es8316/rk3588-es8316.conf


### PR DESCRIPTION
Add UCM configuration for the RK3588 SoC based Rock 5B board to enable the analog audio support provided by the Everest Semi ES8316 codec.