### PR TITLE
Add Asus ROG STRIX X670E-F Gaming Wifi to USB-Audio.conf

### DIFF
--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -55,7 +55,7 @@ If.realtek-alc4080 {
 		# 0b05:1a16 ASUS ROG Strix B660-F Gaming WiFi
 		# 0b05:1a20 ASUS ROG STRIX Z690-I Gaming Wifi
 		# 0b05:1a27 ALC4082 on ASUS ROG Maximus Z690 Hero
-		# 0b05:1a52 ASUS ROG Strix Z790-E Gaming Wifi
+		# 0b05:1a52 ASUS ROG Strix X670E-F & Z790-E Gaming Wifi
 		# 0b05:1a53 ALC4082 on ASUS ROG Crosshair X670E Extreme
 		# 0db0:005a MSI MPG Z690 CARBON WIFI
 		# 0db0:151f MSI X570S EDGE MAX WIFI


### PR DESCRIPTION
Since the id was already present in the list, I have only added a comment denoting this board also uses that id

My alsa-info as a proof can be found here: http://alsa-project.org/db/?f=1ad83f467dc312e2ac7743859c647695dbccb6ce