### PR TITLE
ucm2: PinePhone: use "Mix Mono" routing for earpiece

### DIFF
--- a/ucm2/Allwinner/A64/PinePhone/HiFi.conf
+++ b/ucm2/Allwinner/A64/PinePhone/HiFi.conf
@@ -26,11 +26,13 @@ SectionDevice."Earpiece" {
 	Comment "Internal Earpiece"
 
 	EnableSequence [
+		cset "name='AIF1 DA0 Stereo Playback Route' Mix Mono"
 		cset "name='Earpiece Playback Switch' on"
 	]
 
 	DisableSequence [
 		cset "name='Earpiece Playback Switch' off"
+		cset "name='AIF1 DA0 Stereo Playback Route' Stereo"
 	]
 
 	Value {

--- a/ucm2/Allwinner/A64/PinePhone/VoiceCall.conf
+++ b/ucm2/Allwinner/A64/PinePhone/VoiceCall.conf
@@ -31,11 +31,13 @@ SectionDevice."Earpiece" {
 	Comment "Internal Earpiece"
 
 	EnableSequence [
+		cset "name='AIF1 DA0 Stereo Playback Route' Mix Mono"
 		cset "name='Earpiece Playback Switch' on"
 	]
 
 	DisableSequence [
 		cset "name='Earpiece Playback Switch' off"
+		cset "name='AIF1 DA0 Stereo Playback Route' Stereo"
 	]
 
 	Value {


### PR DESCRIPTION
The earpiece speaker is a mono device, using only a single channel (in our case, the left one) from the DA0 output. This causes loss of information as the right channel is completely discarded when playing stereo audio.

In order to avoid this issue, set `AIF1 DA0 Stereo Playback Route` to `Mix Mono` when using the "Earpiece" output port (and only in this case).