### PR TITLE
Intel/sof-essx8336: Fix HiFi.conf

### DIFF
--- a/ucm2/Intel/sof-essx8336/HiFi.conf
+++ b/ucm2/Intel/sof-essx8336/HiFi.conf
@@ -82,6 +82,7 @@ SectionDevice."Speaker" {
 	DisableSequence [
 		cset "name='Speaker Switch' off"
 	]
+
 	Value {
 		PlaybackPriority 100
 		PlaybackPCM "hw:${CardId}"
@@ -97,6 +98,14 @@ SectionDevice."Headphones" {
 
 	ConflictingDevice [
 		"Speaker"
+	]
+
+	EnableSequence [
+		cset "name='Headphone Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Headphone Switch' off"
 	]
 
 	Value {
@@ -123,12 +132,12 @@ SectionDevice."Headset" {
 	}
 
 	EnableSequence [
-		cset "name='Headset Switch' on"
+		cset "name='Headset Mic Switch' on"
 		cset "name='Digital Mic Mux' 'dmic disable'"
 	]
 
 	DisableSequence [
-		cset "name='Headset Switch' on"
+		cset "name='Headset Mic Switch' off"
 	]
 
 	Value {


### PR DESCRIPTION
1. <del>Enable Left/Right Headphone Mixer Left/Right DAC Switch in BootSequence.  Despite they seem enabled in sof-essx8336.conf, if I don't add this I'll need to enable them with alsamixer.  I guess they are killed by disdevall.</del>
2. Switch Headphone on/off in Headphones enable/disable sequence.  This should be obvious.
3. "Headset Switch" is not recognized and triggers errors running "alsaucm -c hw:0 set _verb Hifi".  Change it to "Headset Mic Switch". And in the disable sequence we should turn it off, not on.