### PR TITLE
USB-Audio: Add Steinberg UR44C

### DIFF
--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -103,9 +103,9 @@ If.steinberg-ur24c {
 
 If.steinberg-ur44 {
 	Condition {
-		Type String
-		Haystack "${CardComponents}"
-		Needle "USB0499:1700"
+		Type RegexMatch
+		String "${CardComponents}"
+		Regex "USB0499:17[03]0"
 	}
 	True.Define.ProfileName "Steinberg/UR44"
 }


### PR DESCRIPTION
Adds support for the Steinberg UR44C. In fact, it is similar to the Steinberg UR44, but uses USB-C with USB 3.1 and has a different USB devnum (1730 instead of 1700).