### PR TITLE
ucm2: Qualcomm: sc8280xp: fix device numbers

### DIFF
--- a/ucm2/Qualcomm/sc8280xp/HiFi.conf
+++ b/ucm2/Qualcomm/sc8280xp/HiFi.conf
@@ -27,7 +27,7 @@ SectionDevice."Speaker" {
 
 	Value {
 		PlaybackPriority 100
-		PlaybackPCM "hw:${CardId},5"
+		PlaybackPCM "hw:${CardId},1"
 		PlaybackMixer "default:${CardId}"
 	}
 }
@@ -42,7 +42,7 @@ SectionDevice."Headphones" {
 
 	Value {
 		PlaybackPriority 200
-		PlaybackPCM "hw:${CardId},4"
+		PlaybackPCM "hw:${CardId},0"
 		PlaybackMixer "default:${CardId}"
 		PlaybackMixerElem "HP Digital"
 		JackControl "Headphone Jack"
@@ -60,7 +60,7 @@ SectionDevice."Mic" {
 
 	Value {
 		CapturePriority 100
-		CapturePCM "hw:${CardId},6"
+		CapturePCM "hw:${CardId},2"
 		CaptureMixerElem "ADC2"
 		JackControl "Mic Jack"
 		JackHWMute "DMic01"
@@ -78,6 +78,6 @@ SectionDevice."DMic01" {
 
 	Value {
 		CapturePriority 100
-		CapturePCM "hw:${CardId},7"
+		CapturePCM "hw:${CardId},3"
 	}
 }


### PR DESCRIPTION
Due to a bug in the Qualcomm ASoC drivers, we ended up with card device numbers starting at some number that is not dai-link id. This bug is now fixed, so update the ucm files inline with this.

Fixes: https://github.com/alsa-project/alsa-ucm-conf/pull/284