### PR TITLE
SplitPCM: Fix Device variable in SplitPCMDevice macro

### DIFF
--- a/ucm2/common/pcm/split.conf
+++ b/ucm2/common/pcm/split.conf
@@ -323,13 +323,12 @@ DefineMacro.SplitPCM.If.0 {
 #
 
 DefineMacro.SplitPCMDevice {
-	Define.__dev ""
 	If.0 {
 		Condition {
 			Type String
-			Empty "${var:__dev}"
+			Empty "${var:__Device}"
 		}
-		True.Define.__dev "0"
+		True.Define.__Device "0"
 	}
 	If.1 {
 		Condition {
@@ -339,7 +338,7 @@ DefineMacro.SplitPCMDevice {
 		False {
 			Value {
 				"${var:__Direction}Channels" "${var:__HWChannels}"
-				"${var:__Direction}PCM" "hw:${CardId},${var:__dev}"
+				"${var:__Direction}PCM" "hw:${CardId},${var:__Device}"
 				"${var:__Direction}Channel0" "${var:__Channel0}"
 				"${var:__Direction}ChannelPos0" "${var:__ChannelPos0}"
 			}
@@ -355,7 +354,7 @@ DefineMacro.SplitPCMDevice {
 			}
 		}
 		True {
-			Define.__pcmdev "${var:__Name}:${CardId},${var:__dev},${var:__Channel0}"
+			Define.__pcmdev "${var:__Name}:${CardId},${var:__Device},${var:__Channel0}"
 			If.ch1 {
 				Condition {
 					Type String


### PR DESCRIPTION
Currently, the variable name is dev instead of Device as the comment would suggest, update the name to fit the comment. Also, the variable gets ignored due to it getting set to nothing right away, remove that line to allow the variable to work as intended.