### PR TITLE
ucm2 profile for Universal Audio Volt 2

### DIFF
--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -210,6 +210,17 @@ If.focusrite-scarlett-2i {
 	}
 }
 
+If.ua-volt2 {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB2b5a:0021"
+	}
+	True.Define {
+		ProfileName "UniversalAudio/Volt2"
+	}
+}
+
 If.behringer-umc202hd {
 	Condition {
 		Type String

--- a/ucm2/USB-Audio/UniversalAudio/Volt2-HiFi.conf
+++ b/ucm2/USB-Audio/UniversalAudio/Volt2-HiFi.conf
@@ -1,0 +1,54 @@
+Include.pcm_split.File "/common/pcm/split.conf"
+
+Macro [
+	{
+		SplitPCM {
+			Name "volt2_mono_in"
+			Direction Capture
+			Channels 1
+			HWChannels 2
+			HWChannelPos0 MONO
+			HWChannelPos1 MONO
+		}
+	}
+]
+
+SectionDevice."Line1" {
+	Comment "Monitor Out"
+	Value {
+		PlaybackPriority 200
+		PlaybackPCM "hw:${CardId}"
+	}
+}
+
+SectionDevice."Mic1" {
+	Comment "Mono Input 1"
+
+	Value {
+		CapturePriority 200
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "volt2_mono_in"
+		Direction Capture
+		HWChannels 2
+		Channels 1
+		Channel0 0
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Mic2" {
+	Comment "Mono Input 2"
+
+	Value {
+		CapturePriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "volt2_mono_in"
+		Direction Capture
+		HWChannels 2
+		Channels 1
+		Channel0 1
+		ChannelPos0 MONO
+	}
+}

--- a/ucm2/USB-Audio/UniversalAudio/Volt2.conf
+++ b/ucm2/USB-Audio/UniversalAudio/Volt2.conf
@@ -1,0 +1,11 @@
+Comment "Universal Audio Volt 2"
+
+SectionUseCase."HiFi" {
+	Comment "Default"
+	File "/USB-Audio/UniversalAudio/Volt2-HiFi.conf"
+}
+
+Define.DirectPlaybackChannels 2
+Define.DirectCaptureChannels 2
+
+Include.dhw.File "/common/direct.conf"


### PR DESCRIPTION
This adds a profile for the (relatively recent) Universal Audio Volt 2 USB audio interface. It has a Stereo output and 2 mono inputs that are (like most budget interfaces) combined into a stereo input. This profile effectively splits these inputs into two Line inputs. These inputs can be used interchangeably for XLR microphones, Line level signals or Hi-Z instruments.

The only weird thing is that in my machine the Mono Input 2 appears first in order but pretty sure I defined the prorities in the configuration file just fine. Everything works well on my machine.

[alsa-info.txt](https://github.com/alsa-project/alsa-ucm-conf/files/12385352/alsa-info.txt)

The other Volt interfaces are similar so they surely could be accommodated in this profile as well if someone has them.