### PR TITLE
Add a config for the Allen & Heath Zedi 10 mixer.

### DIFF
--- a/ucm2/USB-Audio/AllenAndHeath/Zedi10-Hifi.conf
+++ b/ucm2/USB-Audio/AllenAndHeath/Zedi10-Hifi.conf
@@ -1,0 +1,194 @@
+Include.pcm_split.File "/common/pcm/split.conf"
+
+Macro [
+	{
+		SplitPCM {
+			Name "zedi10_stereo_out"
+			Direction Playback
+			Channels 2
+			HWChannels 4
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 FL
+			HWChannelPos3 FR
+		}
+	}
+	{
+		SplitPCM {
+			Name "zedi10_stereo_in"
+			Direction Capture
+			Channels 2
+			HWChannels 4
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 FL
+			HWChannelPos3 FR
+		}
+	}
+	{
+		SplitPCM {
+			Name "zedi10_mono_in"
+			Direction Capture
+			Channels 1
+			HWChannels 4
+			HWChannelPos0 MONO
+			HWChannelPos1 MONO
+			HWChannelPos2 MONO
+			HWChannelPos3 MONO
+		}
+	}
+]
+
+SectionDevice."Line1" {
+	Comment "USB IN 1-2"
+
+	Value {
+		PlaybackPriority 100
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "zedi10_stereo_out"
+		Direction Playback
+		HWChannels 4
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line2" {
+	Comment "USB IN 3-4"
+
+	Value {
+		PlaybackPriority 200
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "zedi10_stereo_out"
+		Direction Playback
+		HWChannels 4
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Mic1" {
+	Comment "M1"
+
+	ConflictingDevice [
+		"Line12"
+	]
+
+        Value {
+		CapturePriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "zedi10_mono_in"
+		Direction Capture
+		HWChannels 4
+		Channels 1
+		Channel0 0
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Mic2" {
+	Comment "M2"
+
+	ConflictingDevice [
+		"Line12"
+	]
+	
+	Value {
+		CapturePriority 101
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "zedi10_mono_in"
+		Direction Capture
+		HWChannels 4
+		Channels 1
+		Channel0 1
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Mic3" {
+	Comment "M3"
+
+	ConflictingDevice [
+		"Line34"
+	]
+
+	Value {
+		CapturePriority 102
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "zedi10_mono_in"
+		Direction Capture
+		HWChannels 4
+		Channels 1
+		Channel0 2
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Mic4" {
+	Comment "M4"
+
+	ConflictingDevice [
+		"Line34"
+	]
+	
+	Value {
+		CapturePriority 103
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "zedi10_mono_in"
+		Direction Capture
+		HWChannels 4
+		Channels 1
+		Channel0 3
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Line12" {
+	Comment "USB OUT 1-2"
+
+	Value {
+		CapturePriority 104
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "zedi10_stereo_in"
+		Direction Capture
+		HWChannels 4
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line34" {
+	Comment "USB OUT 3-4"
+
+	Value {
+		CapturePriority 105
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "zedi10_stereo_in"
+		Direction Capture
+		HWChannels 4
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}

--- a/ucm2/USB-Audio/AllenAndHeath/Zedi10.conf
+++ b/ucm2/USB-Audio/AllenAndHeath/Zedi10.conf
@@ -1,0 +1,12 @@
+Comment "Allen & Heath Zedi10 Recording Mode"
+
+SectionUseCase."Recording" {
+        Comment "Recording Mode (4 chan output, 4 chan input)"
+        File "/USB-Audio/AllenAndHeath/Zedi10-Hifi.conf"
+}
+
+Define.DirectCardName "Zedi10"
+Define.DirectPlaybackChannels 4
+Define.DirectCaptureChannels 4
+
+Include.dhw.File "/common/direct.conf"

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -335,6 +335,15 @@ If.ua-volt2 {
 	}
 }
 
+If.zedi10 {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB22f0:0016"
+	}
+	True.Define.ProfileName "AllenAndHeath/Zedi10"
+}
+
 If.mixremap {
 	Condition {
 		Type String


### PR DESCRIPTION

[alsa-info.txt](https://github.com/alsa-project/alsa-ucm-conf/files/12402535/alsa-info.txt)
The mixer has an embedded 4x4 USB interface, this config surfaces the mixer channels as 4 mono inputs, 2 stereo inputs and 2 stereo outputs. Config based on the Behringer Flow8 config.