### PR TITLE
ucm2: Add intial Amlogic GXL support - v2

### DIFF
--- a/ucm2/Amlogic/p241/p241-HiFi.conf
+++ b/ucm2/Amlogic/p241/p241-HiFi.conf
@@ -1,0 +1,40 @@
+SectionDevice."Line" {
+	Comment "Analog Lineout"
+
+	EnableSequence [
+		cset "name='AIU ACODEC SRC' I2S"
+		cset "name='AIU ACODEC OUT EN Switch' 1"
+		cset "name='ACODEC Playback Switch' 1"
+	]
+	
+	DisableSequence [
+		cset "name='ACODEC Playback Switch' 0"
+		cset "name='AIU ACODEC OUT EN Switch' 0"
+		cset "name='AIU ACODEC SRC' DISABLED"
+	]
+	
+	Value {
+		PlaybackPriority 100
+		PlaybackPCM "hw:${CardId},0"
+		PlaybackChannels 2
+		PlaybackVolume "ACODEC Playback Volume"
+		PlaybackMixerElem "ACODEC"	
+	}
+}
+
+SectionDevice."HDMI" {
+	Comment "HDMI"
+
+	EnableSequence [
+		cset "name='AIU HDMI CTRL SRC' I2S"
+	]
+
+	DisableSequence [
+		cset "name='AIU HDMI CTRL SRC' DISABLED"
+	]
+
+	Value {
+		PlaybackPriority 200
+		PlaybackPCM "hw:${CardId},0"
+	}	
+}

--- a/ucm2/Amlogic/p241/p241.conf
+++ b/ucm2/Amlogic/p241/p241.conf
@@ -1,0 +1,31 @@
+# Use case for the p241 Amlogic s805x reference design
+
+Syntax 3
+
+SectionUseCase."HiFi" {
+	File "/Amlogic/p241/p241-HiFi.conf"
+	Comment "Play HiFi quality Music"
+}
+
+FixedBootSequence [
+	cset "name='AIU SPDIF SRC SEL' SPDIF"
+]
+
+BootSequence [
+	cset "name='AIU ACODEC I2S Lane Select' 0"
+	cset "name='ACODEC Playback Channel Mode' Stereo"
+	cset "name='ACODEC Playback Volume' 80%"
+	cset "name='ACODEC Ramp Rate' Fast"
+	cset "name='ACODEC Volume Ramp Switch' on"
+	cset "name='ACODEC Mute Ramp Switch' on"
+	cset "name='ACODEC Unmute Ramp Switch' on"
+	cset "name='ACODEC Right DAC Sel' Right"
+	cset "name='ACODEC Left DAC Sel' Left"
+]
+
+SectionDefaults [
+	cset "name='ACODEC Playback Switch' off"
+	cset "name='AIU ACODEC OUT EN Switch' off"
+	cset "name='AIU ACODEC SRC' DISABLED"
+	cset "name='AIU HDMI CTRL SRC' DISABLED"
+]

--- a/ucm2/conf.d/gx-sound-card/GXL-P241.conf
+++ b/ucm2/conf.d/gx-sound-card/GXL-P241.conf
@@ -1,0 +1,1 @@
+../../Amlogic/p241/p241.conf

--- a/ucm2/conf.d/gx-sound-card/LIBRETECH-CC.conf
+++ b/ucm2/conf.d/gx-sound-card/LIBRETECH-CC.conf
@@ -1,0 +1,1 @@
+../../Amlogic/p241/p241.conf


### PR DESCRIPTION
This PR adds initial support for the Amlogic P241 (S905x ref design) and the Libretech-CC based on the same chip.
This is a v2 of PR #137 

* s/Meson/Amlogic
* PCM  has been move to the device section (Dropping empty verb section)
* Priority are different between the 2 devices (HDMI is more commonly used so it has higher prio)

Tested both outputs (port) with pulseaudio.