### PR TITLE
Add UCM2 configuration for Behringer UMC404HD

### DIFF
--- a/ucm2/USB-Audio/Behringer/UMC404HD-HiFi.conf
+++ b/ucm2/USB-Audio/Behringer/UMC404HD-HiFi.conf
@@ -1,0 +1,200 @@
+Include.pcm_split.File "/common/pcm/split.conf"
+
+Macro [
+	{
+		SplitPCM {
+			Name "umc404hd_stereo_out"
+			Direction Playback
+			Format S32_LE
+			Channels 2
+			HWChannels 4
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 FL
+			HWChannelPos3 FR
+		}
+	}
+	{
+		SplitPCM {
+			Name "umc404hd_mono_in"
+			Direction Capture
+			Format S32_LE
+			Channels 1
+			HWChannels 4
+			HWChannelPos0 MONO
+			HWChannelPos1 MONO
+			HWChannelPos2 MONO
+			HWChannelPos3 MONO
+		}
+	}
+]
+
+Define.PCMCTLName "PCM Playback"
+
+If.pcm_controls {
+	Condition {
+		Type ControlExists
+		Control "name='UMC404HD 192k Output Playback Switch'"
+	}
+	True.Define.PCMCTLName "UMC404HD 192k Output Playback"
+}
+
+Include.ctl_remap.File "/common/ctl/remap.conf"
+
+Macro [
+	{
+		CtlRemapStereoVolSw {
+			Dst "Line A Playback"
+			Src "${var:PCMCTLName}"
+			Index0 0
+			Index1 1
+		}
+	}
+	{
+		CtlRemapStereoVolSw {
+			Dst "Line B Playback"
+			Src "${var:PCMCTLName}"
+			Index0 2
+			Index1 3
+		}
+	}
+	{
+		CtlRemapMonoVolSw {
+			Dst "Input 1 Capture"
+			Src "Mic Capture"
+			Index 0
+		}
+	}
+	{
+		CtlRemapMonoVolSw {
+			Dst "Input 2 Capture"
+			Src "Mic Capture"
+			Index 1
+		}
+	}
+        {
+                CtlRemapMonoVolSw {
+                        Dst "Input 3 Capture"
+                        Src "Mic Capture"
+                        Index 2
+                }
+        }
+        {
+                CtlRemapMonoVolSw {
+                        Dst "Input 4 Capture"
+                        Src "Mic Capture"
+                        Index 3
+                }
+        }
+]
+
+SectionDevice."Line1" {
+	Comment "Line A"
+	Value {
+		PlaybackPriority 200
+		PlaybackMixer "default:${CardId}"
+		PlaybackMixerElem "Line A"
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "umc404hd_stereo_out"
+		Direction Playback
+		HWChannels 4
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line2" {
+	Comment "Line B"
+
+	Value {
+		PlaybackPriority 100
+		PlaybackMixer "default:${CardId}"
+		PlaybackMixerElem "Line B"
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "umc404hd_stereo_out"
+		Direction Playback
+		HWChannels 4
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Mic1" {
+	Comment "Input 1"
+
+	Value {
+		CapturePriority 200
+		CaptureMixer "default:${CardId}"
+		CaptureMixerElem "Input 1"
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "umc404hd_mono_in"
+		Direction Capture
+		HWChannels 4
+		Channels 1
+		Channel0 0
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Mic2" {
+	Comment "Input 2"
+
+	Value {
+		CapturePriority 100
+		CaptureMixer "default:${CardId}"
+		CaptureMixerElem "Input 2"
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "umc404hd_mono_in"
+		Direction Capture
+		HWChannels 4
+		Channels 1
+		Channel0 1
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Mic3" {
+        Comment "Input 3"
+
+        Value {
+                CapturePriority 100
+                CaptureMixer "default:${CardId}"
+                CaptureMixerElem "Input 3"
+        }
+        Macro.pcm_split.SplitPCMDevice {
+                Name "umc404hd_mono_in"
+                Direction Capture
+                HWChannels 4
+                Channels 1
+                Channel0 2
+                ChannelPos0 MONO
+        }
+}
+
+SectionDevice."Mic4" {
+        Comment "Input 4"
+
+        Value {
+                CapturePriority 100
+                CaptureMixer "default:${CardId}"
+                CaptureMixerElem "Input 4"
+        }
+        Macro.pcm_split.SplitPCMDevice {
+                Name "umc404hd_mono_in"
+                Direction Capture
+                HWChannels 4
+                Channels 1
+                Channel0 3
+                ChannelPos0 MONO
+        }
+}

--- a/ucm2/USB-Audio/Behringer/UMC404HD.conf
+++ b/ucm2/USB-Audio/Behringer/UMC404HD.conf
@@ -1,0 +1,11 @@
+Comment "Behringer UMC404HD"
+
+SectionUseCase."HiFi" {
+	Comment "Default"
+	File "/USB-Audio/Behringer/UMC404HD-HiFi.conf"
+}
+
+Define.DirectPlaybackChannels 4
+Define.DirectCaptureChannels 4
+
+Include.dhw.File "/common/direct.conf"

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -236,6 +236,18 @@ If.behringer-umc204hd {
 	}
 }
 
+If.behringer-umc404hd {
+        Condition {
+                Type String
+                Haystack "${CardComponents}"
+                Needle "USB1397:0509"
+        }
+        True.Define {
+                ProfileName "Behringer/UMC404HD"
+                MixerRemap yes
+        }
+}
+
 If.behringer-Flow8-Streaming {
 	Condition {
 	Type String


### PR DESCRIPTION
The only difference between UMC204HD and UMC404HD are the 2 additional inputs and a different USB device ID. Tested with my 404HD, works great.