### PR TITLE
USB-Audio: Add FiiO K11 config

### DIFF
--- a/ucm2/USB-Audio/FiiO/FiiO-K11-HiFi.conf
+++ b/ucm2/USB-Audio/FiiO/FiiO-K11-HiFi.conf
@@ -1,0 +1,6 @@
+SectionDevice."Headphones" {
+	Comment "Headphones"
+	Value {
+		PlaybackPCM "hw:${CardId},0"
+	}
+}

--- a/ucm2/USB-Audio/FiiO/FiiO-K11.conf
+++ b/ucm2/USB-Audio/FiiO/FiiO-K11.conf
@@ -1,0 +1,6 @@
+Comment "FiiO K11"
+
+SectionUseCase."HiFi" {
+	Comment "Default"
+	File "/USB-Audio/FiiO/FiiO-K11-HiFi.conf"
+}

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -337,6 +337,17 @@ If.ua-volt2 {
 	}
 }
 
+If.K11 {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB2972:0077"
+	}
+	True.Define {
+		ProfileName "FiiO/FiiO-K11"
+	}
+}
+
 If.mixremap {
 	Condition {
 		Type String


### PR DESCRIPTION
Without an ALSA config the device shows up as "Digital" and "Analog", and the Analog option has no volume control. The DAC only exposes the headphone jack in USB DAC mode, so just headphones. 

Attached some information about the DAC

[aplay-L.txt](https://github.com/alsa-project/alsa-ucm-conf/files/13035153/aplay-L.txt)
[proc-asound-K11-stream0.txt](https://github.com/alsa-project/alsa-ucm-conf/files/13035154/proc-asound-K11-stream0.txt)
