### PR TITLE
Add UCM2 configuration for Topping DX3 Pro+

### DIFF
--- a/ucm2/USB-Audio/Topping/DX3ProPlus-HiFi.conf
+++ b/ucm2/USB-Audio/Topping/DX3ProPlus-HiFi.conf
@@ -1,0 +1,6 @@
+SectionDevice."Headphones" {
+	Comment "Headphones"
+	Value {
+		PlaybackPCM "hw:${CardId},0"
+	}
+}

--- a/ucm2/USB-Audio/Topping/DX3ProPlus.conf
+++ b/ucm2/USB-Audio/Topping/DX3ProPlus.conf
@@ -1,0 +1,6 @@
+Comment "DX3 Pro+"
+
+SectionUseCase."HiFi" {
+	Comment "Default"
+	File "/USB-Audio/Topping/DX3ProPlus-HiFi.conf"
+}

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -337,6 +337,17 @@ If.ua-volt2 {
 	}
 }
 
+If.Pro {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB152a:8750"
+	}
+	True.Define {
+		ProfileName "Topping/DX3ProPlus"
+	}
+}
+
 If.mixremap {
 	Condition {
 		Type String


### PR DESCRIPTION
Fixes it showing up as "digital" and "analog" output in Settings, should just be "Headphones".