### PR TITLE
Initialise AIF2 ADC Stereo Capture Route

### DIFF
--- a/ucm2/Allwinner/A64/PinePhone/VoiceCall.conf
+++ b/ucm2/Allwinner/A64/PinePhone/VoiceCall.conf
@@ -2,6 +2,10 @@ SectionVerb {
 	EnableSequence [
 		cset "name='AIF2 Digital DAC Playback Switch' on"
 		cset "name='AIF2 ADC Mixer ADC Capture Switch' on"
+		#
+		# 2023-11-01 Previously un-initialised;
+		# see https://github.com/alsa-project/alsa-ucm-conf/issues/351 :
+		cset "name='AIF2 ADC Stereo Capture Route' Mix Mono"
 	]
 
 	Value {


### PR DESCRIPTION
As pointed out in issue #351 [1], the parameter 'AIF2 ADC Stereo Capture Route' was previously uninitialised. I'm not very convinced that this particular value (Mix Mono) is the best combination with the other PinePhone settings, but better that there is at least a value rather than no value, so that people can provide bug reports based on tests that are closer to being reproducible. As described in [1], there is circumstantial evidence favouring this value.

This commit does not set a value for HiFi.conf - presumably the value is irrelevant for HiFi, which does not appear to be as buggy as VoiceCall.

[1] https://github.com/alsa-project/alsa-ucm-conf/issues/351