### PR TITLE
Documentation: Add ucm URL

### DIFF
--- a/ucm2/Allwinner/A64/PinePhone/PinePhone.conf
+++ b/ucm2/Allwinner/A64/PinePhone/PinePhone.conf
@@ -1,8 +1,15 @@
 Syntax 2
 
-# https://wiki.pine64.org/index.php/PinePhone
+# To understand (or propose bug reports) for the different
+# parts of these configuration files, see:
+# https://www.alsa-project.org/alsa-doc/alsa-lib/group__ucm__conf.html
+
+# PinePhone-specific audio card structure help:
 # https://files.pine64.org/doc/PinePhone/PinePhone%20v1.2%20Released%20Schematic.pdf
 # https://xnux.eu/devices/feature/audio-pp.html
+
+# General PinePhone help:
+# https://wiki.pine64.org/index.php/PinePhone
 
 SectionUseCase."HiFi" {
 	File "/Allwinner/A64/PinePhone/HiFi.conf"


### PR DESCRIPTION
This commit adds the main alsa-ucm-conf documentation URL to PinePhone.conf, and clarifies the relevance of the other three URLs.

While in principle it could be argued that anyone editing ucm2 .conf files should RTFM, in practice everybody's busy and will not always find which documentation is the most useful and up-to-date. This commit aims to help people identify where they can expect to find the most useful+up-to-date info so that they can understand the current roles of the various types of sections of the config files, and file bug reports if behaviour of alsa-lib software differs from what's described in the documentation.

This merge request should hopefully be uncontroversial. :)
