### PR TITLE
ucm2: Add support for MT8186 Corsola Steelix Chromebook with SOF

### DIFF
--- a/ucm2/MediaTek/mt8186-sof/init.conf
+++ b/ucm2/MediaTek/mt8186-sof/init.conf
@@ -1,0 +1,7 @@
+# mt8186 specific boot sequence
+
+BootSequence [
+	# AFE HW Gain enablement
+	cset "name='HW Gain 1 Volume' 524288"
+	cset "name='HW Gain 2 Volume' 524288"
+]

--- a/ucm2/MediaTek/mt8186-sof/mt6366-rt1019-rt5682s/HiFi.conf
+++ b/ucm2/MediaTek/mt8186-sof/mt6366-rt1019-rt5682s/HiFi.conf
@@ -1,0 +1,86 @@
+# Use case configuration for mt8186-mt6366-rt1019-rt5682s
+
+SectionVerb {
+	EnableSequence [
+		disdevall ""
+	]
+
+	Value.TQ "HiFi"
+}
+
+SectionDevice."Speaker" {
+	Comment "Speaker"
+
+	EnableSequence [
+		cset "name='Speakers Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Speakers Switch' off"
+	]
+
+	Value {
+		PlaybackChannels 2
+		PlaybackPCM "hw:${CardId},25"
+		PlaybackPriority 100
+		PlaybackMixerElem "Speaker"
+		PlaybackVolume "Speaker Playback Volume"
+	}
+}
+
+SectionDevice."Headphones" {
+	Comment "Headphones"
+
+	EnableSequence [
+		cset "name='Headphone Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Headphone Switch' off"
+	]
+
+	Value {
+		PlaybackPriority 200
+		PlaybackPCM "hw:${CardId},26"
+		JackControl "Headphone Jack"
+	}
+}
+
+SectionDevice."Headset" {
+	Comment "Headset Microphone"
+
+	EnableSequence [
+		cset "name='Headset Mic Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Headset Mic Switch' off"
+	]
+
+	Value {
+		CapturePriority 200
+		CapturePCM "hw:${CardId},28"
+		JackControl "Headset Mic Jack"
+	}
+}
+
+SectionDevice."Mic" {
+	Comment "Internal Microphone"
+
+	EnableSequence [
+		cset "name='MTKAIF_DMIC Switch' on"
+		cset "name='UL1_CH1 ADDA_UL_CH1 Switch' on"
+		cset "name='UL1_CH2 ADDA_UL_CH2 Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='MTKAIF_DMIC Switch' off"
+		cset "name='UL1_CH1 ADDA_UL_CH1 Switch' off"
+		cset "name='UL1_CH2 ADDA_UL_CH2 Switch' off"
+	]
+
+	Value {
+		CapturePCM "hw:${CardId},27"
+		CapturePriority 100
+	}
+}

--- a/ucm2/MediaTek/mt8186-sof/mt6366-rt1019-rt5682s/init.conf
+++ b/ucm2/MediaTek/mt8186-sof/mt6366-rt1019-rt5682s/init.conf
@@ -1,0 +1,39 @@
+# mt6366-rt1019-rt5682s specific boot sequence
+BootSequence [
+	# Headset Microphone on RT5682s
+	cset "name='IF1 01 ADC Swap Mux' L/L"
+	cset "name='Stereo1 ADC L Mux' 'ADC1 L'"
+	cset "name='RECMIX1L CBJ Switch' on"
+	cset "name='STO1 ADC Capture Switch' on,off"
+	cset "name='CBJ Boost Volume' 28"
+
+	# Internal Microphone on MT6366
+	cset "name='Mt6366 Mic Type Mux' DMIC"
+	cset "name='Mt6366 PGA Volume' 4"
+	cset "name='Stereo1 ADC L1 Mux' ADC"
+	cset "name='Stereo1 ADC R1 Mux' ADC"
+	cset "name='Stereo1 ADC MIXL ADC2 Switch' off"
+	cset "name='Stereo1 ADC MIXR ADC2 Switch' off"
+	cset "name='Stereo1 ADC MIXL ADC1 Switch' on"
+	cset "name='Stereo1 ADC MIXR ADC1 Switch' on"
+
+	# I2S0 UL2: Headset Microphone
+	cset "name='UL2_CH1 I2S0_CH1 Switch' on"
+	cset "name='UL2_CH2 I2S0_CH2 Switch' on"
+	cset "name='I2S0_HD_Mux' Low_Jitter"
+
+	# I2S1 DL2: Headset Speaker
+	cset "name='I2S1_CH1 DL2_CH1 Switch' on"
+	cset "name='I2S1_CH2 DL2_CH2 Switch' on"
+	cset "name='I2S1_HD_Mux' Low_Jitter"
+
+	# I2S3 DL1: Internal Speakers
+	cset "name='I2S3_CH1 DL1_CH1 Switch' on"
+	cset "name='I2S3_CH2 DL1_CH2 Switch' on"
+	cset "name='I2S3_HD_Mux' Low_Jitter"
+
+	# Internal Speakers DAC
+	cset "name='Stereo1 DAC MIXL DAC L1 Switch' on"
+	cset "name='Stereo1 DAC MIXR DAC R1 Switch' on"
+	cset "name='DAC1 Playback Volume' 120"
+]

--- a/ucm2/MediaTek/mt8186-sof/mt6366-rt1019-rt5682s/sof-mt8186-mt6366-rt1019-rt5682s.conf
+++ b/ucm2/MediaTek/mt8186-sof/mt6366-rt1019-rt5682s/sof-mt8186-mt6366-rt1019-rt5682s.conf
@@ -1,0 +1,12 @@
+Comment "MT8186 MT6366 RT1019 RT5682s sound card"
+Syntax 4
+
+SectionUseCase."HiFi" {
+	File "/MediaTek/mt8186-sof/mt6366-rt1019-rt5682s/HiFi.conf"
+	Comment "Default"
+}
+
+Include.card-init.File "/lib/card-init.conf"
+Include.ctl-remap.File "/lib/ctl-remap.conf"
+Include.init.File "/MediaTek/mt8186-sof/init.conf"
+Include.init-rt1019-rt5682s.File "/MediaTek/mt8186-sof/mt6366-rt1019-rt5682s/init.conf"

--- a/ucm2/conf.d/sof-mt8186_rt10/sof-mt8186_rt1019_rt5682s.conf
+++ b/ucm2/conf.d/sof-mt8186_rt10/sof-mt8186_rt1019_rt5682s.conf
@@ -1,0 +1,1 @@
+../../MediaTek/mt8186-sof/mt6366-rt1019-rt5682s/sof-mt8186-mt6366-rt1019-rt5682s.conf


### PR DESCRIPTION
Add support for the Lenovo 300e Yoga Chromebook Gen4, powered by MediaTek Kompanio 520 (MT8186) with a HiFi4 Audio DSP running SoundOpenFirmware.
This machine uses the MT6366 PMIC, with RT1019 and RT5862s as headphones and speaker codecs/amps.

This configuration has been successfully tested on ArchLinux with PipeWire 0.3.83 + WirePlumber.