### PR TITLE
Add UCM for PinePhone Pro

### DIFF
--- a/ucm2/Rockchip/rk3399/PinePhonePro/HiFi.conf
+++ b/ucm2/Rockchip/rk3399/PinePhonePro/HiFi.conf
@@ -1,0 +1,278 @@
+SectionVerb {
+	EnableSequence [
+		# First of all, disable the internal speaker amplifier
+		cset "name='Internal Speaker Switch' off"
+
+		### Based on /codecs/rt5640/EnableSeq.conf ###
+
+		# RT5640 default output routing
+		cset "name='DAC MIXL INF1 Switch' on"
+		cset "name='DAC MIXR INF1 Switch' on"
+		cset "name='DAC MIXL Stereo ADC Switch' off"
+		cset "name='DAC MIXR Stereo ADC Switch' off"
+		cset "name='Stereo DAC MIXL DAC L1 Switch' on"
+		cset "name='Stereo DAC MIXR DAC R1 Switch' on"
+		cset "name='Stereo DAC MIXL DAC L2 Switch' on"
+		cset "name='Stereo DAC MIXR DAC R2 Switch' on"
+		cset "name='OUT MIXL DAC L1 Switch' on"
+		cset "name='OUT MIXR DAC R1 Switch' on"
+		cset "name='SPK MIXL DAC L1 Switch' on"
+		cset "name='SPK MIXR DAC R1 Switch' on"
+
+		# uncomment to enable swap between AIF1 and AIF2
+		# warning: can only work with SSP0 firmware enabled
+		cset "name='SDI select' 0"
+		cset "name='DAI select' 0"
+		#cset "name='SDI select' 1"
+		#cset "name='DAI select' 1"
+
+		cset "name='DAC2 Playback Switch' on"
+
+		# Input Configuration
+		cset "name='Stereo ADC1 Mux' ADC"
+		cset "name='Stereo ADC2 Mux' DMIC1"
+		cset "name='ADC Capture Switch' on"
+
+		cset "name='Mono ADC L1 Mux' ADCL"
+		cset "name='Mono ADC R1 Mux' ADCR"
+		cset "name='Mono ADC L2 Mux' DMIC L1"
+		cset "name='Mono ADC R2 Mux' DMIC R1"
+		cset "name='Mono ADC Capture Switch' on"
+
+		# Set capture volume to 0dB so modem audio doesn't overdrive the ADC
+		cset "name='ADC Capture Volume' 47"
+		cset "name='Mono ADC Capture Volume' 47"
+
+		# The second 'Mono ADC' path does not have a 'Boost Gain',
+		# set this to 0dB so that the volume of the AIF1 and AIF2 paths is equal.
+		cset "name='ADC Boost Gain' 0"
+
+		# Set IN1 internal mic boost to 8 (max)
+		# Set IN2 headset-mic boost to 1, headset mics are quite loud
+		# Set IN3 (modem audio) boost to 0 as it's already loud enough
+		cset "name='IN1 Boost' 8"
+		cset "name='IN2 Boost' 1"
+		cset "name='IN3 Boost' 0"
+
+		# Start with all controls which are used by the individual
+		# input/output Enable/DisableSequences off
+
+		cset "name='RECMIXL BST1 Switch' off"
+		cset "name='RECMIXR BST1 Switch' off"
+		# IN2 is headset mic, make sure its route is enabled
+		cset "name='RECMIXL BST2 Switch' on"
+		cset "name='RECMIXR BST2 Switch' on"
+		cset "name='RECMIXL BST3 Switch' off"
+		cset "name='RECMIXR BST3 Switch' off"
+
+		cset "name='Stereo ADC MIXL ADC1 Switch' off"
+		cset "name='Stereo ADC MIXR ADC1 Switch' off"
+		cset "name='Stereo ADC MIXL ADC2 Switch' off"
+		cset "name='Stereo ADC MIXR ADC2 Switch' off"
+		cset "name='Mono ADC MIXL ADC1 Switch' off"
+		cset "name='Mono ADC MIXR ADC1 Switch' off"
+		cset "name='Mono ADC MIXL ADC2 Switch' off"
+		cset "name='Mono ADC MIXR ADC2 Switch' off"
+
+		# Limit amplification factor of earpiece amplifier so sound stays clear
+		cset "name='Class D SPK Ratio Control' 1.66x"
+
+		# Turn off playback switches by default, otherwise both Speaker
+		# and headphones are playing audio initially until headphones are
+		# re-inserted.
+		cset "name='HP L Playback Switch' off"
+		cset "name='HP R Playback Switch' off"
+		cset "name='Speaker L Playback Switch' off"
+		cset "name='Speaker R Playback Switch' off"
+
+		# MONO output is used as IN3 here, so make sure it's disabled
+		cset "name='Mono Playback Switch' off"
+
+		# Set playback volumes to 0dB
+		cset "name='HP Playback Volume' 31"
+		cset "name='Speaker Playback Volume' 31"
+	]
+
+	DisableSequence [
+		# Turn off all output channels
+		cset "name='HP L Playback Switch' off"
+		cset "name='HP R Playback Switch' off"
+		cset "name='HP Channel Switch' off"
+		cset "name='HPO MIX HPVOL Switch' off"
+		cset "name='Speaker L Playback Switch' off"
+		cset "name='Speaker R Playback Switch' off"
+		cset "name='Speaker Channel Switch' off"
+		cset "name='SPOL MIX SPKVOL L Switch' off"
+		cset "name='SPOL MIX SPKVOL R Switch' off"
+
+
+		# Reset output routing
+		cset "name='DAC MIXL INF1 Switch' off"
+		cset "name='DAC MIXR INF1 Switch' off"
+		cset "name='OUT MIXL DAC L1 Switch' off"
+		cset "name='OUT MIXR DAC R1 Switch' off"
+		cset "name='SPK MIXL DAC L1 Switch' off"
+		cset "name='SPK MIXR DAC R1 Switch' off"
+	]
+
+	Value {
+		TQ "HiFi"
+	}
+}
+
+SectionDevice."Earpiece" {
+	Comment "Internal Earpiece"
+
+	ConflictingDevice [
+		"Headphones"
+		"Speaker"
+	]
+
+	EnableSequence [
+		cset "name='SPOL MIX SPKVOL L Switch' on"
+# for mono speaker we apply left on right
+#		cset "name='SPOR MIX SPKVOL R Switch' on"
+		cset "name='SPOL MIX SPKVOL R Switch' on"
+		cset "name='Speaker Channel Switch' on"
+		cset "name='Speaker L Playback Switch' on"
+		cset "name='Speaker R Playback Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Speaker Channel Switch' off"
+		cset "name='Speaker L Playback Switch' off"
+		cset "name='Speaker R Playback Switch' off"
+	]
+
+	Value {
+		PlaybackPriority 100
+		PlaybackPCM "hw:${CardId}"
+		PlaybackMixerElem "Speaker"
+		PlaybackVolume "Speaker Playback Volume"
+		PlaybackMasterElem "DAC1"
+	}
+}
+
+SectionDevice."Speaker" {
+	Comment "Internal Speaker"
+
+	ConflictingDevice [
+		"Earpiece"
+		"Headphones"
+	]
+
+	EnableSequence [
+		cset "name='HPO MIX HPVOL Switch' on"
+		cset "name='HP Channel Switch' on"
+		cset "name='HP L Playback Switch' on"
+		cset "name='HP R Playback Switch' on"
+		cset "name='Internal Speaker Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Internal Speaker Switch' off"
+		cset "name='HP Channel Switch' off"
+		cset "name='HP L Playback Switch' off"
+		cset "name='HP R Playback Switch' off"
+	]
+
+	Value {
+		PlaybackPriority 200
+		PlaybackPCM "hw:${CardId}"
+		PlaybackMixerElem "HP"
+		PlaybackVolume "HP Playback Volume"
+		PlaybackMasterElem "DAC1"
+	}
+}
+
+SectionDevice."Headphones" {
+	Comment "Headphones"
+
+	ConflictingDevice [
+		"Earpiece"
+		"Speaker"
+	]
+
+	EnableSequence [
+		cset "name='HPO MIX HPVOL Switch' on"
+		cset "name='HP Channel Switch' on"
+		cset "name='HP L Playback Switch' on"
+		cset "name='HP R Playback Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='HP Channel Switch' off"
+		cset "name='HP L Playback Switch' off"
+		cset "name='HP R Playback Switch' off"
+	]
+
+	Value {
+		PlaybackPriority 300
+		PlaybackPCM "hw:${CardId}"
+		JackControl "Headphones Jack"
+		PlaybackMixerElem "HP"
+		PlaybackVolume "HP Playback Volume"
+		PlaybackMasterElem "DAC1"
+	}
+}
+
+SectionDevice."Mic" {
+	Comment "Internal Microphone"
+
+	ConflictingDevice [
+		"Headset"
+	]
+
+	EnableSequence [
+		cset "name='Mono ADC MIXL ADC2 Switch' on"
+		cset "name='Mono ADC MIXR ADC2 Switch' on"
+		cset "name='Stereo ADC MIXL ADC2 Switch' on"
+		cset "name='Stereo ADC MIXR ADC2 Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Mono ADC MIXL ADC2 Switch' off"
+		cset "name='Mono ADC MIXR ADC2 Switch' off"
+		cset "name='Stereo ADC MIXL ADC2 Switch' off"
+		cset "name='Stereo ADC MIXR ADC2 Switch' off"
+	]
+
+	Value {
+		CapturePriority 100
+		CapturePCM "hw:${CardId}"
+		CaptureMixerElem "ADC"
+		CaptureVolume "ADC Capture Volume"
+		CaptureSwitch "ADC Capture Switch"
+	}
+}
+
+SectionDevice."Headset" {
+	Comment "Headset Microphone"
+
+	ConflictingDevice [
+		"Mic"
+	]
+
+	EnableSequence [
+		cset "name='Mono ADC MIXL ADC1 Switch' on"
+		cset "name='Mono ADC MIXR ADC1 Switch' on"
+		cset "name='Stereo ADC MIXL ADC1 Switch' on"
+		cset "name='Stereo ADC MIXR ADC1 Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Mono ADC MIXL ADC1 Switch' off"
+		cset "name='Mono ADC MIXR ADC1 Switch' off"
+		cset "name='Stereo ADC MIXL ADC1 Switch' off"
+		cset "name='Stereo ADC MIXR ADC1 Switch' off"
+	]
+
+	Value {
+		CapturePriority 200
+		CapturePCM "hw:${CardId}"
+		JackControl "Headphones Jack"
+		CaptureMixerElem "ADC"
+		CaptureVolume "ADC Capture Volume"
+		CaptureSwitch "ADC Capture Switch"
+	}
+}

--- a/ucm2/Rockchip/rk3399/PinePhonePro/PinePhonePro.conf
+++ b/ucm2/Rockchip/rk3399/PinePhonePro/PinePhonePro.conf
@@ -1,0 +1,16 @@
+Syntax 4
+Comment "PinePhone Pro"
+
+SectionUseCase."HiFi" {
+	File "HiFi.conf"
+	Comment "Default"
+}
+
+SectionUseCase."Voice Call" {
+	File "VoiceCall.conf"
+	Comment "Phone call"
+}
+
+Include.card-init.File "/lib/card-init.conf"
+Include.ctl-remap.File "/lib/ctl-remap.conf"
+Include.codec-init.File "/codecs/rt5640/init.conf"

--- a/ucm2/Rockchip/rk3399/PinePhonePro/VoiceCall.conf
+++ b/ucm2/Rockchip/rk3399/PinePhonePro/VoiceCall.conf
@@ -1,0 +1,275 @@
+SectionVerb {
+	EnableSequence [
+		# First of all, disable the internal speaker amplifier
+		cset "name='Internal Speaker Switch' off"
+
+		### Based on /codecs/rt5640/EnableSeq.conf ###
+
+		# Get audio only from the microphones, not the system
+		cset "name='DAC MIXL INF1 Switch' off"
+		cset "name='DAC MIXR INF1 Switch' off"
+		cset "name='DAC MIXL Stereo ADC Switch' on"
+		cset "name='DAC MIXR Stereo ADC Switch' on"
+		cset "name='Stereo DAC MIXL DAC L1 Switch' on"
+		cset "name='Stereo DAC MIXR DAC R1 Switch' on"
+		cset "name='Stereo DAC MIXL DAC L2 Switch' on"
+		cset "name='Stereo DAC MIXR DAC R2 Switch' on"
+		cset "name='OUT MIXL DAC L1 Switch' off"
+		cset "name='OUT MIXR DAC R1 Switch' off"
+		cset "name='SPK MIXL DAC L1 Switch' off"
+		cset "name='SPK MIXR DAC R1 Switch' off"
+
+		# uncomment to enable swap between AIF1 and AIF2
+		# warning: can only work with SSP0 firmware enabled
+		cset "name='SDI select' 0"
+		cset "name='DAI select' 0"
+		#cset "name='SDI select' 1"
+		#cset "name='DAI select' 1"
+
+		cset "name='DAC2 Playback Switch' on"
+
+		# Input Configuration
+		cset "name='Stereo ADC1 Mux' ADC"
+		cset "name='Stereo ADC2 Mux' DMIC1"
+		cset "name='ADC Capture Switch' on"
+
+		cset "name='Mono ADC L1 Mux' ADCL"
+		cset "name='Mono ADC R1 Mux' ADCR"
+		cset "name='Mono ADC L2 Mux' DMIC L1"
+		cset "name='Mono ADC R2 Mux' DMIC R1"
+		cset "name='Mono ADC Capture Switch' on"
+
+		# Set capture volume to 0dB so modem audio doesn't overdrive the ADC
+		cset "name='ADC Capture Volume' 47"
+		cset "name='Mono ADC Capture Volume' 47"
+
+		# The second 'Mono ADC' path does not have a 'Boost Gain',
+		# set this to 0dB so that the volume of the AIF1 and AIF2 paths is equal.
+		cset "name='ADC Boost Gain' 0"
+
+		# Set IN1 internal mic boost to 8 (max)
+		# Set IN2 headset-mic boost to 1, headset mics are quite loud
+		# Set IN3 (modem audio) boost to 0 as it's already loud enough
+		cset "name='IN1 Boost' 8"
+		cset "name='IN2 Boost' 1"
+		cset "name='IN3 Boost' 0"
+
+		# Start with all controls which are used by the individual
+		# input/output Enable/DisableSequences off
+
+		cset "name='RECMIXL BST1 Switch' off"
+		cset "name='RECMIXR BST1 Switch' off"
+		# IN2 is headset mic, make sure its routed to the left channel
+		cset "name='RECMIXL BST2 Switch' on"
+		cset "name='RECMIXR BST2 Switch' off"
+		# IN3 is modem audio, route it to the right channel
+		cset "name='RECMIXL BST3 Switch' off"
+		cset "name='RECMIXR BST3 Switch' on"
+
+		cset "name='Stereo ADC MIXL ADC1 Switch' off"
+		cset "name='Stereo ADC MIXR ADC1 Switch' off"
+		cset "name='Stereo ADC MIXL ADC2 Switch' off"
+		cset "name='Stereo ADC MIXR ADC2 Switch' off"
+		cset "name='Mono ADC MIXL ADC1 Switch' off"
+		cset "name='Mono ADC MIXR ADC1 Switch' off"
+		cset "name='Mono ADC MIXL ADC2 Switch' off"
+		cset "name='Mono ADC MIXR ADC2 Switch' off"
+
+		# Limit amplification factor of earpiece amplifier so sound stays clear
+		cset "name='Class D SPK Ratio Control' 1.66x"
+
+		# Loopback IN3 to earpiece/speaker/headphones
+		cset "name='OUT MIXR REC MIXR Switch' on"
+		cset "name='SPK MIXR OUT MIXR Switch' on"
+
+		# Send the left channel (microphones) to the modem through DAC L1
+		cset "name='LOUT MIX DAC L1 Switch' on"
+		# Don't use DAC R1 nor the OUTVOL blocks as we use them for
+		# routing audio from the modem
+		cset "name='LOUT MIX DAC R1 Switch' off"
+		cset "name='LOUT MIX OUTVOL L Switch' off"
+		cset "name='LOUT MIX OUTVOL R Switch' off"
+
+		# Disable left channel for HP (speaker/headphones) output
+		# as we're only routing modem audio to the right channel
+		cset "name='HP L Playback Switch' off"
+
+		# Turn off playback switches by default, otherwise both Speaker
+		# and headphones are playing audio initially until headphones are
+		# re-inserted.
+		cset "name='HP L Playback Switch' off"
+		cset "name='HP R Playback Switch' off"
+		cset "name='Speaker L Playback Switch' off"
+		cset "name='Speaker R Playback Switch' off"
+
+		# MONO output is used as IN3 here, so make sure it's disabled
+		cset "name='Mono Playback Switch' off"
+
+		# Set playback volumes to 0dB
+		cset "name='HP Playback Volume' 31"
+		cset "name='Speaker Playback Volume' 31"
+	]
+
+	DisableSequence [
+		# Turn off all output channels
+		cset "name='HP L Playback Switch' off"
+		cset "name='HP R Playback Switch' off"
+		cset "name='HP Channel Switch' off"
+		cset "name='Speaker L Playback Switch' off"
+		cset "name='Speaker R Playback Switch' off"
+		cset "name='Speaker Channel Switch' off"
+
+		# Reset output routing
+		cset "name='DAC MIXL Stereo ADC Switch' off"
+		cset "name='DAC MIXR Stereo ADC Switch' off"
+		cset "name='OUT MIXR REC MIXR Switch' off"
+		cset "name='SPK MIXR OUT MIXR Switch' off"
+		cset "name='LOUT MIX DAC L1 Switch' off"
+
+		# Reset ADC input routing
+		cset "name='RECMIXL BST2 Switch' off"
+		cset "name='RECMIXR BST3 Switch' off"
+	]
+
+	Value {
+		TQ "VoiceCall"
+	}
+}
+
+SectionDevice."Earpiece" {
+	Comment "Internal Earpiece"
+
+	ConflictingDevice [
+		"Headphones"
+		"Speaker"
+	]
+
+	EnableSequence [
+		cset "name='SPOL MIX SPKVOL L Switch' on"
+		# Send right channel to left as it's mono only
+		cset "name='SPOL MIX SPKVOL R Switch' on"
+		cset "name='Speaker Channel Switch' on"
+		cset "name='Speaker L Playback Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Speaker Channel Switch' off"
+		cset "name='Speaker L Playback Switch' off"
+	]
+
+	Value {
+		PlaybackPriority 200
+		PlaybackPCM "hw:${CardId}"
+		PlaybackMixerElem "Speaker"
+		PlaybackVolume "Speaker Playback Volume"
+		PlaybackMasterElem "DAC1"
+	}
+}
+
+SectionDevice."Speaker" {
+	Comment "Internal Speaker"
+
+	ConflictingDevice [
+		"Earpiece"
+		"Headphones"
+	]
+
+	EnableSequence [
+ 		cset "name='HPO MIX HPVOL Switch'  on"
+		cset "name='HP Channel Switch' on"
+		cset "name='HP R Playback Switch' on"
+		cset "name='Internal Speaker Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Internal Speaker Switch' off"
+		cset "name='HP Channel Switch' off"
+		cset "name='HP R Playback Switch' off"
+	]
+
+	Value {
+		PlaybackPriority 100
+		PlaybackPCM "hw:${CardId}"
+		PlaybackMixerElem "HP"
+		PlaybackVolume "HP Playback Volume"
+		PlaybackMasterElem "DAC1"
+	}
+}
+
+SectionDevice."Headphones" {
+	Comment "Headphones"
+
+	ConflictingDevice [
+		"Earpiece"
+		"Speaker"
+	]
+
+	EnableSequence [
+ 		cset "name='HPO MIX HPVOL Switch'  on"
+		cset "name='HP Channel Switch' on"
+		cset "name='HP R Playback Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='HP Channel Switch' off"
+		cset "name='HP R Playback Switch' off"
+	]
+
+	Value {
+		PlaybackPriority 300
+		PlaybackPCM "hw:${CardId}"
+		JackControl "Headphones Jack"
+		PlaybackMixerElem "HP"
+		PlaybackVolume "HP Playback Volume"
+		PlaybackMasterElem "DAC1"
+	}
+}
+
+SectionDevice."Mic" {
+	Comment "Internal Microphone"
+
+	ConflictingDevice [
+		"Headset"
+	]
+
+	EnableSequence [
+		cset "name='Stereo ADC MIXL ADC2 Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Stereo ADC MIXL ADC2 Switch' off"
+	]
+
+	Value {
+		CapturePriority 100
+		CapturePCM "hw:${CardId}"
+		CaptureMixerElem "ADC"
+		CaptureVolume "ADC Capture Volume"
+		CaptureSwitch "ADC Capture Switch"
+	}
+}
+
+SectionDevice."Headset" {
+	Comment "Headset Microphone"
+
+	ConflictingDevice [
+		"Mic"
+	]
+
+	EnableSequence [
+		cset "name='Stereo ADC MIXL ADC1 Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Stereo ADC MIXL ADC1 Switch' off"
+	]
+
+	Value {
+		CapturePriority 200
+		CapturePCM "hw:${CardId}"
+		JackControl "Headphones Jack"
+		CaptureMixerElem "ADC"
+		CaptureVolume "ADC Capture Volume"
+		CaptureSwitch "ADC Capture Switch"
+	}
+}

--- a/ucm2/conf.d/simple-card/PinePhonePro.conf
+++ b/ucm2/conf.d/simple-card/PinePhonePro.conf
@@ -1,0 +1,1 @@
+../../Rockchip/rk3399/PinePhonePro/PinePhonePro.conf


### PR DESCRIPTION
Merge PinePhonePro from https://gitlab.com/pine64-org/pine64-alsa-ucm branch master

Also, add conf.d/simple-card/PinePhonePro.conf symlink, and remove some stray spaces that got mixed in with the tabs.

Ideally, #374 should be merged first. This should work already on systems started without UEFI, as then there is no DMI, and the CardLongName should be set to CardName. However, for most installations, this probably won't be the case, and #374 will be needed for those. Fixes #125

Since I didn't write the UCM myself, I tried to preserve the history & authorship of the original work using a merge commit. Rebasing this properly without breaking the reference is a bit tricky, so I intend to do that myself after #374 is merged. Also I hope that's going to survive this pull request, but I haven't tried this before.