### PR TITLE
USB-Audio: Add support for Solid State Labs SSL 2

### DIFF
--- a/ucm2/USB-Audio/SolidStateLabs/SSL2-HiFi.conf
+++ b/ucm2/USB-Audio/SolidStateLabs/SSL2-HiFi.conf
@@ -1,0 +1,55 @@
+Include.pcm_split.File "/common/pcm/split.conf"
+
+Macro [
+	{
+		SplitPCM {
+			Name "ssl2_mono_in"
+			Direction Capture
+			Channels 1
+			HWChannels 2
+			HWChannelPos0 MONO
+			HWChannelPos1 MONO
+		}
+	}
+]
+
+SectionDevice."Line1" {
+	Comment "Stereo Line"
+
+	Value {
+		PlaybackPriority 200
+		PlaybackPCM "hw:${CardId}"
+	}
+}
+
+SectionDevice."Mic1" {
+	Comment "Mic/Line/Inst 1"
+
+	Value {
+		CapturePriority 200
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ssl2_mono_in"
+		Direction Capture
+		HWChannels 2
+		Channels 1
+		Channel0 0
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Mic2" {
+	Comment "Mic/Line/Inst 2"
+
+	Value {
+		CapturePriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ssl2_mono_in"
+		Direction Capture
+		HWChannels 2
+		Channels 1
+		Channel0 1
+		ChannelPos0 MONO
+	}
+}

--- a/ucm2/USB-Audio/SolidStateLabs/SSL2.conf
+++ b/ucm2/USB-Audio/SolidStateLabs/SSL2.conf
@@ -1,0 +1,11 @@
+Comment "Solid State Labs SSL 2"
+
+SectionUseCase."HiFi" {
+	Comment "HiFi"
+	File "/USB-Audio/SolidStateLabs/SSL2-HiFi.conf"
+}
+
+Define.DirectPlaybackChannels 2
+Define.DirectCaptureChannels 2
+
+Include.dhw.File "/common/direct.conf"

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -359,6 +359,17 @@ If.zedi10 {
 	True.Define.ProfileName "AllenAndHeath/Zedi10"
 }
 
+If.ssl2 {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB31e9:0001"
+	}
+	True.Define {
+		ProfileName "SolidStateLabs/SSL2"
+	}
+}
+
 If.mixremap {
 	Condition {
 		Type String


### PR DESCRIPTION
This adds support for the [Solid State Labs SSL 2](https://www.solidstatelogic.com/products/ssl2).