### PR TITLE
USB-Audio: add MOTU M6 config

### DIFF
--- a/ucm2/USB-Audio/MOTU/M6-HiFi.conf
+++ b/ucm2/USB-Audio/MOTU/M6-HiFi.conf
@@ -1,0 +1,245 @@
+Include.pcm_split.File "/common/pcm/split.conf"
+
+Macro [
+	{
+		SplitPCM {
+			Name "m6_stereo_out"
+			Direction Playback
+			Channels 2
+			HWChannels 4
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 FL
+			HWChannelPos3 FR
+		}
+	}
+	{
+		SplitPCM {
+			Name "m6_mono_in"
+			Direction Capture
+			Channels 1
+			HWChannels 6
+			HWChannelPos0 MONO
+			HWChannelPos1 MONO
+			HWChannelPos2 MONO
+			HWChannelPos3 MONO
+			HWChannelPos4 MONO
+			HWChannelPos5 MONO
+		}
+	}
+	{
+		SplitPCM {
+			Name "m6_stereo_in"
+			Direction Capture
+			Channels 2
+			HWChannels 6
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 FL
+			HWChannelPos3 FR
+			HWChannelPos4 FL
+			HWChannelPos5 FR
+		}
+	}
+]
+
+SectionDevice."Line1" {
+	Comment "Headphone + Monitor Out"
+	Value {
+		PlaybackPriority 200
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "m6_stereo_out"
+		Direction Playback
+		HWChannels 4
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line2" {
+	Comment "Line Out"
+
+	Value {
+		PlaybackPriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "m6_stereo_out"
+		Direction Playback
+		HWChannels 6
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Mic1" {
+	Comment "Mic In 1L"
+
+	Value {
+		CapturePriority 200
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "m6_mono_in"
+		Direction Capture
+		HWChannels 6
+		Channels 1
+		Channel0 0
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Mic2" {
+	Comment "Mic In 2R"
+
+	Value {
+		CapturePriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "m6_mono_in"
+		Direction Capture
+		HWChannels 6
+		Channels 1
+		Channel0 1
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Mic3" {
+	Comment "Mic In 3L"
+
+	Value {
+		CapturePriority 200
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "m6_mono_in"
+		Direction Capture
+		HWChannels 6
+		Channels 1
+		Channel0 2
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Mic4" {
+	Comment "Mic In 4R"
+
+	Value {
+		CapturePriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "m6_mono_in"
+		Direction Capture
+		HWChannels 6
+		Channels 1
+		Channel0 3
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Line5" {
+	Comment "Line In L"
+
+	Value {
+		CapturePriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "m6_mono_in"
+		Direction Capture
+		HWChannels 6
+		Channels 1
+		Channel0 4
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Line6" {
+	Comment "Line In R"
+
+	Value {
+		CapturePriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "m6_mono_in"
+		Direction Capture
+		HWChannels 6
+		Channels 1
+		Channel0 5
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Mic5" {
+	Comment "Stereo Mic In 1L+2R"
+
+	ConflictingDevice [
+		"Mic1"
+		"Mic2"
+	]
+
+	Value {
+		CapturePriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "m6_stereo_in"
+		Direction Capture
+		HWChannels 6
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Mic6" {
+	Comment "Stereo Mic In 3L+4R"
+
+	ConflictingDevice [
+		"Mic3"
+		"Mic4"
+	]
+
+	Value {
+		CapturePriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "m6_stereo_in"
+		Direction Capture
+		HWChannels 6
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line7" {
+	Comment "Stereo Line In L+R"
+
+	ConflictingDevice [
+		"Line5"
+		"Line6"
+	]
+
+	Value {
+		CapturePriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "m6_stereo_in"
+		Direction Capture
+		HWChannels 6
+		Channels 2
+		Channel0 4
+		Channel1 5
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+

--- a/ucm2/USB-Audio/MOTU/M6.conf
+++ b/ucm2/USB-Audio/MOTU/M6.conf
@@ -1,0 +1,12 @@
+Comment "MOTU M6"
+
+SectionUseCase."HiFi" {
+	Comment "Analog Stereo Outputs + Inputs"
+	File "/USB-Audio/MOTU/M6-HiFi.conf"
+}
+
+Define.DirectPlaybackChannels 4
+Define.DirectCaptureChannels 6
+
+Include.dhw.File "/common/direct.conf"
+

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -132,20 +132,28 @@ If.roland-bridgecast {
 	True.Define.ProfileName "Roland/BridgeCast"
 }
 
-If.motu-m24 {
+If.motu-m246 {
 	Condition {
 		Type RegexMatch
 		String "${CardComponents}"
 		Regex "USB07fd:000[8b]"
 	}
-	True.If.M4 {
+	True.If.M6 {
 		Condition {
 			Type String
 			Haystack "${CardLongName}"
-			Needle "MOTU M4"
+			Needle "MOTU M6"
 		}
-		True.Define.ProfileName "MOTU/M4"
-		False.Define.ProfileName "MOTU/M2"
+		True.Define.ProfileName "MOTU/M6"
+		False.If.M4 {
+			Condition {
+				Type String
+				Haystack "${CardLongName}"
+				Needle "MOTU M4"
+			}
+			True.Define.ProfileName "MOTU/M4"
+			False.Define.ProfileName "MOTU/M2"
+		}
 	}
 }
 


### PR DESCRIPTION
This card shares the same ID as the MOTU M2 and M4, so we use the long card name to identify it.