### PR TITLE
USB-Audio: fix comment in MOTU M4 config

### DIFF
--- a/ucm2/USB-Audio/MOTU/M4-HiFi.conf
+++ b/ucm2/USB-Audio/MOTU/M4-HiFi.conf
@@ -139,7 +139,7 @@ SectionDevice."Line4" {
 }
 
 SectionDevice."Mic3" {
-	Comment "Stereo Mic In 1L+1R"
+	Comment "Stereo Mic In 1L+2R"
 
 	ConflictingDevice [
 		"Mic1"


### PR DESCRIPTION
Mic2 is 2R, not 1R, so update the Stereo entry accordingly. This makes it consistent with the M2 and M6 (https://github.com/alsa-project/alsa-ucm-conf/pull/378) configs.