### PR TITLE
USB-Audio Add support for MSI MEG Z690 ACE (ALC4082)

### DIFF
--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -71,6 +71,7 @@ If.realtek-alc4080 {
 		# 0db0:6cc9 MSI MPG Z590 Gaming Plus
 		# 0db0:7696 MSI MAG B650M Mortar Wifi
 		# 0db0:82c7 MSI MEG Z690I Unify
+		# 0db0:124b MSI MEG Z690 ACE
 		# 0db0:8af7 MSI MPG Z590 Gaming Force
 		# 0db0:961e MSI MEG X670E ACE
 		# 0db0:a073 MSI MAG X570S Torpedo Max
@@ -82,7 +83,7 @@ If.realtek-alc4080 {
 		# 0db0:d6e7 MSI MPG X670E Carbon Wifi
 		# 26ce:0a06 ASRock X670E/Z790 Taichi
 		# 26ce:0a08 ASRock Z790 PG-ITX/TB4
-		Regex "USB((0414:a0(0e|1[0124]))|(0b05:(19(84|9[69])|1a(16|2[07]|5[23c])))|(0db0:(005a|151f|1feb|3130|36e7|419c|422d|4240|62a4|6c[0c]9|7696|82c7|8af7|961e|a(073|228|47c|74b)|b202|d1d7|d6e7))|(26ce:0a0[68]))"
+		Regex "USB((0414:a0(0e|1[0124]))|(0b05:(19(84|9[69])|1a(16|2[07]|5[23c])))|(0db0:(005a|151f|1feb|3130|36e7|419c|422d|4240|62a4|6c[0c]9|7696|82c7|124b|8af7|961e|a(073|228|47c|74b)|b202|d1d7|d6e7))|(26ce:0a0[68]))"
 	}
 	True.Define.ProfileName "Realtek/ALC4080"
 }


### PR DESCRIPTION
Tested this out on my motherboard and it fixed my problem with the onboard sound being treated as a generic USB device. Fixing it allowed me to record from line-in, among other things.