### PR TITLE
Qcom volume fixes

### DIFF
--- a/ucm2/Qualcomm/sc8280xp/HiFi.conf
+++ b/ucm2/Qualcomm/sc8280xp/HiFi.conf
@@ -19,8 +19,8 @@ SectionVerb {
 SectionDevice."Speaker" {
 	Comment "Speaker playback"
 
-	Include.wcdspke.File "/codecs/qcom-lpass/wsa-macro/SpeakerEnableSeq.conf"
-	Include.wcdspkd.File "/codecs/qcom-lpass/wsa-macro/SpeakerDisableSeq.conf"
+	Include.wsamspke.File "/codecs/qcom-lpass/wsa-macro/SpeakerEnableSeq.conf"
+	Include.wsamspkd.File "/codecs/qcom-lpass/wsa-macro/SpeakerDisableSeq.conf"
 	Include.wsaspke.File "/codecs/wsa883x/SpeakerEnableSeq.conf"
 	Include.wsaspkd.File "/codecs/wsa883x/SpeakerDisableSeq.conf"
 

--- a/ucm2/Qualcomm/sc8280xp/HiFi.conf
+++ b/ucm2/Qualcomm/sc8280xp/HiFi.conf
@@ -9,7 +9,6 @@ SectionVerb {
 		cset "name='MultiMedia3 Mixer TX_CODEC_DMA_TX_3' 1"
 	]
 
-	Include.wcde.File "/codecs/wcd938x/DefaultEnableSeq.conf"
 	Include.wsae.File "/codecs/wsa883x/DefaultEnableSeq.conf"
 
 	Value {

--- a/ucm2/Qualcomm/sc8280xp/LENOVO-X13s.conf
+++ b/ucm2/Qualcomm/sc8280xp/LENOVO-X13s.conf
@@ -5,6 +5,14 @@ SectionUseCase."HiFi" {
 	Comment "HiFi quality Music."
 }
 
+BootSequence [
+	cset "name='SpkrLeft PA Volume' 12"
+	cset "name='SpkrRight PA Volume' 12"
+	cset "name='HPHL Volume' 20"
+	cset "name='HPHR Volume' 20"
+	cset "name='ADC2 Volume' 10"
+]
+
 Include.card-init.File "/lib/card-init.conf"
 Include.ctl-remap.File "/lib/ctl-remap.conf"
 Include.wcd-init.File "/codecs/wcd938x/init.conf"

--- a/ucm2/Qualcomm/sc8280xp/LENOVO-X13s.conf
+++ b/ucm2/Qualcomm/sc8280xp/LENOVO-X13s.conf
@@ -7,7 +7,7 @@ SectionUseCase."HiFi" {
 
 Include.card-init.File "/lib/card-init.conf"
 Include.ctl-remap.File "/lib/ctl-remap.conf"
-Include.codec-init.File "/codecs/wcd938x/init.conf"
-Include.codec-init.File "/codecs/wsa883x/init.conf"
-Include.codec-init.File "/codecs/qcom-lpass/wsa-macro/init.conf"
-Include.codec-init.File "/codecs/qcom-lpass/rx-macro/init.conf"
+Include.wcd-init.File "/codecs/wcd938x/init.conf"
+Include.wsa-init.File "/codecs/wsa883x/init.conf"
+Include.wsam-init.File "/codecs/qcom-lpass/wsa-macro/init.conf"
+Include.rxm-init.File "/codecs/qcom-lpass/rx-macro/init.conf"

--- a/ucm2/Qualcomm/sc8280xp/LENOVO-X13s.conf
+++ b/ucm2/Qualcomm/sc8280xp/LENOVO-X13s.conf
@@ -8,8 +8,8 @@ SectionUseCase."HiFi" {
 BootSequence [
 	cset "name='SpkrLeft PA Volume' 12"
 	cset "name='SpkrRight PA Volume' 12"
-	cset "name='HPHL Volume' 20"
-	cset "name='HPHR Volume' 20"
+	cset "name='HPHL Volume' 10"
+	cset "name='HPHR Volume' 10"
 	cset "name='ADC2 Volume' 10"
 ]
 

--- a/ucm2/Qualcomm/x1e80100/HiFi.conf
+++ b/ucm2/Qualcomm/x1e80100/HiFi.conf
@@ -9,7 +9,6 @@ SectionVerb {
 		cset "name='MultiMedia4 Mixer VA_CODEC_DMA_TX_0' 1"
 	]
 
-	Include.wcde.File "/codecs/wcd938x/DefaultEnableSeq.conf"
 	Include.wsae.File "/codecs/wsa884x/four-speakers/DefaultEnableSeq.conf"
 	Include.wsm1e.File "/codecs/qcom-lpass/wsa-macro/Wsa1SpeakerEnableSeq.conf"
 	Include.wsm2e.File "/codecs/qcom-lpass/wsa-macro/Wsa2SpeakerEnableSeq.conf"

--- a/ucm2/Qualcomm/x1e80100/X1E80100-CRD.conf
+++ b/ucm2/Qualcomm/x1e80100/X1E80100-CRD.conf
@@ -7,7 +7,7 @@ SectionUseCase."HiFi" {
 
 Include.card-init.File "/lib/card-init.conf"
 Include.ctl-remap.File "/lib/ctl-remap.conf"
-Include.codec-init.File "/codecs/wcd938x/init.conf"
-Include.codec-init.File "/codecs/wsa884x/four-speakers/init.conf"
-Include.codec-init.File "/codecs/qcom-lpass/wsa-macro/four-speakers/init.conf"
-Include.codec-init.File "/codecs/qcom-lpass/rx-macro/init.conf"
+Include.wcd-init.File "/codecs/wcd938x/init.conf"
+Include.wsa-init.File "/codecs/wsa884x/four-speakers/init.conf"
+Include.wsam-init.File "/codecs/qcom-lpass/wsa-macro/four-speakers/init.conf"
+Include.rxm-init.File "/codecs/qcom-lpass/rx-macro/init.conf"

--- a/ucm2/Qualcomm/x1e80100/X1E80100-CRD.conf
+++ b/ucm2/Qualcomm/x1e80100/X1E80100-CRD.conf
@@ -5,6 +5,12 @@ SectionUseCase."HiFi" {
 	Comment "HiFi quality Music."
 }
 
+BootSequence [
+	cset "name='HPHL Volume' 20"
+	cset "name='HPHR Volume' 20"
+	cset "name='ADC2 Volume' 10"
+]
+
 Include.card-init.File "/lib/card-init.conf"
 Include.ctl-remap.File "/lib/ctl-remap.conf"
 Include.wcd-init.File "/codecs/wcd938x/init.conf"

--- a/ucm2/codecs/wcd938x/DefaultEnableSeq.conf
+++ b/ucm2/codecs/wcd938x/DefaultEnableSeq.conf
@@ -1,4 +1,0 @@
-EnableSequence [
-	cset "name='HPHR Volume' 20"
-	cset "name='HPHL Volume' 20"
-]

--- a/ucm2/codecs/wcd938x/HeadphoneMicEnableSeq.conf
+++ b/ucm2/codecs/wcd938x/HeadphoneMicEnableSeq.conf
@@ -3,5 +3,4 @@ EnableSequence [
 	cset "name='HDR12 MUX' NO_HDR12"
 	cset "name='ADC2 MUX' INP2"
 	cset "name='ADC2 Switch' 1"
-	cset "name='ADC2 Volume' 10"
 ]

--- a/ucm2/codecs/wcd938x/init.conf
+++ b/ucm2/codecs/wcd938x/init.conf
@@ -1,9 +1,5 @@
 # WCD938X specific volume control settings
 
-BootSequence [
-	cset "name='ADC2 Volume' 12"
-]
-
 LibraryConfig.remap.Config {
 
 	ctl.default.map {

--- a/ucm2/codecs/wsa883x/SpeakerEnableSeq.conf
+++ b/ucm2/codecs/wsa883x/SpeakerEnableSeq.conf
@@ -4,11 +4,9 @@ EnableSequence [
 	cset "name='SpkrLeft DAC Switch' 1"
 	cset "name='SpkrLeft VISENSE Switch' 0"
 	cset "name='SpkrLeft WSA MODE' 0"
-	cset "name='SpkrLeft PA Volume' 12"
 	cset "name='SpkrRight COMP Switch' 1"
 	cset "name='SpkrRight BOOST Switch' 1"
 	cset "name='SpkrRight DAC Switch' 1"
 	cset "name='SpkrRight VISENSE Switch' 0"
-	cset "name='SpkrRight PA Volume' 12"
 	cset "name='SpkrRight WSA MODE' 0"
 ]


### PR DESCRIPTION
Fix the Qualcomm sc8280xp and x1e80100 configurations which accidentally left the Speaker and Headphones mixer controls undefined so that the sound server falls back to software mixing. Also set the default volume levels in machine specific BootSequences so that the user can override the defaults.