### PR TITLE
ucm2: Qualcomm: Lenovo-X13s: reduce default headphones volume further

### DIFF
--- a/ucm2/Qualcomm/sc8280xp/LENOVO-X13s.conf
+++ b/ucm2/Qualcomm/sc8280xp/LENOVO-X13s.conf
@@ -8,8 +8,8 @@ SectionUseCase."HiFi" {
 BootSequence [
 	cset "name='SpkrLeft PA Volume' 12"
 	cset "name='SpkrRight PA Volume' 12"
-	cset "name='HPHL Volume' 10"
-	cset "name='HPHR Volume' 10"
+	cset "name='HPHL Volume' 2"
+	cset "name='HPHR Volume' 2"
 	cset "name='ADC2 Volume' 10"
 ]
 


### PR DESCRIPTION
A recent change reduced the default headphones volume from setting 20 (0 dB) to 10 (-15 dB) but also this setting can be quite loud and cause distortion with some headphones.

Reduce the default volume further to setting 2 (-27 dB), which results in more comfortable volume levels with such headphones.