### PR TITLE
Add support for Asus ROG Maximus Z790 Apex Encore motherboard

### DIFF
--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -58,6 +58,7 @@ If.realtek-alc4080 {
 		# 0b05:1a52 ASUS ROG Strix X670E-F & Z790-E Gaming Wifi
 		# 0b05:1a53 ALC4082 on ASUS ROG Crosshair X670E Extreme
 		# 0b05:1a5c ASUS ROG Strix B650E-I Gaming WiFi
+		# 0b05:1a97 ASUS ROG Maximus Z790 Apex Encore
 		# 0db0:005a MSI MPG Z690 CARBON WIFI
 		# 0db0:124b MSI MEG Z690 ACE
 		# 0db0:151f MSI X570S EDGE MAX WIFI
@@ -83,7 +84,7 @@ If.realtek-alc4080 {
 		# 0db0:d6e7 MSI MPG X670E Carbon Wifi
 		# 26ce:0a06 ASRock X670E/Z790 Taichi
 		# 26ce:0a08 ASRock Z790 PG-ITX/TB4
-		Regex "USB((0414:a0(0e|1[0124]))|(0b05:(19(84|9[69])|1a(16|2[07]|5[23c])))|(0db0:(005a|124b|151f|1feb|3130|36e7|419c|422d|4240|62a4|6c[0c]9|7696|82c7|8af7|961e|a(073|228|47c|74b)|b202|d1d7|d6e7))|(26ce:0a0[68]))"
+		Regex "USB((0414:a0(0e|1[0124]))|(0b05:(19(84|9[69])|1a(16|2[07]|5[23c]|97)))|(0db0:(005a|124b|151f|1feb|3130|36e7|419c|422d|4240|62a4|6c[0c]9|7696|82c7|8af7|961e|a(073|228|47c|74b)|b202|d1d7|d6e7))|(26ce:0a0[68]))"
 	}
 	True.Define.ProfileName "Realtek/ALC4080"
 }


### PR DESCRIPTION
The Asus ROG Maximus Z790 Apex Encore motherboard is yet another Asus board with a Realtek ALC4080 chip.  This adds the USB device id for this chip as it appears on this motherboard, which is needed to enable the rear microphone port.

My [alsa-info.txt](https://github.com/alsa-project/alsa-ucm-conf/files/14026974/alsa-info.txt) details attached.
