### PR TITLE
ucm2: acp3x-es83xx: introduce UCM support for acp3x-es83xx sound card

### DIFF
--- a/ucm2/AMD/acp3x-es83xx/HiFi.conf
+++ b/ucm2/AMD/acp3x-es83xx/HiFi.conf
@@ -1,0 +1,94 @@
+SectionVerb {
+	EnableSequence [
+		disdevall ""
+		# Disable all inputs / outputs
+		#   (may be duplicated with disdevall)
+		cset "name='Headphone Switch' off"
+		cset "name='Headset Mic Switch' off"
+		cset "name='Internal Mic Switch' off"
+		cset "name='DAC Mono Mix Switch' off"
+	]
+}
+
+If.dmic {
+	Condition {
+		Type String
+		Empty "${var:DeviceDmic}"
+	}
+	False.SectionDevice."Mic" {
+		Comment "Digital Microphone"
+
+		Value {
+			CapturePriority 100
+			CapturePCM "hw:${CardId},${var:DeviceDmic}"
+			CaptureChannels 2
+		}
+	}
+}
+
+SectionDevice."Speaker" {
+	Comment "Speakers"
+
+	ConflictingDevice [
+		"Headphones"
+	]
+
+	EnableSequence [
+		cset "name='Speaker Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Speaker Switch' off"
+	]
+
+	Value {
+		PlaybackPriority 100
+		PlaybackPCM "hw:${CardId}"
+		# The es8316 only has a HP-amp which is muxed to the speaker
+		# or to the headpones output
+		PlaybackMixerElem "Headphone Mixer"
+		PlaybackMasterElem "DAC"
+	}
+}
+
+SectionDevice."Headphones" {
+	Comment "Headphones"
+
+	ConflictingDevice [
+		"Speaker"
+	]
+
+	Value {
+		PlaybackPriority 300
+		PlaybackPCM "hw:${CardId}"
+		PlaybackMixerElem "Headphone Mixer"
+		PlaybackMasterElem "DAC"
+		JackControl "Headphone Jack"
+		JackHWMute "Speaker"
+	}
+}
+
+SectionDevice."Headset" {
+	Comment "Headset Microphone"
+
+	EnableSequence [
+		cset "name='Differential Mux' lin1-rin1"
+		cset "name='Headset Mic Switch' on"
+		cset "name='Digital Mic Mux' 'dmic disable'"
+		cset "name='Internal Mic Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Headset Mic Switch' on"
+		cset "name='Internal Mic Switch' off"
+	]
+
+	Value {
+		CapturePriority 300
+		CapturePCM "hw:${CardId}"
+		CaptureMixerElem "ADC PGA Gain"
+		CaptureMasterElem "ADC"
+		JackControl "Headset Mic Jack"
+	}
+}
+

--- a/ucm2/AMD/acp3x-es83xx/acp3x-es83xx.conf
+++ b/ucm2/AMD/acp3x-es83xx/acp3x-es83xx.conf
@@ -1,0 +1,33 @@
+Syntax 6
+
+Define.DeviceDmic "$${find-device:type=pcm,stream=capture,field=id,regex='dmic'}"
+
+BootSequence [
+	# Setup muxes / switches
+	cset "name='Left Headphone Mixer Left DAC Switch' on"
+	cset "name='Right Headphone Mixer Right DAC Switch' on"
+	# Set digital mix mux to "dmic disable"
+	# That doesn't affect dmic, but other values mute headset mic
+	cset "name='Digital Mic Mux' 0"
+
+	# Set HP vol to 0 dB
+	cset "name='Headphone Playback Volume' 100%"
+	cset "name='Headphone Mixer Volume' 100%"
+
+	# Set DAC vol
+	cset "name='DAC Playback Volume' 70%"
+	# LDATA TO LDAC, RDATA TO RDAC
+	cset "name='DAC Source Mux' 0"
+
+	# Disable Auto Level Control
+	cset "name='ALC Capture Switch' off"
+
+	# Set capture vol
+	cset "name='ADC Capture Volume' 70%"
+]
+
+SectionUseCase."HiFi" {
+	File "/AMD/acp3x-es83xx/HiFi.conf"
+	Comment "Play and record HiFi quality Music"
+}
+

--- a/ucm2/conf.d/acp3x-es83xx/acp3x-es83xx.conf
+++ b/ucm2/conf.d/acp3x-es83xx/acp3x-es83xx.conf
@@ -1,0 +1,1 @@
+../../AMD/acp3x-es83xx/acp3x-es83xx.conf


### PR DESCRIPTION
Based on already existing UCM support in ucm2/Intel/sof-essx8336

This commit adds support for a line of Huawei laptops that use the AMD ACP controller and a es8336 codec.
The kernel machine driver is already upstream.  
The proposed settings are based on the intel es83xx support already present, but with the difference that
this line of laptops do not use an analog microphone that is connected to the codec.

[alsa-info.zip](https://github.com/alsa-project/alsa-ucm-conf/files/14073662/alsa-info.zip)
