### PR TITLE
USB-Audio: ALC4080: Add support for MSI MPG B650 Carbon Wifi (0db0:70d3)

### DIFF
--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -72,6 +72,7 @@ If.realtek-alc4080 {
 		# 0db0:6c09 MSI MPG Z790 Carbon Wifi
 		# 0db0:6cc9 MSI MPG Z590 Gaming Plus
 		# 0db0:7696 MSI MAG B650M Mortar Wifi
+		# 0db0:70d3 MSI MPG B650 Carbon Wifi
 		# 0db0:82c7 MSI MEG Z690I Unify
 		# 0db0:8af7 MSI MPG Z590 Gaming Force
 		# 0db0:961e MSI MEG X670E ACE
@@ -84,7 +85,7 @@ If.realtek-alc4080 {
 		# 0db0:d6e7 MSI MPG X670E Carbon Wifi
 		# 26ce:0a06 ASRock X670E/Z790 Taichi
 		# 26ce:0a08 ASRock Z790 PG-ITX/TB4
-		Regex "USB((0414:a0(0e|1[0124]))|(0b05:(19(84|9[69])|1a(16|2[07]|5[23c]|97)))|(0db0:(005a|124b|151f|1feb|3130|36e7|419c|422d|4240|62a4|6c[0c]9|7696|82c7|8af7|961e|a(073|228|47c|74b)|b202|d1d7|d6e7))|(26ce:0a0[68]))"
+		Regex "USB((0414:a0(0e|1[0124]))|(0b05:(19(84|9[69])|1a(16|2[07]|5[23c]|97)))|(0db0:(005a|124b|151f|1feb|3130|36e7|419c|422d|4240|62a4|6c[0c]9|7696|70d3|82c7|8af7|961e|a(073|228|47c|74b)|b202|d1d7|d6e7))|(26ce:0a0[68]))"
 	}
 	True.Define.ProfileName "Realtek/ALC4080"
 }


### PR DESCRIPTION
This PR adds support for the MSI MPG B650 Carbon Wifi board. This makes the front headphone and microphone ports working (tested on my local hardware).  The microphone sound volume is a bit low compared to windows, [as mentioned previously](https://github.com/alsa-project/alsa-ucm-conf/pull/143/files#r845264949), but in general it works.

Fixes #359

```
$ sudo lsusb | grep Audio
Bus 001 Device 003: ID 0db0:70d3 Micro Star International USB Audio
$ alsaucm listcards
  0: hw:4
    Generic USB Audio at usb-0000:0f:00.0-6, high speed

```



