### PR TITLE
sof-soundwire: rt1308: Fix single amp configuration

### DIFF
--- a/ucm2/sof-soundwire/rt1308.conf
+++ b/ucm2/sof-soundwire/rt1308.conf
@@ -28,8 +28,9 @@ DefineMacro.rt1308spk.If.0 {
 SectionDevice."Speaker" {
 	Comment	"Speaker"
 
-	Macro.num1.rt1308spk { ForAmps "[12]" Amp 1 Sel LL }
-	Macro.num2.rt1308spk { ForAmps "2" Amp 2 Sel RR }
+	Macro.num1.rt1308spk { ForAmps "1" Amp 1 Sel LR }
+	Macro.num2.rt1308spk { ForAmps "2" Amp 1 Sel LL }
+	Macro.num3.rt1308spk { ForAmps "2" Amp 2 Sel RR }
 
 	EnableSequence [
 		cset "name='Speaker Switch' on"


### PR DESCRIPTION
If the device have single rt1308 amp then the codec's Channel Select should be set to "LR" and not to "LL". "LL" is only valid if we have 2 amps, in that case one is the Left and the other is the Right channel.

This fixes for example Dell Latitude 9520 which only played on the Left speaker, Right is silent.