### PR TITLE
ucm2: MediaTek: mt8195-sof: Add support for Tomato RT5682s variant

### DIFF
--- a/ucm2/MediaTek/mt8195-sof/mt6359-rt1019-rt5682/HiFi.conf
+++ b/ucm2/MediaTek/mt8195-sof/mt6359-rt1019-rt5682/HiFi.conf
@@ -33,13 +33,27 @@ SectionDevice."Headphones" {
 
 	EnableSequence [
 		cset "name='Headphone Switch' on"
-		cset "name='HPOL Playback Switch' 1"
-		cset "name='HPOR Playback Switch' 1"
 	]
 
+	If.is_rt5682i_hp {
+		Condition {
+			Type ControlExists
+			Control "name='HPOL Playback Switch'"
+		}
+		True {
+			EnableSequence [
+				cset "name='HPOL Playback Switch' 1"
+				cset "name='HPOR Playback Switch' 1"
+			]
+
+			DisableSequence [
+				cset "name='HPOL Playback Switch' 0"
+				cset "name='HPOR Playback Switch' 0"
+			]
+		}
+	}
+
 	DisableSequence [
-		cset "name='HPOL Playback Switch' 0"
-		cset "name='HPOR Playback Switch' 0"
 		cset "name='Headphone Switch' off"
 	]
 

--- a/ucm2/MediaTek/mt8195-sof/mt6359-rt1019-rt5682/init.conf
+++ b/ucm2/MediaTek/mt8195-sof/mt6359-rt1019-rt5682/init.conf
@@ -1,9 +1,20 @@
-# rt1019-rt5682 specific boot sequence
+# rt1019-rt5682i/s specific boot sequence
+
+If.is_rt5682i {
+	# We can safely assume that both L/R exist if L does.
+	Condition {
+		Type ControlExists
+		Control "name='DAC L Mux"
+	}
+	True.BootSequence [
+		cset "name='DAC L Mux' IF1"
+		cset "name='DAC R Mux' IF1"
+	]
+}
+
 BootSequence [
 	cset "name='Stereo1 DAC MIXL DAC L1 Switch' 1"
 	cset "name='Stereo1 DAC MIXR DAC R1 Switch' 1"
-	cset "name='DAC L Mux' IF1"
-	cset "name='DAC R Mux' IF1"
 	cset "name='IF1 01 ADC Swap Mux' 2"
 	cset "name='CBJ Boost Volume' 3"
 	cset "name='Stereo1 ADC L Mux' 'ADC1 L'"

--- a/ucm2/conf.d/sof-m8195_r1019/sof-m8195_r1019_5682s.conf
+++ b/ucm2/conf.d/sof-m8195_r1019/sof-m8195_r1019_5682s.conf
@@ -1,0 +1,1 @@
+../../MediaTek/mt8195-sof/mt6359-rt1019-rt5682/sof-mt8195-mt6359-rt1019-rt5682.conf


### PR DESCRIPTION
A later revision of the MT8195 Cherry Tomato Chromebook (Acer Chromebook Spin 513 CP513-2H, Revision 3 and 4) are using the RT5682s codec instead of RT5682i.

The differences are only about a couple of missing switches, where the 'i' variant had a switch for the L/R Headphone output and a configurable DAC L/R Mux, while the 's' one misses the mux control and solely relies on the main Headphone Switch.

This configuration has been tested on Arch Linux with Pipewire 10.03 + WirePlumber.