### PR TITLE
qcom: sdm845: MM1: fixes

### DIFF
--- a/ucm2/Qualcomm/sdm845/HiFi-MM1.conf
+++ b/ucm2/Qualcomm/sdm845/HiFi-MM1.conf
@@ -40,7 +40,7 @@ SectionDevice."Speaker" {
 		PlaybackPriority 100
 		PlaybackPCM "hw:${CardId},0"
 		PlaybackMixer "default:${CardId}"
-		PlaybackMixerElem "Speaker Digital"
+		PlaybackMixerElem "Speaker"
 	}
 }
 
@@ -54,7 +54,7 @@ SectionDevice."Headphones" {
 		PlaybackPriority 200
 		PlaybackPCM "hw:${CardId},2"
 		PlaybackMixer "default:${CardId}"
-		PlaybackMixerElem "HP Digital"
+		PlaybackMixerElem "HP"
 	}
 }
 

--- a/ucm2/Qualcomm/sdm845/HiFi-MM1.conf
+++ b/ucm2/Qualcomm/sdm845/HiFi-MM1.conf
@@ -55,6 +55,7 @@ SectionDevice."Headphones" {
 		PlaybackPCM "hw:${CardId},2"
 		PlaybackMixer "default:${CardId}"
 		PlaybackMixerElem "HP"
+		JackControl "Headphone Jack"
 	}
 }
 


### PR DESCRIPTION
I'm testing it on a device which is not in upstream yet, but it uses this configuration

It seems that the only device in upstream using it is Lenovo Yoga C630 laptop and we got it tested as well https://oftc.irclog.whitequark.org/aarch64-laptops/2024-04-06#33084827

The changes are pretty straightforward, check commit messages of each commit