### PR TITLE
ucm2: HDA: Use Master volume control for dual speakers

### DIFF
--- a/ucm2/HDA/HiFi-analog.conf
+++ b/ucm2/HDA/HiFi-analog.conf
@@ -146,12 +146,19 @@ If.spk {
 				EnableSequence [
 					cset "name='Speaker Playback Switch' on"
 					cset "name='Bass Speaker Playback Switch' on"
+					cset "name='Speaker Playback Volume' 100%"
+					cset "name='Bass Speaker Playback Volume' 100%"
 				]
 
 				DisableSequence [
 					cset "name='Speaker Playback Switch' off"
 					cset "name='Bass Speaker Playback Switch' off"
 				]
+				Value {
+					PlaybackMixerElem "Master"
+					PlaybackVolume "Master Playback Volume"
+					PlaybackSwitch "Master Playback Switch"
+				}
 			}
 			False {
 				EnableSequence [
@@ -161,16 +168,18 @@ If.spk {
 				DisableSequence [
 					cset "name='Speaker Playback Switch' off"
 				]
+				Value {
+					PlaybackMixerElem "Speaker"
+					PlaybackVolume "Speaker Playback Volume"
+					PlaybackSwitch "Speaker Playback Switch"
+				}
 			}
 		}
 
 		Value {
 			PlaybackPriority 100
 			PlaybackPCM "hw:${CardId}"
-			PlaybackMixerElem "Speaker"
 			PlaybackMasterElem "Master"
-			PlaybackVolume "Speaker Playback Volume"
-			PlaybackSwitch "Speaker Playback Switch"
 		}
 	}
 }


### PR DESCRIPTION
This PR extends the existing 'activate Bass Speaker' case with additional configuration

- Use Master mixer for volume control (instead of only using Speaker)
- Configure Speaker Volume and Bass Speaker volume to max since Master volume regulation is used

It fixes a case where only the first speaker volume is changed using the system volume control.