### PR TITLE
sof-hda-dsp/sof-soundwire: Create "hdmi:" mapping PCMs to allow passthrough if supported

### DIFF
--- a/ucm2/Intel/sof-hda-dsp/sof-hda-dsp.conf
+++ b/ucm2/Intel/sof-hda-dsp/sof-hda-dsp.conf
@@ -1,9 +1,19 @@
 Syntax 6
 
-Define.DeviceMic "Mic"
-Define.DeviceDmic ""
-
 Include.card-init.File "/lib/card-init.conf"
+
+Define {
+	DeviceMic "Mic"
+	DeviceDmic ""
+	Iec61937Pcms1 ""
+}
+
+DefineRegex {
+	Iec61937Pcms {
+		Regex "iec61937-pcm:(([0-9]+(,))*[0-9]+)"
+		String "${CardComponents}"
+	}
+}
 
 If.devdmic {
 	Condition {
@@ -114,4 +124,42 @@ If.Capture {
 		cset "name='Capture Volume' 60%"
 		cset "name='Capture Switch' on"
 	]
+}
+
+Include.hdmi-pcm.File "/common/pcm/hdmi.conf"
+
+If.Hdmi3-iec61937 {
+	Condition {
+		Type RegexMatch
+		Regex "((^|,)[3](,|$))"
+		String "${var:Iec61937Pcms1}"
+	}
+	True.Macro.hdmi3.HdmiPCM { Device 3 Index 0 }
+}
+
+If.Hdmi4-iec61937 {
+	Condition {
+		Type RegexMatch
+		Regex "((^|,)[4](,|$))"
+		String "${var:Iec61937Pcms1}"
+	}
+	True.Macro.hdmi4.HdmiPCM { Device 4 Index 1 }
+}
+
+If.Hdmi5-iec61937 {
+	Condition {
+		Type RegexMatch
+		Regex "((^|,)[5](,|$))"
+		String "${var:Iec61937Pcms1}"
+	}
+	True.Macro.hdmi5.HdmiPCM { Device 5 Index 2 }
+}
+
+If.HdmiIec61937 {
+	Condition {
+		Type RegexMatch
+		Regex "((^|,)[345](,|$))"
+		String "${var:Iec61937Pcms1}"
+	}
+	True.Macro.save_hdmi_cfg.HdmiPCMSave { Name "42-sof-hdmi" }
 }

--- a/ucm2/common/pcm/hdmi.conf
+++ b/ucm2/common/pcm/hdmi.conf
@@ -1,0 +1,74 @@
+# Macro HdmiPCM - Generate ALSA control section for hdmi: PCM device
+#
+# Arguments:
+#   Device - hardware PCM device
+#   Index - hdmi: device index and control index
+#
+
+DefineMacro.HdmiPCM {
+	LibraryConfig.generic.Config.hdmi-pcm.pcm.hdmi."${var:__Index}" {
+		@args [ CARD AES0 AES1 AES2 AES3 ]
+		@args.CARD {
+			type string
+		}
+		@args.AES0 {
+			type integer
+		}
+		@args.AES1 {
+			type integer
+		}
+		@args.AES2 {
+			type integer
+		}
+		@args.AES3 {
+			type integer
+		}
+		type hooks
+		slave.pcm {
+			type hw
+			card $CARD
+			device "${evali:$__Device}"
+		}
+		hooks.0 {
+			type ctl_elems
+			hook_args [
+			{
+				name "IEC958 Playback Default"
+				index "${evali:$__Index}"
+				lock true
+				preserve true
+				value [ $AES0 $AES1 $AES2 $AES3 ]
+			}
+			{
+				name "IEC958 Playback Switch"
+				index "${evali:$__Index}"
+				value true
+			}
+			]
+		}
+		hint.device "${evali:$__Device}"
+	}
+}
+
+# Macro HdmiPCMSave - Save the generated ALSA control for hdmi: PCM device(s)
+#		      generated inside 'hdmi-pcm' section by prior calls to
+#		      HdmiPCM macro
+#
+# Arguments:
+#   [Name] - Optional name excluding the .conf extension to use for the
+#	     configuration file, defaults to "42-hdmi-pcm"
+#
+
+DefineMacro.HdmiPCMSave {
+	If.name {
+		Condition {
+			Type String
+			Empty "${var:-__Name}"
+		}
+		True.Define.__Name "42-hdmi-pcm"
+	}
+
+	FixedBootSequence [
+			cfg-save "${var:LibDir}/${var:__Name}.conf:hdmi-pcm"
+	]
+}

--- a/ucm2/sof-soundwire/sof-soundwire.conf
+++ b/ucm2/sof-soundwire/sof-soundwire.conf
@@ -15,6 +15,7 @@ Define {
 	HeadsetCodec1 ""
 	MicCodec1 ""
 	Mics1 "0"
+	Iec61937Pcms1 ""
 }
 
 DefineRegex {
@@ -40,6 +41,10 @@ DefineRegex {
 	}
 	Mics {
 		Regex " cfg-mics:([1-9][0-9]*)"
+		String "${CardComponents}"
+	}
+	Iec61937Pcms {
+		Regex "iec61937-pcm:(([0-9]+(,))*[0-9]+)"
 		String "${CardComponents}"
 	}
 }
@@ -102,4 +107,42 @@ If.mics-array {
 		 # dmic array info
 		exec "-nhlt-dmic-info -o ${var:LibDir}/dmics-nhlt.json"
 	}
+}
+
+Include.hdmi-pcm.File "/common/pcm/hdmi.conf"
+
+If.Hdmi5-iec61937 {
+	Condition {
+		Type RegexMatch
+		Regex "((^|,)[5](,|$))"
+		String "${var:Iec61937Pcms1}"
+	}
+	True.Macro.hdmi5.HdmiPCM { Device 5 Index 0 }
+}
+
+If.Hdmi6-iec61937 {
+	Condition {
+		Type RegexMatch
+		Regex "((^|,)[6](,|$))"
+		String "${var:Iec61937Pcms1}"
+	}
+	True.Macro.hdmi6.HdmiPCM { Device 6 Index 1 }
+}
+
+If.Hdmi7-iec61937 {
+	Condition {
+		Type RegexMatch
+		Regex "((^|,)[7](,|$))"
+		String "${var:Iec61937Pcms1}"
+	}
+	True.Macro.hdmi7.HdmiPCM { Device 7 Index 2 }
+}
+
+If.HdmiIec61937 {
+	Condition {
+		Type RegexMatch
+		Regex "((^|,)[567](,|$))"
+		String "${var:Iec61937Pcms1}"
+	}
+	True.Macro.save_hdmi_cfg.HdmiPCMSave { Name "42-sof-hdmi" }
 }


### PR DESCRIPTION
Hi,

SOF with IPC4 can use 'ChainDMA' on selected PCMs (HDMI/DP currently) which allows them to be used for bytestream passthrough since the data is passed through unmodified.
The kernel will list the PCMs with ChainDMA to the card's components list:
https://github.com/thesofproject/linux/pull/4921
For example for sof-dsp-hda cards `iec61937-pcm:5,4,3` will be added.

For user space to use HDMI passthrough, the `hdmi:` PCM device should be present correctly mapping to the machine, for example for sof-dsp-hda:
```
aplay -L | grep hdmi

hdmi:CARD=sofhdadsp,DEV=0
hdmi:CARD=sofhdadsp,DEV=1
hdmi:CARD=sofhdadsp,DEV=2
```
This PR does this by
1. Checking the `iec61937-pcm` indexes against the expected HDMI devices (sof-dsp-hda: 3-5, sof-soundwire: 5-7)
2. If there is a match (passthrough can be supported) then we will create three conf files:

The generated files are:
[1] /var/lib/alsa/conf.d/42-sof-hdmi.conf
[2] /var/lib/alsa/card[card_number].conf.d/30-sof-hdmi-common.conf
[3] /var/lib/alsa/card[card_number].conf.d/31-sof-hdmi.conf

[1] includes the pcm/iec958.conf and pcm/hdmi.conf to global space of
    alsaconf to be used by the card macros
[2] Card specific macros for hdmi PCM definition, mapping
[3] Card specific definitions of the three HDMI port

Note for [1]: I needed to use `shell "echo '...` since the `cfg-save` would expand the includes into the saved config file and that just does not result a working alsa configuration.

@perexg, I'm sure all this can be done in a cleaner way... We cannot do this unconditionally as if the HDMI is not using ChainDMA (and SOF is not IPC4) then the passthrough is not possible since the firmware might touch the data.