### PR TITLE
common: pcm: hdmi/sof-hda-dsp/sof-soundwire: Syntax 7 dependent macro to generate the hdmi device sections

### DIFF
--- a/ucm2/Intel/sof-hda-dsp/sof-hda-dsp.conf
+++ b/ucm2/Intel/sof-hda-dsp/sof-hda-dsp.conf
@@ -1,4 +1,4 @@
-Syntax 6
+Syntax 7
 
 Include.card-init.File "/lib/card-init.conf"
 
@@ -128,32 +128,9 @@ If.Capture {
 
 Include.hdmi-pcm.File "/common/pcm/hdmi.conf"
 
-If.Hdmi3-iec61937 {
-	Condition {
-		Type RegexMatch
-		Regex "((^|,)[3](,|$))"
-		String "${var:Iec61937Pcms1}"
-	}
-	True.Macro.hdmi3.HdmiPCM { Device 3 Index 0 }
-}
-
-If.Hdmi4-iec61937 {
-	Condition {
-		Type RegexMatch
-		Regex "((^|,)[4](,|$))"
-		String "${var:Iec61937Pcms1}"
-	}
-	True.Macro.hdmi4.HdmiPCM { Device 4 Index 1 }
-}
-
-If.Hdmi5-iec61937 {
-	Condition {
-		Type RegexMatch
-		Regex "((^|,)[5](,|$))"
-		String "${var:Iec61937Pcms1}"
-	}
-	True.Macro.hdmi5.HdmiPCM { Device 5 Index 2 }
-}
+Macro.0.HdmiDevice { Iec61937Devices "${var:Iec61937Pcms1}" Dev 3 Idx 0 }
+Macro.1.HdmiDevice { Iec61937Devices "${var:Iec61937Pcms1}" Dev 4 Idx 1 }
+Macro.2.HdmiDevice { Iec61937Devices "${var:Iec61937Pcms1}" Dev 5 Idx 2 }
 
 If.HdmiIec61937 {
 	Condition {

--- a/ucm2/common/pcm/hdmi.conf
+++ b/ucm2/common/pcm/hdmi.conf
@@ -1,3 +1,5 @@
+Syntax 7
+
 # Macro HdmiPCM - Generate ALSA control section for hdmi: PCM device
 #
 # Arguments:
@@ -71,4 +73,23 @@ DefineMacro.HdmiPCMSave {
 	FixedBootSequence [
 			cfg-save "${var:LibDir}/${var:__Name}.conf:hdmi-pcm"
 	]
+}
+
+# Macro SofHdmiDevice - Create hdmi PCM device for a sound card if passthrough
+#			is supported
+#
+# Arguments:
+#   Iec61937Devices - Comma separated list of PCM device ids supporting iec61937
+#		      passthrough
+#   Dev - Hardware PCM device to match in Iec61937Devices for iec61937 support
+#   Idx - hdmi: device index and control index
+#
+
+DefineMacro.HdmiDevice.If.iec61937 {
+	Condition {
+		Type RegexMatch
+		Regex "((^|,)[${var:__Dev}](,|$))"
+		String "${var:__Iec61937Devices}"
+	}
+	True.Macro.0.HdmiPCM { Device "${var:__Dev}" Index "${var:__Idx}" }
 }

--- a/ucm2/sof-soundwire/sof-soundwire.conf
+++ b/ucm2/sof-soundwire/sof-soundwire.conf
@@ -1,4 +1,4 @@
-Syntax 6
+Syntax 7
 
 SectionUseCase."HiFi" {
 	File "/sof-soundwire/HiFi.conf"
@@ -111,32 +111,9 @@ If.mics-array {
 
 Include.hdmi-pcm.File "/common/pcm/hdmi.conf"
 
-If.Hdmi5-iec61937 {
-	Condition {
-		Type RegexMatch
-		Regex "((^|,)[5](,|$))"
-		String "${var:Iec61937Pcms1}"
-	}
-	True.Macro.hdmi5.HdmiPCM { Device 5 Index 0 }
-}
-
-If.Hdmi6-iec61937 {
-	Condition {
-		Type RegexMatch
-		Regex "((^|,)[6](,|$))"
-		String "${var:Iec61937Pcms1}"
-	}
-	True.Macro.hdmi6.HdmiPCM { Device 6 Index 1 }
-}
-
-If.Hdmi7-iec61937 {
-	Condition {
-		Type RegexMatch
-		Regex "((^|,)[7](,|$))"
-		String "${var:Iec61937Pcms1}"
-	}
-	True.Macro.hdmi7.HdmiPCM { Device 7 Index 2 }
-}
+Macro.0.HdmiDevice { Iec61937Devices "${var:Iec61937Pcms1}" Dev 5 Idx 0 }
+Macro.1.HdmiDevice { Iec61937Devices "${var:Iec61937Pcms1}" Dev 6 Idx 1 }
+Macro.2.HdmiDevice { Iec61937Devices "${var:Iec61937Pcms1}" Dev 7 Idx 2 }
 
 If.HdmiIec61937 {
 	Condition {


### PR DESCRIPTION
Hi,

The PR will introduce a generic `HdmiDevice` macro, which can replace duplicated conditions in sof UCM files and potentially used by other devices to generate the needed section for the hdmi PCM devices to allow passthrough.

The PR is marked as DNM and is in draft since the change depends on Syntax 7 support, which is only available in git version of alsa-lib, it is not a simple ask for a user (or developer) to use it and the change would break UCM for released alsa-lib.

@perexg, is this something that you were suggesting? I think the macro and it's definition is generic enough, I hope that it will be usable for non SOF setups.