### PR TITLE
MOTU 828 (28x32) ucm2 configuration

### DIFF
--- a/ucm2/USB-Audio/MOTU/D828-HiFi.conf
+++ b/ucm2/USB-Audio/MOTU/D828-HiFi.conf
@@ -5,10 +5,12 @@
 #except for the two front microphone ports (each mono)
 #and the two rear optical ports (each is 8-channel ADAT)
 
-#***** Still needs to be done:  ADAT mode of optical ports (in+out, 8-channels, to surround71)
-#I have removed these ports for now
-
-
+#***** Still needs to be done*****:
+#1)  ADAT mode for banks A & B of optical ports (each bank has in + out, 8-channels).  I have removed these ports for now, as the macro only supports 2 channel parameters
+#2)  Related to the above:  a conflict switch so that optical Bank A can switch between 2-channel TOSLink and 8-channel ADAT
+#3)  Conflict switch for front microphones, to switch between 2 mono microphones or a single stereo microphone
+#4)  Surround mapping (7.1 configuration, such that channels 0,1,4,5,6,7,8,9 map to FL,FR,FC,LFE,SL,SR,RL,RR (respectively)
+#5)  Surround mixdown, such that line outs play surround, while headphones mixdown surround to stereo
 
 Include.pcm_split.File "/common/pcm/split.conf"
 
@@ -34,6 +36,7 @@ Macro [
 			HWChannelPos1 MONO
 		}
 	}
+
 	{
 		SplitPCM {
 			Name "motu828_stereo_in"
@@ -246,7 +249,7 @@ SectionDevice."Mic1" {
 }
 
 SectionDevice."Mic2" {
-	Comment "Mic / Line / Instrument In 1"
+	Comment "Mic / Line / Instrument In 2"
 
 	Value {
 		CapturePriority 190
@@ -358,7 +361,7 @@ SectionDevice."Line10" {
 
 #On the back of the MOTU 828, this is a single RCA connector, labeled "S/PDIF IN":
 
-SectionDevice."SPDIF4" {
+SectionDevice."SPDIF5" {
 	Comment "S/PDIF In (RCA)"
 
 	Value {
@@ -382,11 +385,11 @@ SectionDevice."SPDIF4" {
 #   8-channel ADAT
 #in the MOTU 828's menu
 
-SectionDevice."SPDIF5" {
+SectionDevice."SPDIF6" {
 	Comment "Optical A In (S/PDIF)"
 
 	Value {
-		CapturePriority 120
+		CapturePriority 130
 	}
 	Macro.pcm_split.SplitPCMDevice {
 		Name "motu828_stereo_in"

--- a/ucm2/USB-Audio/MOTU/D828-HiFi.conf
+++ b/ucm2/USB-Audio/MOTU/D828-HiFi.conf
@@ -1,20 +1,33 @@
-#MOTU 828 (28x32) Factory Defaults
-#This is how the MOTU 828 initially appears in its included CueMix5 software for Mac OSX and Windows
+# MOTU 828 (28x32), released in 2024, Factory Defaults
+# This is how the MOTU 828 initially appears in its included CueMix5 software for Mac OSX and Windows
 
-#All devices are stereo
-#except for the two front microphone ports (each mono)
-#and the two rear optical ports (each is 8-channel ADAT)
+# ***** Still needs to be done*****:
+# 1)  ADAT mode for banks A & B of optical ports (each in and out on each bank has 8-channels).  I have removed these ports for now, as the macro only supports 2 channel parameters
+# 2)  Related to the above:  a conflict switch so that optical Bank A can switch between 2-channel TOSLink and 8-channel ADAT
+# 3)  Surround mapping (eg. 7.1 or 5.1.2 configuration, such that channels 0,1,4,5,6,7,8,9 map to FL,FR,FC,LFE,SL,SR,RL,RR (respectively)
+# 4)  Headphone mixdown + surround, such that line outs play surround, while headphones mixdown surround to stereo
 
-#***** Still needs to be done*****:
-#1)  ADAT mode for banks A & B of optical ports (each bank has in + out, 8-channels).  I have removed these ports for now, as the macro only supports 2 channel parameters
-#2)  Related to the above:  a conflict switch so that optical Bank A can switch between 2-channel TOSLink and 8-channel ADAT
-#3)  Conflict switch for front microphones, to switch between 2 mono microphones or a single stereo microphone
-#4)  Surround mapping (7.1 configuration, such that channels 0,1,4,5,6,7,8,9 map to FL,FR,FC,LFE,SL,SR,RL,RR (respectively)
-#5)  Surround mixdown, such that line outs play surround, while headphones mixdown surround to stereo
+# Line Naming conventions:
+# Due to the number of LINE devices, to make this intuitive to follow, I have chosen to adopt a naming convention for LINES
+# Outputs are prefixed with "0"; and Inputs are prefixed with "1", followed by the physical channel number(s), which start at 1
+# Example:  Input lines 1-2 (stereo) is named "Line112"; Output lines 1-2 (stereo) is named "Line012"; Input line 1 (mono) is named "Line11"; and Output line 1 (mono) is named "Line01"
+
+# And these are ordered how I think would align to the most common usage
+# Mono microphones first, then stereo lines, then multichannel digital, followed by the alternate stereo mic and mono line options
+# In sequential order, consistent with the MOTU 828
+# (The order is reversed in this file because that's how it appears in my OS)
+
+
+
+#----------------------
+#---This section uses the referenced macro for the device configuration---:
+# While the MOTU 828 can support mono outputs, I do not foresee ever needing this in practical usage.  It can be added in the future if necessary.
+#----------------------
 
 Include.pcm_split.File "/common/pcm/split.conf"
 
 Macro [
+	
 	{
 		SplitPCM {
 			Name "motu828_stereo_out"
@@ -25,7 +38,7 @@ Macro [
 			HWChannelPos1 FR
 		}
 	}
-	
+
 	{
 		SplitPCM {
 			Name "motu828_mono_in"
@@ -36,7 +49,7 @@ Macro [
 			HWChannelPos1 MONO
 		}
 	}
-
+	
 	{
 		SplitPCM {
 			Name "motu828_stereo_in"
@@ -47,144 +60,42 @@ Macro [
 			HWChannelPos1 FR
 		}
 	}
-
 ]
 
+#-----------------------
 #---Physical Outputs---:
+#-----------------------
 
-#On the back of the MOTU 828, these are XLR connectors, labeled "MAIN OUT (A)"
-#These are controlled by the [AB ON], [A], and [B] buttons on the front of the MOTU 828
+# On the back of the MOTU 828, these are 2 optical input connectors: "OPTICAL IN A" and "OPTICAL IN B".
+# BANK A (only) can be configured as either:
+#    2-channel TOSLINK, or
+#    8-channel ADAT
+# in the MOTU 828's menu
+# Currently, only the 2-channel TOSLINK mode is supported
 
-SectionDevice."Line1" {
-	Comment "Main Out A (1-2)"
+SectionDevice."SPDIF2" {
+	Comment "[stereo] Optical Out A (TOSLink)"
 	Value {
-		PlaybackPriority 200
+		PlaybackPriority 140
 	}
 	Macro.pcm_split.SplitPCMDevice {
 		Name "motu828_stereo_out"
 		Direction Playback
 		HWChannels 32
 		Channels 2
-		Channel0 0
-		Channel1 1
+
+		Channel0 16
+		Channel1 17
+
 		ChannelPos0 FL
 		ChannelPos1 FR
 	}
 }
 
-#On the back of the MOTU 828, these are labelled "Line Out (B) 3|4" and are 1/4" connectors:
-#These are controlled by the [AB ON], [A], and [B] buttons on the front of the MOTU 828
-
-SectionDevice."Line2" {
-	Comment "Main Out B / Line Out (3-4)"
-	Value {
-		PlaybackPriority 190
-	}
-	Macro.pcm_split.SplitPCMDevice {
-		Name "motu828_stereo_out"
-		Direction Playback
-		HWChannels 32
-		Channels 2
-		Channel0 2
-		Channel1 3
-		ChannelPos0 FL
-		ChannelPos1 FR
-	}
-}
-
-#On the back of the MOTU 828, these are labelled "Line Out" and are 1/4" connectors:
-
-SectionDevice."Line3" {
-	Comment "Line Out (5-6)"
-	Value {
-		PlaybackPriority 180
-	}
-	Macro.pcm_split.SplitPCMDevice {
-		Name "motu828_stereo_out"
-		Direction Playback
-		HWChannels 32
-		Channels 2
-		Channel0 4
-		Channel1 5
-		ChannelPos0 FL
-		ChannelPos1 FR
-	}
-}
-
-SectionDevice."Line4" {
-	Comment "Line Out (7-8)"
-	Value {
-		PlaybackPriority 170
-	}
-	Macro.pcm_split.SplitPCMDevice {
-		Name "motu828_stereo_out"
-		Direction Playback
-		HWChannels 32
-		Channels 2
-		Channel0 6
-		Channel1 7
-		ChannelPos0 FL
-		ChannelPos1 FR
-	}
-}
-
-SectionDevice."Line5" {
-	Comment "Line Out (9-10)"
-	Value {
-		PlaybackPriority 160
-	}
-	Macro.pcm_split.SplitPCMDevice {
-		Name "motu828_stereo_out"
-		Direction Playback
-		HWChannels 32
-		Channels 2
-		Channel0 8
-		Channel1 9
-		ChannelPos0 FL
-		ChannelPos1 FR
-	}
-}
-
-#On the front of the MOTU 828, these are 1/4" TRS connectors:
-
-SectionDevice."Headphones1" {
-	Comment "Headphones 1"
-	Value {
-		PlaybackPriority 198
-	}
-	Macro.pcm_split.SplitPCMDevice {
-		Name "motu828_stereo_out"
-		Direction Playback
-		HWChannels 32
-		Channels 2
-		Channel0 10
-		Channel1 11
-		ChannelPos0 FL
-		ChannelPos1 FR
-	}
-}
-
-SectionDevice."Headphones2" {
-	Comment "Headphones 2"
-	Value {
-		PlaybackPriority 197
-	}
-	Macro.pcm_split.SplitPCMDevice {
-		Name "motu828_stereo_out"
-		Direction Playback
-		HWChannels 32
-		Channels 2
-		Channel0 12
-		Channel1 13
-		ChannelPos0 FL
-		ChannelPos1 FR
-	}
-}
-
-#On the back of the MOTU 828, this is a single RCA connector, labelled "S/PDIF OUT":
+#On the back of the MOTU 828, this is a single RCA connector: "S/PDIF OUT":
 
 SectionDevice."SPDIF1" {
-	Comment "S/PDIF Out (RCA)"
+	Comment "[stereo] S/PDIF Out (RCA)"
 	Value {
 		PlaybackPriority 150
 	}
@@ -200,157 +111,34 @@ SectionDevice."SPDIF1" {
 	}
 }
 
-#On the back of the MOTU 828, these are 2 optical input connectors, labeled "OPTICAL IN A" and "OPTICAL IN B".
-#BANK A (only) can be configured as either:
-#   2-channel TOSLINK, or
-#   8-channel ADAT
-#in the MOTU 828's menu
-#For now, this will only support 2-channel on Bank A
-#In the future, it will support 8-channels on Banks A & B
+#On the front of the MOTU 828, these are 1/4" TRS connectors: (Headphone icons)
 
-SectionDevice."SPDIF2" {
-	Comment "Optical Out A (S/PDIF)"
+SectionDevice."Headphones2" {
+	Comment "[stereo] Headphones 2"
 	Value {
-		PlaybackPriority 140
+		PlaybackPriority 197
 	}
 	Macro.pcm_split.SplitPCMDevice {
 		Name "motu828_stereo_out"
 		Direction Playback
 		HWChannels 32
 		Channels 2
-		
-		Channel0 16
-		Channel1 17
-		
+		Channel0 12
+		Channel1 13
 		ChannelPos0 FL
 		ChannelPos1 FR
 	}
 }
 
-#---Physical Inputs---:
-
-#On the front of the MOTU 828, these are Combo (XLR + 1/4" TRS) connectors, labeled MIC / LINE / INSTRUMENT
-#and they are paired with the "MIC INSERT" balanced 1/4" TRS connectors on the back of the MOTU 828:
-
-SectionDevice."Mic1" {
-	Comment "Mic / Line / Instrument In 1"
-
+SectionDevice."Headphones1" {
+	Comment "[stereo] Headphones 1"
 	Value {
-		CapturePriority 200
+		PlaybackPriority 198
 	}
 	Macro.pcm_split.SplitPCMDevice {
-		Name "motu828_mono_in"
-		Direction Capture
-		HWChannels 30
-		Channels 1
-		Channel0 0
-		ChannelPos0 MONO
-	}
-}
-
-SectionDevice."Mic2" {
-	Comment "Mic / Line / Instrument In 2"
-
-	Value {
-		CapturePriority 190
-	}
-	Macro.pcm_split.SplitPCMDevice {
-		Name "motu828_mono_in"
-		Direction Capture
-		HWChannels 30
-		Channels 1
-		Channel0 1
-		ChannelPos0 MONO
-	}
-}
-
-#On the back of the MOTU 828, these are labelled "LINE IN" and are balanced 1/4" TRS connectors:
-
-SectionDevice."Line6" {
-	Comment "Line In 3-4"
-	Value {
-		CapturePriority 180
-	}
-	Macro.pcm_split.SplitPCMDevice {
-		Name "motu828_stereo_in"
-		Direction Capture
-		HWChannels 30
-		Channels 2
-		Channel0 2
-		Channel1 3
-		ChannelPos0 FL
-		ChannelPos1 FR
-	}
-}
-
-SectionDevice."Line7" {
-	Comment "Line In 5-6"
-
-	Value {
-		CapturePriority 170
-	}
-	Macro.pcm_split.SplitPCMDevice {
-		Name "motu828_stereo_in"
-		Direction Capture
-		HWChannels 30
-		Channels 2
-		Channel0 4
-		Channel1 5
-		ChannelPos0 FL
-		ChannelPos1 FR
-	}
-}
-
-SectionDevice."Line8" {
-	Comment "Line In 7-8"
-
-	Value {
-		CapturePriority 160
-	}
-	Macro.pcm_split.SplitPCMDevice {
-		Name "motu828_stereo_in"
-		Direction Capture
-		HWChannels 30
-		Channels 2
-		Channel0 6
-		Channel1 7
-		ChannelPos0 FL
-		ChannelPos1 FR
-	}
-}
-
-SectionDevice."Line9" {
-	Comment "Line In 9-10"
-
-	Value {
-		CapturePriority 150
-	}
-	Macro.pcm_split.SplitPCMDevice {
-		Name "motu828_stereo_in"
-		Direction Capture
-		HWChannels 30
-		Channels 2
-		Channel0 8
-		Channel1 9
-		ChannelPos0 FL
-		ChannelPos1 FR
-	}
-}
-
-#This is an internal loopback device provided by the MOTU 828:
-#By default, it appears here, after the Line Inputs.
-#However, it can be reconfigured in the CueMix5 software to appear as the first two channels
-
-SectionDevice."Line10" {
-	Comment "Loopback"
-
-	Value {
-		CapturePriority 199
-	}
-	Macro.pcm_split.SplitPCMDevice {
-		Name "motu828_stereo_in"
-		Direction Capture
-		HWChannels 30
+		Name "motu828_stereo_out"
+		Direction Playback
+		HWChannels 32
 		Channels 2
 		Channel0 10
 		Channel1 11
@@ -359,10 +147,294 @@ SectionDevice."Line10" {
 	}
 }
 
-#On the back of the MOTU 828, this is a single RCA connector, labeled "S/PDIF IN":
+#On the back of the MOTU 828, these are 1/4" connectors: "LINE OUT"
+
+SectionDevice."Line0910" {
+	Comment "[stereo] Line Out (9-10)"
+	Value {
+		PlaybackPriority 160
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_stereo_out"
+		Direction Playback
+		HWChannels 32
+		Channels 2
+		Channel0 8
+		Channel1 9
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line078" {
+	Comment "[stereo] Line Out (7-8)"
+	Value {
+		PlaybackPriority 170
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_stereo_out"
+		Direction Playback
+		HWChannels 32
+		Channels 2
+		Channel0 6
+		Channel1 7
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line056" {
+	Comment "[stereo] Line Out (5-6)"
+	Value {
+		PlaybackPriority 180
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_stereo_out"
+		Direction Playback
+		HWChannels 32
+		Channels 2
+		Channel0 4
+		Channel1 5
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+# On the back of the MOTU 828, these are 1/4" connectors: "LINE OUT (B): 3 | 4"
+# These are controlled by the [AB ON], [A], and [B] buttons on the front of the MOTU 828
+
+SectionDevice."Line034" {
+	Comment "[stereo] Main Out B / Line Out (3-4)"
+	Value {
+		PlaybackPriority 190
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_stereo_out"
+		Direction Playback
+		HWChannels 32
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+# On the back of the MOTU 828, these are XLR connectors: "MAIN OUT (A)"
+# These are controlled by the [AB ON], [A], and [B] buttons on the front of the MOTU 828
+
+SectionDevice."Line012" {
+	Comment "[stereo] Main Out A (1-2)"
+	
+	Value {
+		PlaybackPriority 200
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_stereo_out"
+		Direction Playback
+		HWChannels 32
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+
+#----------------------
+#---Physical Inputs---:
+#----------------------
+
+# On the back of the MOTU 828, these are balanced 1/4" TRS connectors: "LINE IN"
+# These are defined as mono here; but there is a separate section with alternate stereo configuration and conflict resolution
+
+SectionDevice."Line110" {
+	Comment "[mono] Line In 10"
+
+	Value {
+		CapturePriority 145
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_mono_in"
+		Direction Capture
+		HWChannels 30
+		Channels 1
+		Channel0 9
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Line19" {
+	Comment "[mono] Line In 9"
+
+	Value {
+		CapturePriority 144
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_mono_in"
+		Direction Capture
+		HWChannels 30
+		Channels 1
+		Channel0 8
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Line18" {
+	Comment "[mono] Line In 8"
+
+	Value {
+		CapturePriority 155
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_mono_in"
+		Direction Capture
+		HWChannels 30
+		Channels 1
+		Channel0 7
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Line17" {
+	Comment "[mono] Line In 7"
+
+	Value {
+		CapturePriority 154
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_mono_in"
+		Direction Capture
+		HWChannels 30
+		Channels 1
+		Channel0 6
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Line16" {
+	Comment "[mono] Line In 6"
+
+	Value {
+		CapturePriority 165
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_mono_in"
+		Direction Capture
+		HWChannels 30
+		Channels 1
+		Channel0 5
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Line15" {
+	Comment "[mono] Line In 5"
+
+	Value {
+		CapturePriority 164
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_mono_in"
+		Direction Capture
+		HWChannels 30
+		Channels 1
+		Channel0 4
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Line14" {
+	Comment "[mono] Line In 4"
+	Value {
+		CapturePriority 174
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_mono_in"
+		Direction Capture
+		HWChannels 30
+		Channels 1
+		Channel0 3
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Line13" {
+	Comment "[mono] Line In 3"
+	Value {
+		CapturePriority 175
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_mono_in"
+		Direction Capture
+		HWChannels 30
+		Channels 1
+		Channel0 2
+		ChannelPos0 MONO
+	}
+}
+
+# On the front of the MOTU 828, these are Combo (XLR + 1/4" TRS) connectors: "MIC / LINE / INSTRUMENT"
+# and they are paired with the "MIC INSERT" balanced 1/4" TRS connectors on the back of the MOTU 828
+# These are defined as a stereo pair here; but there is a separate section with alternate mono configuration
+
+SectionDevice."Mic12" {
+	Comment "[stereo] Mic / Line / Instrument In 1-2"
+	
+	ConflictingDevice [
+		"Mic1"
+		"Mic2"
+	]
+
+	Value {
+		CapturePriority 195
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_stereo_in"
+		Direction Capture
+		HWChannels 30
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+# On the back of the MOTU 828, these are 2 optical input connectors: "OPTICAL IN A" and "OPTICAL IN B"
+# BANK A (only) can be configured as either:
+#    2-channel TOSLINK, or
+#    8-channel ADAT
+# in the MOTU 828's menu
+# Because these each use a single physical connection, there is no alternate mono definition for these
+# Currently, only the 2-channel TOSLINK mode is supported
+
+SectionDevice."SPDIF6" {
+	Comment "[stereo] Optical A In (TOSLink)"
+
+	Value {
+		CapturePriority 120
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_stereo_in"
+		Direction Capture
+		HWChannels 30
+		Channels 2
+
+		Channel0 14
+		Channel1 15
+
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+# On the back of the MOTU 828, this is a single RCA connector: "S/PDIF IN":
+# Because these each use a single physical connection, there is no alternate mono definition for these
 
 SectionDevice."SPDIF5" {
-	Comment "S/PDIF In (RCA)"
+	Comment "[stereo] S/PDIF In (RCA)"
 
 	Value {
 		CapturePriority 140
@@ -379,28 +451,156 @@ SectionDevice."SPDIF5" {
 	}
 }
 
-#On the back of the MOTU 828, these are 2 optical input connectors, labeled "OPTICAL IN A" and "OPTICAL IN B".
-#BANK A (only) can be configured as either:
-#   2-channel TOSLINK, or
-#   8-channel ADAT
-#in the MOTU 828's menu
+# This is an internal loopback device provided by the MOTU 828.  It does not have a physical external connection, other than the USB cable
+# By default, it appears here, assigned to physical channels 11-12, after the physical Line Inputs #1-10.
+# However, it can be reconfigured in the CueMix5 software (under "DEVICE" -> "Loopback Location") to appear as the first two channels (1-2), presumably shifting all other LINE channel assignments
+# Make sure it is set to "USB in 11-12 (Default)"
 
-SectionDevice."SPDIF6" {
-	Comment "Optical A In (S/PDIF)"
+SectionDevice."Line11011" {
+	Comment "[stereo] Internal Loopback"
 
 	Value {
-		CapturePriority 130
+		CapturePriority 199
 	}
 	Macro.pcm_split.SplitPCMDevice {
 		Name "motu828_stereo_in"
 		Direction Capture
 		HWChannels 30
 		Channels 2
-		
-		Channel0 14
-		Channel1 15
-		
+		Channel0 10
+		Channel1 11
 		ChannelPos0 FL
 		ChannelPos1 FR
+	}
+}
+
+# On the back of the MOTU 828, these are balanced 1/4" TRS connectors: "LINE IN"
+# These are stereo bridges; but there is a separate section with alternate mono configuration
+# Conflict resolution due to duplication of connections is handled here in the stereo devices
+
+SectionDevice."Line1910" {
+	Comment "[stereo] Line In 9-10"
+	
+	ConflictingDevice [
+		"Line19"
+		"Line110"
+	]
+
+	Value {
+		CapturePriority 150
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_stereo_in"
+		Direction Capture
+		HWChannels 30
+		Channels 2
+		Channel0 8
+		Channel1 9
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line178" {
+	Comment "[stereo] Line In 7-8"
+	
+	ConflictingDevice [
+		"Line17"
+		"Line18"
+	]
+
+	Value {
+		CapturePriority 160
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_stereo_in"
+		Direction Capture
+		HWChannels 30
+		Channels 2
+		Channel0 6
+		Channel1 7
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line156" {
+	Comment "[stereo] Line In 5-6"
+	
+	ConflictingDevice [
+		"Line15"
+		"Line16"
+	]
+
+	Value {
+		CapturePriority 170
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_stereo_in"
+		Direction Capture
+		HWChannels 30
+		Channels 2
+		Channel0 4
+		Channel1 5
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line134" {
+	Comment "[stereo] Line In 3-4"
+	
+	ConflictingDevice [
+		"Line13"
+		"Line14"
+	]
+	Value {
+		CapturePriority 180
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_stereo_in"
+		Direction Capture
+		HWChannels 30
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+# On the front of the MOTU 828, these are Combo (XLR + 1/4" TRS) connectors: "MIC / LINE / INSTRUMENT"
+# and they are paired with the "MIC INSERT" balanced 1/4" TRS connectors on the back of the MOTU 828:
+# These are defined as mono here; but there is a separate section with alternate stereo configuration and conflict resolution
+
+SectionDevice."Mic2" {
+	Comment "[mono] Mic / Line / Instrument In 2"
+
+	Value {
+		CapturePriority 190
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_mono_in"
+		Direction Capture
+		HWChannels 30
+		Channels 1
+		Channel0 1
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Mic1" {
+	Comment "[mono] Mic / Line / Instrument In 1"
+
+	Value {
+		CapturePriority 200
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_mono_in"
+		Direction Capture
+		HWChannels 30
+		Channels 1
+		Channel0 0
+		ChannelPos0 MONO
 	}
 }

--- a/ucm2/USB-Audio/MOTU/D828-HiFi.conf
+++ b/ucm2/USB-Audio/MOTU/D828-HiFi.conf
@@ -2,20 +2,10 @@
 # This is how the MOTU 828 initially appears in its included CueMix5 software for Mac OSX and Windows
 
 # ***** Still needs to be done*****:
-# 1)  ADAT mode for banks A & B of optical ports (each in and out on each bank has 8-channels).  I have removed these ports for now, as the macro only supports 2 channel parameters
-# 2)  Related to the above:  a conflict switch so that optical Bank A can switch between 2-channel TOSLink and 8-channel ADAT
-# 3)  Surround mapping (eg. 7.1 or 5.1.2 configuration, such that channels 0,1,4,5,6,7,8,9 map to FL,FR,FC,LFE,SL,SR,RL,RR (respectively)
-# 4)  Headphone mixdown + surround, such that line outs play surround, while headphones mixdown surround to stereo
-
-# Line Naming conventions:
-# Due to the number of LINE devices, to make this intuitive to follow, I have chosen to adopt a naming convention for LINES
-# Outputs are prefixed with "0"; and Inputs are prefixed with "1", followed by the physical channel number(s), which start at 1
-# Example:  Input lines 1-2 (stereo) is named "Line112"; Output lines 1-2 (stereo) is named "Line012"; Input line 1 (mono) is named "Line11"; and Output line 1 (mono) is named "Line01"
-
-# And these are ordered how I think would align to the most common usage
-# Mono microphones first, then stereo lines, then multichannel digital, followed by the alternate stereo mic and mono line options
-# In sequential order, consistent with the MOTU 828
-# (The order is reversed in this file because that's how it appears in my OS)
+# 1)  ADAT mode for banks A & B of optical ports (8ch each in + out, each bank).  Removed these for now, as the macro only supports 2 channel parameters
+# 2)  Related:  a conflict switch for optical Bank A between 2-channel TOSLink and 8-channel ADAT
+# 3)  Surround mapping (eg. 7.1 configuration, like 0,1,4,5,6,7,8,9 map to FL,FR,FC,LFE,SL,SR,RL,RR respectively
+# 4)  Headphone mixdown + surround, so line outs play surround, while headphones mixdown surround to stereo
 
 
 
@@ -66,6 +56,154 @@ Macro [
 #---Physical Outputs---:
 #-----------------------
 
+# On the back of the MOTU 828, these are XLR connectors: "MAIN OUT (A)"
+# These are controlled by the [AB ON], [A], and [B] buttons on the front of the MOTU 828
+
+SectionDevice."Line 1" {
+	Comment "[stereo] Main Out A (1-2)"
+	
+	Value {
+			PlaybackPriority 320
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_stereo_out"
+		Direction Playback
+		HWChannels 32
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+# On the back of the MOTU 828, these are 1/4" connectors: "LINE OUT (B): 3 | 4"
+# These are controlled by the [AB ON], [A], and [B] buttons on the front of the MOTU 828
+
+SectionDevice."Line 2" {
+	Comment "[stereo] Main Out B / Line Out (3-4)"
+	Value {
+		PlaybackPriority 310
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_stereo_out"
+		Direction Playback
+		HWChannels 32
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+#On the back of the MOTU 828, these are 1/4" connectors: "LINE OUT"
+
+SectionDevice."Line 3" {
+	Comment "[stereo] Line Out (5-6)"
+	Value {
+		PlaybackPriority 300
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_stereo_out"
+		Direction Playback
+		HWChannels 32
+		Channels 2
+		Channel0 4
+		Channel1 5
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line 4" {
+	Comment "[stereo] Line Out (7-8)"
+	Value {
+		PlaybackPriority 290
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_stereo_out"
+		Direction Playback
+		HWChannels 32
+		Channels 2
+		Channel0 6
+		Channel1 7
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line 5" {
+	Comment "[stereo] Line Out (9-10)"
+	Value {
+		PlaybackPriority 280
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_stereo_out"
+		Direction Playback
+		HWChannels 32
+		Channels 2
+		Channel0 8
+		Channel1 9
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+#On the front of the MOTU 828, these are 1/4" TRS connectors: (Headphone icons)
+
+SectionDevice."Headphones 1" {
+	Comment "[stereo] Headphones (1)"
+	Value {
+		PlaybackPriority 270
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_stereo_out"
+		Direction Playback
+		HWChannels 32
+		Channels 2
+		Channel0 10
+		Channel1 11
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+SectionDevice."Headphones 2" {
+	Comment "[stereo] Headphones (2)"
+	Value {
+		PlaybackPriority 260
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_stereo_out"
+		Direction Playback
+		HWChannels 32
+		Channels 2
+		Channel0 12
+		Channel1 13
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+#On the back of the MOTU 828, this is a single RCA connector: "S/PDIF OUT":
+
+SectionDevice."SPDIF 1" {
+	Comment "[stereo] S/PDIF Out (RCA)"
+	Value {
+		PlaybackPriority 250
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_stereo_out"
+		Direction Playback
+		HWChannels 32
+		Channels 2
+		Channel0 14
+		Channel1 15
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
 # On the back of the MOTU 828, these are 2 optical input connectors: "OPTICAL IN A" and "OPTICAL IN B".
 # BANK A (only) can be configured as either:
 #    2-channel TOSLINK, or
@@ -73,10 +211,10 @@ Macro [
 # in the MOTU 828's menu
 # Currently, only the 2-channel TOSLINK mode is supported
 
-SectionDevice."SPDIF2" {
+SectionDevice."SPDIF 2" {
 	Comment "[stereo] Optical Out A (TOSLink)"
 	Value {
-		PlaybackPriority 140
+		PlaybackPriority 240
 	}
 	Macro.pcm_split.SplitPCMDevice {
 		Name "motu828_stereo_out"
@@ -92,126 +230,64 @@ SectionDevice."SPDIF2" {
 	}
 }
 
-#On the back of the MOTU 828, this is a single RCA connector: "S/PDIF OUT":
+#----------------------
+#---Physical Inputs---:
+#----------------------
 
-SectionDevice."SPDIF1" {
-	Comment "[stereo] S/PDIF Out (RCA)"
+# On the front of the MOTU 828, these are Combo (XLR + 1/4" TRS) connectors: "MIC / LINE / INSTRUMENT"
+# and they are paired with the "MIC INSERT" balanced 1/4" TRS connectors on the back of the MOTU 828:
+# These are defined as mono here; but there is a separate section with alternate stereo configuration and conflict resolution
+
+SectionDevice."Mic 1" {
+	Comment "[mono] Mic / Line / Instrument In (1)"
+
 	Value {
-		PlaybackPriority 150
+		CapturePriority 300
 	}
 	Macro.pcm_split.SplitPCMDevice {
-		Name "motu828_stereo_out"
-		Direction Playback
-		HWChannels 32
-		Channels 2
-		Channel0 14
-		Channel1 15
-		ChannelPos0 FL
-		ChannelPos1 FR
+		Name "motu828_mono_in"
+		Direction Capture
+		HWChannels 30
+		Channels 1
+		Channel0 0
+		ChannelPos0 MONO
 	}
 }
 
-#On the front of the MOTU 828, these are 1/4" TRS connectors: (Headphone icons)
+SectionDevice."Mic 2" {
+	Comment "[mono] Mic / Line / Instrument In (2)"
 
-SectionDevice."Headphones2" {
-	Comment "[stereo] Headphones 2"
 	Value {
-		PlaybackPriority 197
+		CapturePriority 290
 	}
 	Macro.pcm_split.SplitPCMDevice {
-		Name "motu828_stereo_out"
-		Direction Playback
-		HWChannels 32
-		Channels 2
-		Channel0 12
-		Channel1 13
-		ChannelPos0 FL
-		ChannelPos1 FR
+		Name "motu828_mono_in"
+		Direction Capture
+		HWChannels 30
+		Channels 1
+		Channel0 1
+		ChannelPos0 MONO
 	}
 }
 
-SectionDevice."Headphones1" {
-	Comment "[stereo] Headphones 1"
+# On the back of the MOTU 828, these are balanced 1/4" TRS connectors: "LINE IN"
+# These are stereo bridges; but there is a separate section with alternate mono configuration
+# Conflict resolution due to duplication of connections is handled here in the stereo devices
+
+SectionDevice."Line 6" {
+	Comment "[stereo] Line In (3-4)"
+	
+	ConflictingDevice [
+		"Line13"
+		"Line14"
+	]
 	Value {
-		PlaybackPriority 198
+		CapturePriority 280
 	}
 	Macro.pcm_split.SplitPCMDevice {
-		Name "motu828_stereo_out"
-		Direction Playback
-		HWChannels 32
-		Channels 2
-		Channel0 10
-		Channel1 11
-		ChannelPos0 FL
-		ChannelPos1 FR
-	}
-}
-
-#On the back of the MOTU 828, these are 1/4" connectors: "LINE OUT"
-
-SectionDevice."Line0910" {
-	Comment "[stereo] Line Out (9-10)"
-	Value {
-		PlaybackPriority 160
-	}
-	Macro.pcm_split.SplitPCMDevice {
-		Name "motu828_stereo_out"
-		Direction Playback
-		HWChannels 32
-		Channels 2
-		Channel0 8
-		Channel1 9
-		ChannelPos0 FL
-		ChannelPos1 FR
-	}
-}
-
-SectionDevice."Line078" {
-	Comment "[stereo] Line Out (7-8)"
-	Value {
-		PlaybackPriority 170
-	}
-	Macro.pcm_split.SplitPCMDevice {
-		Name "motu828_stereo_out"
-		Direction Playback
-		HWChannels 32
-		Channels 2
-		Channel0 6
-		Channel1 7
-		ChannelPos0 FL
-		ChannelPos1 FR
-	}
-}
-
-SectionDevice."Line056" {
-	Comment "[stereo] Line Out (5-6)"
-	Value {
-		PlaybackPriority 180
-	}
-	Macro.pcm_split.SplitPCMDevice {
-		Name "motu828_stereo_out"
-		Direction Playback
-		HWChannels 32
-		Channels 2
-		Channel0 4
-		Channel1 5
-		ChannelPos0 FL
-		ChannelPos1 FR
-	}
-}
-
-# On the back of the MOTU 828, these are 1/4" connectors: "LINE OUT (B): 3 | 4"
-# These are controlled by the [AB ON], [A], and [B] buttons on the front of the MOTU 828
-
-SectionDevice."Line034" {
-	Comment "[stereo] Main Out B / Line Out (3-4)"
-	Value {
-		PlaybackPriority 190
-	}
-	Macro.pcm_split.SplitPCMDevice {
-		Name "motu828_stereo_out"
-		Direction Playback
-		HWChannels 32
+		Name "motu828_stereo_in"
+		Direction Capture
+		HWChannels 30
 		Channels 2
 		Channel0 2
 		Channel1 3
@@ -220,183 +296,114 @@ SectionDevice."Line034" {
 	}
 }
 
-# On the back of the MOTU 828, these are XLR connectors: "MAIN OUT (A)"
-# These are controlled by the [AB ON], [A], and [B] buttons on the front of the MOTU 828
-
-SectionDevice."Line012" {
-	Comment "[stereo] Main Out A (1-2)"
-	
-	Value {
-		PlaybackPriority 200
-	}
-	Macro.pcm_split.SplitPCMDevice {
-		Name "motu828_stereo_out"
-		Direction Playback
-		HWChannels 32
-		Channels 2
-		Channel0 0
-		Channel1 1
-		ChannelPos0 FL
-		ChannelPos1 FR
-	}
-}
-
-
-#----------------------
-#---Physical Inputs---:
-#----------------------
-
-# On the back of the MOTU 828, these are balanced 1/4" TRS connectors: "LINE IN"
-# These are defined as mono here; but there is a separate section with alternate stereo configuration and conflict resolution
-
-SectionDevice."Line110" {
-	Comment "[mono] Line In 10"
-
-	Value {
-		CapturePriority 145
-	}
-	Macro.pcm_split.SplitPCMDevice {
-		Name "motu828_mono_in"
-		Direction Capture
-		HWChannels 30
-		Channels 1
-		Channel0 9
-		ChannelPos0 MONO
-	}
-}
-
-SectionDevice."Line19" {
-	Comment "[mono] Line In 9"
-
-	Value {
-		CapturePriority 144
-	}
-	Macro.pcm_split.SplitPCMDevice {
-		Name "motu828_mono_in"
-		Direction Capture
-		HWChannels 30
-		Channels 1
-		Channel0 8
-		ChannelPos0 MONO
-	}
-}
-
-SectionDevice."Line18" {
-	Comment "[mono] Line In 8"
-
-	Value {
-		CapturePriority 155
-	}
-	Macro.pcm_split.SplitPCMDevice {
-		Name "motu828_mono_in"
-		Direction Capture
-		HWChannels 30
-		Channels 1
-		Channel0 7
-		ChannelPos0 MONO
-	}
-}
-
-SectionDevice."Line17" {
-	Comment "[mono] Line In 7"
-
-	Value {
-		CapturePriority 154
-	}
-	Macro.pcm_split.SplitPCMDevice {
-		Name "motu828_mono_in"
-		Direction Capture
-		HWChannels 30
-		Channels 1
-		Channel0 6
-		ChannelPos0 MONO
-	}
-}
-
-SectionDevice."Line16" {
-	Comment "[mono] Line In 6"
-
-	Value {
-		CapturePriority 165
-	}
-	Macro.pcm_split.SplitPCMDevice {
-		Name "motu828_mono_in"
-		Direction Capture
-		HWChannels 30
-		Channels 1
-		Channel0 5
-		ChannelPos0 MONO
-	}
-}
-
-SectionDevice."Line15" {
-	Comment "[mono] Line In 5"
-
-	Value {
-		CapturePriority 164
-	}
-	Macro.pcm_split.SplitPCMDevice {
-		Name "motu828_mono_in"
-		Direction Capture
-		HWChannels 30
-		Channels 1
-		Channel0 4
-		ChannelPos0 MONO
-	}
-}
-
-SectionDevice."Line14" {
-	Comment "[mono] Line In 4"
-	Value {
-		CapturePriority 174
-	}
-	Macro.pcm_split.SplitPCMDevice {
-		Name "motu828_mono_in"
-		Direction Capture
-		HWChannels 30
-		Channels 1
-		Channel0 3
-		ChannelPos0 MONO
-	}
-}
-
-SectionDevice."Line13" {
-	Comment "[mono] Line In 3"
-	Value {
-		CapturePriority 175
-	}
-	Macro.pcm_split.SplitPCMDevice {
-		Name "motu828_mono_in"
-		Direction Capture
-		HWChannels 30
-		Channels 1
-		Channel0 2
-		ChannelPos0 MONO
-	}
-}
-
-# On the front of the MOTU 828, these are Combo (XLR + 1/4" TRS) connectors: "MIC / LINE / INSTRUMENT"
-# and they are paired with the "MIC INSERT" balanced 1/4" TRS connectors on the back of the MOTU 828
-# These are defined as a stereo pair here; but there is a separate section with alternate mono configuration
-
-SectionDevice."Mic12" {
-	Comment "[stereo] Mic / Line / Instrument In 1-2"
+SectionDevice."Line 7" {
+	Comment "[stereo] Line In (5-6)"
 	
 	ConflictingDevice [
-		"Mic1"
-		"Mic2"
+		"Line15"
+		"Line16"
 	]
 
 	Value {
-		CapturePriority 195
+		CapturePriority 270
 	}
 	Macro.pcm_split.SplitPCMDevice {
 		Name "motu828_stereo_in"
 		Direction Capture
 		HWChannels 30
 		Channels 2
-		Channel0 0
-		Channel1 1
+		Channel0 4
+		Channel1 5
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line 8" {
+	Comment "[stereo] Line In (7-8)"
+	
+	ConflictingDevice [
+		"Line17"
+		"Line18"
+	]
+
+	Value {
+		CapturePriority 260
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_stereo_in"
+		Direction Capture
+		HWChannels 30
+		Channels 2
+		Channel0 6
+		Channel1 7
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line 9" {
+	Comment "[stereo] Line In (9-10)"
+	
+	ConflictingDevice [
+		"Line19"
+		"Line110"
+	]
+
+	Value {
+		CapturePriority 250
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_stereo_in"
+		Direction Capture
+		HWChannels 30
+		Channels 2
+		Channel0 8
+		Channel1 9
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+# This is an internal loopback device provided by the MOTU 828.  It does not have a physical external connection, other than the USB cable
+# By default, it appears here, assigned to physical channels 11-12, after the physical Line Inputs #1-10.
+# However, it can be reconfigured in the CueMix5 software (under "DEVICE" -> "Loopback Location") to appear as the first two channels (1-2), presumably shifting all other LINE channel assignments
+# Make sure it is set to "USB in 11-12 (Default)"
+
+SectionDevice."Line 10" {
+	Comment "[stereo] Internal Loopback"
+
+	Value {
+		CapturePriority 240
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_stereo_in"
+		Direction Capture
+		HWChannels 30
+		Channels 2
+		Channel0 10
+		Channel1 11
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+# On the back of the MOTU 828, this is a single RCA connector: "S/PDIF IN":
+# Because these each use a single physical connection, there is no alternate mono definition for these
+
+SectionDevice."SPDIF 3" {
+	Comment "[stereo] S/PDIF In (RCA)"
+
+	Value {
+		CapturePriority 230
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_stereo_in"
+		Direction Capture
+		HWChannels 30
+		Channels 2
+		Channel0 12
+		Channel1 13
 		ChannelPos0 FL
 		ChannelPos1 FR
 	}
@@ -410,11 +417,11 @@ SectionDevice."Mic12" {
 # Because these each use a single physical connection, there is no alternate mono definition for these
 # Currently, only the 2-channel TOSLINK mode is supported
 
-SectionDevice."SPDIF6" {
+SectionDevice."SPDIF 4" {
 	Comment "[stereo] Optical A In (TOSLink)"
 
 	Value {
-		CapturePriority 120
+		CapturePriority 220
 	}
 	Macro.pcm_split.SplitPCMDevice {
 		Name "motu828_stereo_in"
@@ -430,34 +437,17 @@ SectionDevice."SPDIF6" {
 	}
 }
 
-# On the back of the MOTU 828, this is a single RCA connector: "S/PDIF IN":
-# Because these each use a single physical connection, there is no alternate mono definition for these
+# On the front of the MOTU 828, these are Combo (XLR + 1/4" TRS) connectors: "MIC / LINE / INSTRUMENT"
+# and they are paired with the "MIC INSERT" balanced 1/4" TRS connectors on the back of the MOTU 828
+# These are defined as a stereo pair here; but there is a separate section with alternate mono configuration
 
-SectionDevice."SPDIF5" {
-	Comment "[stereo] S/PDIF In (RCA)"
-
-	Value {
-		CapturePriority 140
-	}
-	Macro.pcm_split.SplitPCMDevice {
-		Name "motu828_stereo_in"
-		Direction Capture
-		HWChannels 30
-		Channels 2
-		Channel0 12
-		Channel1 13
-		ChannelPos0 FL
-		ChannelPos1 FR
-	}
-}
-
-# This is an internal loopback device provided by the MOTU 828.  It does not have a physical external connection, other than the USB cable
-# By default, it appears here, assigned to physical channels 11-12, after the physical Line Inputs #1-10.
-# However, it can be reconfigured in the CueMix5 software (under "DEVICE" -> "Loopback Location") to appear as the first two channels (1-2), presumably shifting all other LINE channel assignments
-# Make sure it is set to "USB in 11-12 (Default)"
-
-SectionDevice."Line11011" {
-	Comment "[stereo] Internal Loopback"
+SectionDevice."Mic 3" {
+	Comment "[stereo] Mic / Line / Instrument In (1-2)"
+	
+	ConflictingDevice [
+		"Mic1"
+		"Mic2"
+	]
 
 	Value {
 		CapturePriority 199
@@ -467,140 +457,138 @@ SectionDevice."Line11011" {
 		Direction Capture
 		HWChannels 30
 		Channels 2
-		Channel0 10
-		Channel1 11
+		Channel0 0
+		Channel1 1
 		ChannelPos0 FL
 		ChannelPos1 FR
 	}
 }
 
 # On the back of the MOTU 828, these are balanced 1/4" TRS connectors: "LINE IN"
-# These are stereo bridges; but there is a separate section with alternate mono configuration
-# Conflict resolution due to duplication of connections is handled here in the stereo devices
-
-SectionDevice."Line1910" {
-	Comment "[stereo] Line In 9-10"
-	
-	ConflictingDevice [
-		"Line19"
-		"Line110"
-	]
-
-	Value {
-		CapturePriority 150
-	}
-	Macro.pcm_split.SplitPCMDevice {
-		Name "motu828_stereo_in"
-		Direction Capture
-		HWChannels 30
-		Channels 2
-		Channel0 8
-		Channel1 9
-		ChannelPos0 FL
-		ChannelPos1 FR
-	}
-}
-
-SectionDevice."Line178" {
-	Comment "[stereo] Line In 7-8"
-	
-	ConflictingDevice [
-		"Line17"
-		"Line18"
-	]
-
-	Value {
-		CapturePriority 160
-	}
-	Macro.pcm_split.SplitPCMDevice {
-		Name "motu828_stereo_in"
-		Direction Capture
-		HWChannels 30
-		Channels 2
-		Channel0 6
-		Channel1 7
-		ChannelPos0 FL
-		ChannelPos1 FR
-	}
-}
-
-SectionDevice."Line156" {
-	Comment "[stereo] Line In 5-6"
-	
-	ConflictingDevice [
-		"Line15"
-		"Line16"
-	]
-
-	Value {
-		CapturePriority 170
-	}
-	Macro.pcm_split.SplitPCMDevice {
-		Name "motu828_stereo_in"
-		Direction Capture
-		HWChannels 30
-		Channels 2
-		Channel0 4
-		Channel1 5
-		ChannelPos0 FL
-		ChannelPos1 FR
-	}
-}
-
-SectionDevice."Line134" {
-	Comment "[stereo] Line In 3-4"
-	
-	ConflictingDevice [
-		"Line13"
-		"Line14"
-	]
-	Value {
-		CapturePriority 180
-	}
-	Macro.pcm_split.SplitPCMDevice {
-		Name "motu828_stereo_in"
-		Direction Capture
-		HWChannels 30
-		Channels 2
-		Channel0 2
-		Channel1 3
-		ChannelPos0 FL
-		ChannelPos1 FR
-	}
-}
-
-# On the front of the MOTU 828, these are Combo (XLR + 1/4" TRS) connectors: "MIC / LINE / INSTRUMENT"
-# and they are paired with the "MIC INSERT" balanced 1/4" TRS connectors on the back of the MOTU 828:
 # These are defined as mono here; but there is a separate section with alternate stereo configuration and conflict resolution
 
-SectionDevice."Mic2" {
-	Comment "[mono] Mic / Line / Instrument In 2"
-
+SectionDevice."Line 11" {
+	Comment "[mono] Line In (3)"
 	Value {
-		CapturePriority 190
+		CapturePriority 198
 	}
 	Macro.pcm_split.SplitPCMDevice {
 		Name "motu828_mono_in"
 		Direction Capture
 		HWChannels 30
 		Channels 1
-		Channel0 1
+		Channel0 2
 		ChannelPos0 MONO
 	}
 }
 
-SectionDevice."Mic1" {
-	Comment "[mono] Mic / Line / Instrument In 1"
-
+SectionDevice."Line 12" {
+	Comment "[mono] Line In (4)"
 	Value {
-		CapturePriority 200
+		CapturePriority 197
 	}
 	Macro.pcm_split.SplitPCMDevice {
 		Name "motu828_mono_in"
 		Direction Capture
 		HWChannels 30
 		Channels 1
-		Channel0 0
+		Channel0 3
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Line 13" {
+	Comment "[mono] Line In (5)"
+
+	Value {
+		CapturePriority 196
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_mono_in"
+		Direction Capture
+		HWChannels 30
+		Channels 1
+		Channel0 4
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Line 14" {
+	Comment "[mono] Line In (6)"
+
+	Value {
+		CapturePriority 195
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_mono_in"
+		Direction Capture
+		HWChannels 30
+		Channels 1
+		Channel0 5
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Line 15" {
+	Comment "[mono] Line In (7)"
+
+	Value {
+		CapturePriority 194
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_mono_in"
+		Direction Capture
+		HWChannels 30
+		Channels 1
+		Channel0 6
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Line 16" {
+	Comment "[mono] Line In (8)"
+
+	Value {
+		CapturePriority 193
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_mono_in"
+		Direction Capture
+		HWChannels 30
+		Channels 1
+		Channel0 7
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Line 17" {
+	Comment "[mono] Line In (9)"
+
+	Value {
+		CapturePriority 192
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_mono_in"
+		Direction Capture
+		HWChannels 30
+		Channels 1
+		Channel0 8
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Line 18" {
+	Comment "[mono] Line In (10)"
+
+	Value {
+		CapturePriority 191
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_mono_in"
+		Direction Capture
+		HWChannels 30
+		Channels 1
+		Channel0 9
 		ChannelPos0 MONO
 	}
 }

--- a/ucm2/USB-Audio/MOTU/D828-HiFi.conf
+++ b/ucm2/USB-Audio/MOTU/D828-HiFi.conf
@@ -1,0 +1,518 @@
+#MOTU 828 (28x32) Factory Defaults
+#This is how the MOTU 828 initially appears in its included CueMix5 software for Mac OSX and Windows
+
+#All devices are stereo
+#except for the two front microphone ports (each mono)
+#and the two rear optical ports (each is 8-channel ADAT)
+
+
+
+Include.pcm_split.File "/common/pcm/split.conf"
+
+Macro [
+	{
+		SplitPCM {
+			Name "motu828_stereo_out"
+			Direction Playback
+			Channels 2
+			HWChannels 32
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+		}
+	}
+	
+	{
+		SplitPCM {
+			Name "motu_71_out"
+			Direction Playback
+			Channels 8
+			HWChannels 32
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 C
+			HWChannelPos3 LFE
+			HWChannelPos4 SL
+			HWChannelPos5 SR
+			HWChannelPos6 RL
+			HWChannelPos7 RR
+		}
+	}
+	
+	{
+		SplitPCM {
+			Name "motu828_mono_in"
+			Direction Capture
+			Channels 1
+			HWChannels 30
+			HWChannelPos0 MONO
+			HWChannelPos1 MONO
+		}
+	}
+	{
+		SplitPCM {
+			Name "motu_stereo_in"
+			Direction Capture
+			Channels 2
+			HWChannels 30
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+		}
+	}
+
+	{
+		SplitPCM {
+			Name "motu_71_in"
+			Direction Capture
+			Channels 8
+			HWChannels 30
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 C
+			HWChannelPos3 LFE
+			HWChannelPos4 SL
+			HWChannelPos5 SR
+			HWChannelPos6 RL
+			HWChannelPos7 RR
+		}
+	}
+]
+
+#---Physical Outputs---:
+
+#On the back of the MOTU 828, these are XLR connectors, labeled "MAIN OUT (A)"
+#These are controlled by the [AB ON], [A], and [B] buttons on the front of the MOTU 828
+
+SectionDevice."Line1" {
+	Comment "Main Out A (1-2)"
+	Value {
+		PlaybackPriority 200
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_stereo_out"
+		Direction Playback
+		HWChannels 32
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+#On the back of the MOTU 828, these are labelled "Line Out (B) 3|4" and are 1/4" connectors:
+#These are controlled by the [AB ON], [A], and [B] buttons on the front of the MOTU 828
+
+SectionDevice."Line2" {
+	Comment "Main Out B / Line Out (3-4)"
+	Value {
+		PlaybackPriority 190
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_stereo_out"
+		Direction Playback
+		HWChannels 32
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+#On the back of the MOTU 828, these are labelled "Line Out" and are 1/4" connectors:
+
+SectionDevice."Line3" {
+	Comment "Line Out (5-6)"
+	Value {
+		PlaybackPriority 180
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_stereo_out"
+		Direction Playback
+		HWChannels 32
+		Channels 2
+		Channel0 4
+		Channel1 5
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line4" {
+	Comment "Line Out (7-8)"
+	Value {
+		PlaybackPriority 170
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_stereo_out"
+		Direction Playback
+		HWChannels 32
+		Channels 2
+		Channel0 6
+		Channel1 7
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line5" {
+	Comment "Line Out (9-10)"
+	Value {
+		PlaybackPriority 160
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_stereo_out"
+		Direction Playback
+		HWChannels 32
+		Channels 2
+		Channel0 8
+		Channel1 9
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+#On the front of the MOTU 828, these are 1/4" TRS connectors:
+
+SectionDevice."Headphones1" {
+	Comment "Headphones 1"
+	Value {
+		PlaybackPriority 198
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_stereo_out"
+		Direction Playback
+		HWChannels 32
+		Channels 2
+		Channel0 10
+		Channel1 11
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Headphones2" {
+	Comment "Headphones 2"
+	Value {
+		PlaybackPriority 197
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_stereo_out"
+		Direction Playback
+		HWChannels 32
+		Channels 2
+		Channel0 12
+		Channel1 13
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+#On the back of the MOTU 828, this is a single RCA connector, labelled "S/PDIF OUT":
+
+SectionDevice."SPDIF1" {
+	Comment "S/PDIF Out (RCA)"
+	Value {
+		PlaybackPriority 150
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_stereo_out"
+		Direction Playback
+		HWChannels 32
+		Channels 2
+		Channel0 14
+		Channel1 15
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+#On the back of the MOTU 828, these are 2 optical input connectors, labeled "OPTICAL IN A" and "OPTICAL IN B".
+#BANK A (only) can be configured as either:
+#   2-channel TOSLINK, or
+#   8-channel ADAT
+#in the MOTU 828's menu
+
+SectionDevice."SPDIF2" {
+	Comment "Optical Out A"
+	Value {
+		PlaybackPriority 140
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_71_out"
+		Direction Playback
+		HWChannels 32
+		Channels 8
+		
+		Channel0 16
+		Channel1 17
+		Channel0 18
+		Channel1 19
+		Channel2 20
+		Channel3 21
+		Channel4 22
+		Channel5 23
+		
+		ChannelPos0 FL
+		ChannelPos1 FR
+		ChannelPos0 C
+		ChannelPos1 LFE
+		ChannelPos0 SL
+		ChannelPos1 SR
+		ChannelPos0 RL
+		ChannelPos1 RR
+	}
+}
+
+SectionDevice."SPDIF3" {
+	Comment "Optical Out B"
+	Value {
+		PlaybackPriority 130
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_71_out"
+		Direction Playback
+		HWChannels 32
+		Channels 8
+		
+		Channel0 24
+		Channel1 25
+		Channel0 26
+		Channel1 27
+		Channel2 28
+		Channel3 29
+		Channel4 30
+		Channel5 31
+		
+		ChannelPos0 FL
+		ChannelPos1 FR
+		ChannelPos0 C
+		ChannelPos1 LFE
+		ChannelPos0 SL
+		ChannelPos1 SR
+		ChannelPos0 RL
+		ChannelPos1 RR
+	}
+}
+
+#---Physical Inputs---:
+
+#On the front of the MOTU 828, these are Combo (XLR + 1/4" TRS) connectors, labeled MIC / LINE / INSTRUMENT
+#and they are paired with the "MIC INSERT" balanced 1/4" TRS connectors on the back of the MOTU 828:
+
+SectionDevice."Mic1" {
+	Comment "Mic / Line / Instrument In 1"
+
+	Value {
+		CapturePriority 200
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_mono_in"
+		Direction Capture
+		HWChannels 30
+		Channels 1
+		Channel0 0
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Mic2" {
+	Comment "Mic / Line / Instrument In 1"
+
+	Value {
+		CapturePriority 190
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_mono_in"
+		Direction Capture
+		HWChannels 30
+		Channels 1
+		Channel0 1
+		ChannelPos0 MONO
+	}
+}
+
+#On the back of the MOTU 828, these are labelled "LINE IN" and are balanced 1/4" TRS connectors:
+
+SectionDevice."Line6" {
+	Comment "Line In 3-4"
+	Value {
+		CapturePriority 180
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_stereo_in"
+		Direction Capture
+		HWChannels 30
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line7" {
+	Comment "Line In 5-6"
+
+	Value {
+		CapturePriority 170
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_stereo_in"
+		Direction Capture
+		HWChannels 30
+		Channels 2
+		Channel0 4
+		Channel1 5
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line8" {
+	Comment "Line In 7-8"
+
+	Value {
+		CapturePriority 160
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_stereo_in"
+		Direction Capture
+		HWChannels 30
+		Channels 2
+		Channel0 6
+		Channel1 7
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line9" {
+	Comment "Line In 9-10"
+
+	Value {
+		CapturePriority 150
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_stereo_in"
+		Direction Capture
+		HWChannels 30
+		Channels 2
+		Channel0 8
+		Channel1 9
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+#This is an internal loopback device provided by the MOTU 828:
+#By default, it appears here, after the Line Inputs.
+#However, it can be reconfigured in the CueMix5 software to appear as the first two channels
+
+SectionDevice."Line10" {
+	Comment "Loopback"
+
+	Value {
+		CapturePriority 199
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_stereo_in"
+		Direction Capture
+		HWChannels 30
+		Channels 2
+		Channel0 10
+		Channel1 11
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+#On the back of the MOTU 828, this is a single RCA connector, labeled "S/PDIF IN":
+
+SectionDevice."SPDIF4" {
+	Comment "S/PDIF In (RCA)"
+
+	Value {
+		CapturePriority 140
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_stereo_in"
+		Direction Capture
+		HWChannels 30
+		Channels 2
+		Channel0 12
+		Channel1 13
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+#On the back of the MOTU 828, these are 2 optical input connectors, labeled "OPTICAL IN A" and "OPTICAL IN B".
+#BANK A (only) can be configured as either:
+#   2-channel TOSLINK, or
+#   8-channel ADAT
+#in the MOTU 828's menu
+
+SectionDevice."SPDIF5" {
+	Comment "Optical A In"
+
+	Value {
+		CapturePriority 120
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_71_in"
+		Direction Capture
+		HWChannels 30
+		Channels 8
+		
+		Channel0 14
+		Channel1 15
+		Channel2 16
+		Channel3 17
+		Channel4 18
+		Channel5 19
+		Channel6 20
+		Channel7 21
+		
+		ChannelPos0 FL
+		ChannelPos1 FR
+		ChannelPos0 C
+		ChannelPos1 LFE
+		ChannelPos0 SL
+		ChannelPos1 SR
+		ChannelPos0 RL
+		ChannelPos1 RR
+	}
+}
+
+SectionDevice."SPDIF6" {
+	Comment "Optical B In"
+
+	Value {
+		CapturePriority 110
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "motu828_71_in"
+		Direction Capture
+		HWChannels 30
+		Channels 8
+		
+		Channel0 22
+		Channel1 23
+		Channel2 24
+		Channel3 25
+		Channel4 26
+		Channel5 27
+		Channel6 28
+		Channel7 29
+		
+		ChannelPos0 FL
+		ChannelPos1 FR
+		ChannelPos0 C
+		ChannelPos1 LFE
+		ChannelPos0 SL
+		ChannelPos1 SR
+		ChannelPos0 RL
+		ChannelPos1 RR
+	}
+}

--- a/ucm2/USB-Audio/MOTU/D828-HiFi.conf
+++ b/ucm2/USB-Audio/MOTU/D828-HiFi.conf
@@ -5,6 +5,9 @@
 #except for the two front microphone ports (each mono)
 #and the two rear optical ports (each is 8-channel ADAT)
 
+#***** Still needs to be done:  ADAT mode of optical ports (in+out, 8-channels, to surround71)
+#I have removed these ports for now
+
 
 
 Include.pcm_split.File "/common/pcm/split.conf"
@@ -23,23 +26,6 @@ Macro [
 	
 	{
 		SplitPCM {
-			Name "motu_71_out"
-			Direction Playback
-			Channels 8
-			HWChannels 32
-			HWChannelPos0 FL
-			HWChannelPos1 FR
-			HWChannelPos2 C
-			HWChannelPos3 LFE
-			HWChannelPos4 SL
-			HWChannelPos5 SR
-			HWChannelPos6 RL
-			HWChannelPos7 RR
-		}
-	}
-	
-	{
-		SplitPCM {
 			Name "motu828_mono_in"
 			Direction Capture
 			Channels 1
@@ -50,7 +36,7 @@ Macro [
 	}
 	{
 		SplitPCM {
-			Name "motu_stereo_in"
+			Name "motu828_stereo_in"
 			Direction Capture
 			Channels 2
 			HWChannels 30
@@ -59,22 +45,6 @@ Macro [
 		}
 	}
 
-	{
-		SplitPCM {
-			Name "motu_71_in"
-			Direction Capture
-			Channels 8
-			HWChannels 30
-			HWChannelPos0 FL
-			HWChannelPos1 FR
-			HWChannelPos2 C
-			HWChannelPos3 LFE
-			HWChannelPos4 SL
-			HWChannelPos5 SR
-			HWChannelPos6 RL
-			HWChannelPos7 RR
-		}
-	}
 ]
 
 #---Physical Outputs---:
@@ -232,66 +202,25 @@ SectionDevice."SPDIF1" {
 #   2-channel TOSLINK, or
 #   8-channel ADAT
 #in the MOTU 828's menu
+#For now, this will only support 2-channel on Bank A
+#In the future, it will support 8-channels on Banks A & B
 
 SectionDevice."SPDIF2" {
-	Comment "Optical Out A"
+	Comment "Optical Out A (S/PDIF)"
 	Value {
 		PlaybackPriority 140
 	}
 	Macro.pcm_split.SplitPCMDevice {
-		Name "motu828_71_out"
+		Name "motu828_stereo_out"
 		Direction Playback
 		HWChannels 32
-		Channels 8
+		Channels 2
 		
 		Channel0 16
 		Channel1 17
-		Channel0 18
-		Channel1 19
-		Channel2 20
-		Channel3 21
-		Channel4 22
-		Channel5 23
 		
 		ChannelPos0 FL
 		ChannelPos1 FR
-		ChannelPos0 C
-		ChannelPos1 LFE
-		ChannelPos0 SL
-		ChannelPos1 SR
-		ChannelPos0 RL
-		ChannelPos1 RR
-	}
-}
-
-SectionDevice."SPDIF3" {
-	Comment "Optical Out B"
-	Value {
-		PlaybackPriority 130
-	}
-	Macro.pcm_split.SplitPCMDevice {
-		Name "motu828_71_out"
-		Direction Playback
-		HWChannels 32
-		Channels 8
-		
-		Channel0 24
-		Channel1 25
-		Channel0 26
-		Channel1 27
-		Channel2 28
-		Channel3 29
-		Channel4 30
-		Channel5 31
-		
-		ChannelPos0 FL
-		ChannelPos1 FR
-		ChannelPos0 C
-		ChannelPos1 LFE
-		ChannelPos0 SL
-		ChannelPos1 SR
-		ChannelPos0 RL
-		ChannelPos1 RR
 	}
 }
 
@@ -454,65 +383,21 @@ SectionDevice."SPDIF4" {
 #in the MOTU 828's menu
 
 SectionDevice."SPDIF5" {
-	Comment "Optical A In"
+	Comment "Optical A In (S/PDIF)"
 
 	Value {
 		CapturePriority 120
 	}
 	Macro.pcm_split.SplitPCMDevice {
-		Name "motu828_71_in"
+		Name "motu828_stereo_in"
 		Direction Capture
 		HWChannels 30
-		Channels 8
+		Channels 2
 		
 		Channel0 14
 		Channel1 15
-		Channel2 16
-		Channel3 17
-		Channel4 18
-		Channel5 19
-		Channel6 20
-		Channel7 21
 		
 		ChannelPos0 FL
 		ChannelPos1 FR
-		ChannelPos0 C
-		ChannelPos1 LFE
-		ChannelPos0 SL
-		ChannelPos1 SR
-		ChannelPos0 RL
-		ChannelPos1 RR
-	}
-}
-
-SectionDevice."SPDIF6" {
-	Comment "Optical B In"
-
-	Value {
-		CapturePriority 110
-	}
-	Macro.pcm_split.SplitPCMDevice {
-		Name "motu828_71_in"
-		Direction Capture
-		HWChannels 30
-		Channels 8
-		
-		Channel0 22
-		Channel1 23
-		Channel2 24
-		Channel3 25
-		Channel4 26
-		Channel5 27
-		Channel6 28
-		Channel7 29
-		
-		ChannelPos0 FL
-		ChannelPos1 FR
-		ChannelPos0 C
-		ChannelPos1 LFE
-		ChannelPos0 SL
-		ChannelPos1 SR
-		ChannelPos0 RL
-		ChannelPos1 RR
 	}
 }

--- a/ucm2/USB-Audio/MOTU/D828.conf
+++ b/ucm2/USB-Audio/MOTU/D828.conf
@@ -1,0 +1,11 @@
+Comment "MOTU D828"
+
+SectionUseCase."HiFi" {
+	Comment "Factory Settings - Stereo Outputs + Inputs"
+	File "/USB-Audio/MOTU/D828-HiFi.conf"
+}
+
+Define.DirectPlaybackChannels 32    #32 channels via physical outputs
+Define.DirectCaptureChannels 30     #28 channels via physical inputs + 2 internal loopback inputs
+
+Include.dhw.File "/common/direct.conf"

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -173,6 +173,22 @@ If.motu-m246 {
 	}
 }
 
+If.motu-D828 {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB07fd:000e"
+	}
+	True.If.D828 {
+		Condition {
+			Type String
+			Haystack "${CardLongName}"
+			Needle "MOTU 828"
+		}
+	True.Define.ProfileName "MOTU/D828"
+	}
+}
+
 If.dell-wd15 {
 	Condition {
 		Type RegexMatch


### PR DESCRIPTION
I am trying to create a UCM for the Motu 828 (28 x 32), which was released in 2024.  (Caution: there have been several versions of the 828 over the past few decades.  I am referring to the 2024 model).  

I am not particularly technical when it comes to code and I had to google what a Pull Request is.  And I am struggling on how to do this.  I had previously created an issue here:  https://github.com/alsa-project/alsa-ucm-conf/issues/415

I have made 2 different attempts at creating a ucm configuration:  1 with and 1 without use of the split pcm macros.  I based the 'macro version' loosely on the Motu M6 ucm.  And I created the one without based on a guide I found online.  The version without macros seemed to get further; but for purposes here, I will attempt the Macro version.

Here are the files and changes I have created.  Unfortunately, when I run the command `spa-acp-tool -c 0 -vvvv info`, the results are:
`spa-acp-tool -c 0 -vvvv info

variable '${var:__Device}' is not defined in this context!
error: /USB-Audio/MOTU/D828-HiFi.conf failed to parse device
error: failed to import hw:0 use case configuration -22
variable '${var:__Device}' is not defined in this context!
error: /USB-Audio/MOTU/D828-HiFi.conf failed to parse device
error: failed to import 828 use case configuration -22
UCM not available for card 828
`

At which point the system goes into an alsa fallback / default.

What am I doing wrong?