### PR TITLE
common: pcm/split: add support up to 32 / 8 channels

### DIFF
--- a/ucm2/common/pcm/split.conf
+++ b/ucm2/common/pcm/split.conf
@@ -3,6 +3,52 @@
 #
 
 #
+# Helper macros
+#
+
+DefineMacro.SplitPCM_chnpos.If.0 {
+	Condition {
+		Type String
+		Empty "${var:__HWChannelPos}"
+	}
+	False.LibraryConfig.0.SubstiConfig.pcm."${var:__Name}" {
+		slave.pcm.chmap [ "${var:__HWChannelPos}" ]
+	}
+}
+
+DefineMacro.SplitPCM_chn.If.0 {
+	Condition {
+		Type RegexMatch
+		Regex "${var:__ChRegex}"
+		String "${var:__Channels}"
+	}
+	True.LibraryConfig.0.SubstiConfig.pcm."${var:__Name}" {
+		@args."${eval:$__ChIndex+2}" "CHN${var:__ChIndex}"
+		@args { "CHN${var:__ChIndex}".type integer }
+		bindings."${var:__ChIndex}" "$CHN${var:__ChIndex}"
+	}
+}
+
+DefineMacro.SplitPCMDevice_chnpos.If.0 {
+	Condition {
+		Type String
+		Empty "${var:__Channel}"
+	}
+	False.Value {
+		"${var:__Direction}Channel${var:__Index}" "${var:__Channel}"
+		"${var:__Direction}ChannelPos${var:__Index}" "${var:__ChannelPos}"
+	}
+}
+
+DefineMacro.SplitPCMDevice_addchn.If.0 {
+	Condition {
+		Type String
+		Empty "${var:__Channel}"
+	}
+	False.Define.__pcmdev "${var:__pcmdev},${var:__Channel}"
+}
+
+#
 # Macro SplitPCM
 #
 # Application variable:
@@ -72,226 +118,46 @@ DefineMacro.SplitPCM.If.0 {
 			bindings.0 $CHN0
 		}
 
-		If.pos1 {
-			Condition {
-				Type String
-				Empty "${var:__HWChannelPos1}"
-			}
-			False.LibraryConfig.pos1.SubstiConfig.pcm."${var:__Name}" {
-				slave.pcm.chmap [ "${var:__HWChannelPos1}" ]
-			}
-		}
-		If.pos2 {
-			Condition {
-				Type String
-				Empty "${var:-__HWChannelPos2}"
-			}
-			False.LibraryConfig.pos2.SubstiConfig.pcm."${var:__Name}" {
-				slave.pcm.chmap [ "${var:-__HWChannelPos2}" ]
-			}
-		}
-		If.pos3 {
-			Condition {
-				Type String
-				Empty "${var:-__HWChannelPos3}"
-			}
-			False.LibraryConfig.pos3.SubstiConfig.pcm."${var:__Name}" {
-				slave.pcm.chmap [ "${var:-__HWChannelPos3}" ]
-			}
-		}
-		If.pos4 {
-			Condition {
-				Type String
-				Empty "${var:-__HWChannelPos4}"
-			}
-			False.LibraryConfig.pos4.SubstiConfig.pcm."${var:__Name}" {
-				slave.pcm.chmap [ "${var:-__HWChannelPos4}" ]
-			}
-		}
-		If.pos5 {
-			Condition {
-				Type String
-				Empty "${var:-__HWChannelPos5}"
-			}
-			False.LibraryConfig.pos4.SubstiConfig.pcm."${var:__Name}" {
-				slave.pcm.chmap [ "${var:-__HWChannelPos5}" ]
-			}
-		}
-		If.pos6 {
-			Condition {
-				Type String
-				Empty "${var:-__HWChannelPos6}"
-			}
-			False.LibraryConfig.pos6.SubstiConfig.pcm."${var:__Name}" {
-				slave.pcm.chmap [ "${var:-__HWChannelPos6}" ]
-			}
-		}
-		If.pos7 {
-			Condition {
-				Type String
-				Empty "${var:-__HWChannelPos7}"
-			}
-			False.LibraryConfig.pos7.SubstiConfig.pcm."${var:__Name}" {
-				slave.pcm.chmap [ "${var:-__HWChannelPos7}" ]
-			}
-		}
-		If.pos8 {
-			Condition {
-				Type String
-				Empty "${var:-__HWChannelPos8}"
-			}
-			False.LibraryConfig.pos8.SubstiConfig.pcm."${var:__Name}" {
-				slave.pcm.chmap [ "${var:-__HWChannelPos8}" ]
-			}
-		}
-		If.pos9 {
-			Condition {
-				Type String
-				Empty "${var:-__HWChannelPos9}"
-			}
-			False.LibraryConfig.pos9.SubstiConfig.pcm."${var:__Name}" {
-				slave.pcm.chmap [ "${var:-__HWChannelPos9}" ]
-			}
-		}
-		If.pos10 {
-			Condition {
-				Type String
-				Empty "${var:-__HWChannelPos10}"
-			}
-			False.LibraryConfig.pos10.SubstiConfig.pcm."${var:__Name}" {
-				slave.pcm.chmap [ "${var:-__HWChannelPos10}" ]
-			}
-		}
-		If.pos11 {
-			Condition {
-				Type String
-				Empty "${var:-__HWChannelPos11}"
-			}
-			False.LibraryConfig.pos11.SubstiConfig.pcm."${var:__Name}" {
-				slave.pcm.chmap [ "${var:-__HWChannelPos11}" ]
-			}
-		}
-		If.pos12 {
-			Condition {
-				Type String
-				Empty "${var:-__HWChannelPos12}"
-			}
-			False.LibraryConfig.pos12.SubstiConfig.pcm."${var:__Name}" {
-				slave.pcm.chmap [ "${var:-__HWChannelPos12}" ]
-			}
-		}
-		If.pos13 {
-			Condition {
-				Type String
-				Empty "${var:-__HWChannelPos13}"
-			}
-			False.LibraryConfig.pos13.SubstiConfig.pcm."${var:__Name}" {
-				slave.pcm.chmap [ "${var:-__HWChannelPos13}" ]
-			}
-		}
-		If.pos14 {
-			Condition {
-				Type String
-				Empty "${var:-__HWChannelPos14}"
-			}
-			False.LibraryConfig.pos14.SubstiConfig.pcm."${var:__Name}" {
-				slave.pcm.chmap [ "${var:-__HWChannelPos14}" ]
-			}
-		}
-		If.pos15 {
-			Condition {
-				Type String
-				Empty "${var:-__HWChannelPos15}"
-			}
-			False.LibraryConfig.pos15.SubstiConfig.pcm."${var:__Name}" {
-				slave.pcm.chmap [ "${var:-__HWChannelPos15}" ]
-			}
-		}
-		If.pos16 {
-			Condition {
-				Type String
-				Empty "${var:-__HWChannelPos16}"
-			}
-			False.LibraryConfig.pos16.SubstiConfig.pcm."${var:__Name}" {
-				slave.pcm.chmap [ "${var:-__HWChannelPos16}" ]
-			}
-		}
-		If.pos17 {
-			Condition {
-				Type String
-				Empty "${var:-__HWChannelPos17}"
-			}
-			False.LibraryConfig.pos17.SubstiConfig.pcm."${var:__Name}" {
-				slave.pcm.chmap [ "${var:-__HWChannelPos17}" ]
-			}
-		}
-		If.pos18 {
-			Condition {
-				Type String
-				Empty "${var:-__HWChannelPos18}"
-			}
-			False.LibraryConfig.pos18.SubstiConfig.pcm."${var:__Name}" {
-				slave.pcm.chmap [ "${var:-__HWChannelPos18}" ]
-			}
-		}
-		If.pos19 {
-			Condition {
-				Type String
-				Empty "${var:-__HWChannelPos19}"
-			}
-			False.LibraryConfig.pos19.SubstiConfig.pcm."${var:__Name}" {
-				slave.pcm.chmap [ "${var:-__HWChannelPos19}" ]
-			}
-		}
-		If.pos20 {
-			Condition {
-				Type String
-				Empty "${var:-__HWChannelPos20}"
-			}
-			False.LibraryConfig.pos20.SubstiConfig.pcm."${var:__Name}" {
-				slave.pcm.chmap [ "${var:-__HWChannelPos20}" ]
-			}
-		}
-		If.pos21 {
-			Condition {
-				Type String
-				Empty "${var:-__HWChannelPos21}"
-			}
-			False.LibraryConfig.pos21.SubstiConfig.pcm."${var:__Name}" {
-				slave.pcm.chmap [ "${var:-__HWChannelPos21}" ]
-			}
-		}
-		If.pos22 {
-			Condition {
-				Type String
-				Empty "${var:-__HWChannelPos22}"
-			}
-			False.LibraryConfig.pos22.SubstiConfig.pcm."${var:__Name}" {
-				slave.pcm.chmap [ "${var:-__HWChannelPos22}" ]
-			}
-		}
-		If.pos23 {
-			Condition {
-				Type String
-				Empty "${var:-__HWChannelPos23}"
-			}
-			False.LibraryConfig.pos23.SubstiConfig.pcm."${var:__Name}" {
-				slave.pcm.chmap [ "${var:-__HWChannelPos23}" ]
-			}
-		}
+		Macro.pos1.SplitPCM_chnpos { HWChannelPos="${var:-__HWChannelPos1}" }
+		Macro.pos2.SplitPCM_chnpos { HWChannelPos="${var:-__HWChannelPos2}" }
+		Macro.pos3.SplitPCM_chnpos { HWChannelPos="${var:-__HWChannelPos3}" }
+		Macro.pos4.SplitPCM_chnpos { HWChannelPos="${var:-__HWChannelPos4}" }
+		Macro.pos5.SplitPCM_chnpos { HWChannelPos="${var:-__HWChannelPos5}" }
+		Macro.pos6.SplitPCM_chnpos { HWChannelPos="${var:-__HWChannelPos6}" }
+		Macro.pos7.SplitPCM_chnpos { HWChannelPos="${var:-__HWChannelPos7}" }
+		Macro.pos8.SplitPCM_chnpos { HWChannelPos="${var:-__HWChannelPos8}" }
+		Macro.pos9.SplitPCM_chnpos { HWChannelPos="${var:-__HWChannelPos9}" }
+		Macro.pos10.SplitPCM_chnpos { HWChannelPos="${var:-__HWChannelPos10}" }
+		Macro.pos11.SplitPCM_chnpos { HWChannelPos="${var:-__HWChannelPos11}" }
+		Macro.pos12.SplitPCM_chnpos { HWChannelPos="${var:-__HWChannelPos12}" }
+		Macro.pos13.SplitPCM_chnpos { HWChannelPos="${var:-__HWChannelPos13}" }
+		Macro.pos14.SplitPCM_chnpos { HWChannelPos="${var:-__HWChannelPos14}" }
+		Macro.pos15.SplitPCM_chnpos { HWChannelPos="${var:-__HWChannelPos15}" }
+		Macro.pos16.SplitPCM_chnpos { HWChannelPos="${var:-__HWChannelPos16}" }
+		Macro.pos17.SplitPCM_chnpos { HWChannelPos="${var:-__HWChannelPos17}" }
+		Macro.pos18.SplitPCM_chnpos { HWChannelPos="${var:-__HWChannelPos18}" }
+		Macro.pos19.SplitPCM_chnpos { HWChannelPos="${var:-__HWChannelPos19}" }
+		Macro.pos20.SplitPCM_chnpos { HWChannelPos="${var:-__HWChannelPos20}" }
+		Macro.pos21.SplitPCM_chnpos { HWChannelPos="${var:-__HWChannelPos21}" }
+		Macro.pos22.SplitPCM_chnpos { HWChannelPos="${var:-__HWChannelPos22}" }
+		Macro.pos23.SplitPCM_chnpos { HWChannelPos="${var:-__HWChannelPos23}" }
+		Macro.pos24.SplitPCM_chnpos { HWChannelPos="${var:-__HWChannelPos24}" }
+		Macro.pos25.SplitPCM_chnpos { HWChannelPos="${var:-__HWChannelPos25}" }
+		Macro.pos26.SplitPCM_chnpos { HWChannelPos="${var:-__HWChannelPos26}" }
+		Macro.pos27.SplitPCM_chnpos { HWChannelPos="${var:-__HWChannelPos27}" }
+		Macro.pos28.SplitPCM_chnpos { HWChannelPos="${var:-__HWChannelPos28}" }
+		Macro.pos29.SplitPCM_chnpos { HWChannelPos="${var:-__HWChannelPos29}" }
+		Macro.pos30.SplitPCM_chnpos { HWChannelPos="${var:-__HWChannelPos30}" }
+		Macro.pos31.SplitPCM_chnpos { HWChannelPos="${var:-__HWChannelPos31}" }
+		Macro.pos32.SplitPCM_chnpos { HWChannelPos="${var:-__HWChannelPos32}" }
 
-		If.ch1 {
-			Condition {
-				Type RegexMatch
-				Regex "^([2-9]|[1-9][0-9])$"
-				String "${var:__Channels}"
-			}
-			True.LibraryConfig.ch1.SubstiConfig.pcm."${var:__Name}" {
-				@args.3 CHN1
-				@args { CHN1.type integer }
-				bindings.1 $CHN1
-			}
-		}
+		Macro.ch1.SplitPCM_chn { ChIndex=1 ChRegex="^([2-9]|[1-9][0-9])$" }
+		Macro.ch2.SplitPCM_chn { ChIndex=2 ChRegex="^([3-9]|[1-9][0-9])$" }
+		Macro.ch3.SplitPCM_chn { ChIndex=3 ChRegex="^([4-9]|[1-9][0-9])$" }
+		Macro.ch4.SplitPCM_chn { ChIndex=4 ChRegex="^([5-9]|[1-9][0-9])$" }
+		Macro.ch5.SplitPCM_chn { ChIndex=5 ChRegex="^([6-9]|[1-9][0-9])$" }
+		Macro.ch6.SplitPCM_chn { ChIndex=6 ChRegex="^([7-9]|[1-9][0-9])$" }
+		Macro.ch7.SplitPCM_chn { ChIndex=7 ChRegex="^([8-9]|[1-9][0-9])$" }
 
 		If.dir {
 			Condition {
@@ -342,26 +208,24 @@ DefineMacro.SplitPCMDevice {
 				"${var:__Direction}Channel0" "${var:__Channel0}"
 				"${var:__Direction}ChannelPos0" "${var:__ChannelPos0}"
 			}
-			If.ch1 {
-				Condition {
-					Type String
-					Empty "${var:-__Channel1}"
-				}
-				False.Value {
-					"${var:__Direction}Channel1" "${var:__Channel1}"
-					"${var:__Direction}ChannelPos1" "${var:__ChannelPos1}"
-				}
-			}
+
+			Macro.chn1.SplitPCMDevice_chnpos { Index=1 Channel="${var:-__Channel1}" ChannelPos="${var:-__ChannelPos1}" }
+			Macro.chn2.SplitPCMDevice_chnpos { Index=2 Channel="${var:-__Channel2}" ChannelPos="${var:-__ChannelPos2}" }
+			Macro.chn3.SplitPCMDevice_chnpos { Index=3 Channel="${var:-__Channel3}" ChannelPos="${var:-__ChannelPos3}" }
+			Macro.chn4.SplitPCMDevice_chnpos { Index=4 Channel="${var:-__Channel4}" ChannelPos="${var:-__ChannelPos4}" }
+			Macro.chn5.SplitPCMDevice_chnpos { Index=5 Channel="${var:-__Channel5}" ChannelPos="${var:-__ChannelPos5}" }
+			Macro.chn6.SplitPCMDevice_chnpos { Index=6 Channel="${var:-__Channel6}" ChannelPos="${var:-__ChannelPos6}" }
+			Macro.chn7.SplitPCMDevice_chnpos { Index=7 Channel="${var:-__Channel7}" ChannelPos="${var:-__ChannelPos7}" }
 		}
 		True {
 			Define.__pcmdev "${var:__Name}:${CardId},${var:__Device},${var:__Channel0}"
-			If.ch1 {
-				Condition {
-					Type String
-					Empty "${var:-__Channel1}"
-				}
-				False.Define.__pcmdev "${var:__pcmdev},${var:__Channel1}"
-			}
+			Macro.ch1.SplitPCMDevice_addchn { Channel="${var:-__Channel1}" }
+			Macro.ch2.SplitPCMDevice_addchn { Channel="${var:-__Channel2}" }
+			Macro.ch3.SplitPCMDevice_addchn { Channel="${var:-__Channel3}" }
+			Macro.ch4.SplitPCMDevice_addchn { Channel="${var:-__Channel4}" }
+			Macro.ch5.SplitPCMDevice_addchn { Channel="${var:-__Channel5}" }
+			Macro.ch6.SplitPCMDevice_addchn { Channel="${var:-__Channel6}" }
+			Macro.ch7.SplitPCMDevice_addchn { Channel="${var:-__Channel7}" }
 			Value {
 				"${var:__Direction}Channels" "${var:__Channels}"
 				"${var:__Direction}PCM" "${var:__pcmdev}"


### PR DESCRIPTION
**DO NOT MERGE - after 1.2.12!**

MOTU 828 has up to 32 hardware channels. Add support for this configuration to common/pcm/split.conf.

Also, add support for up to 8 channels for the abstact devices (like 7.1 surround).

Note that this change requires recent alsa-lib (Syntax 7).

Link: https://github.com/alsa-project/alsa-ucm-conf/pull/416