### PR TITLE
Wcd937x support

### DIFF
--- a/ucm2/codecs/qcom-lpass/tx-macro/HeadphoneMicDisableSeq.conf
+++ b/ucm2/codecs/qcom-lpass/tx-macro/HeadphoneMicDisableSeq.conf
@@ -1,5 +1,4 @@
 DisableSequence [
 	cset "name='TX SMIC MUX0' ZERO"
 	cset "name='TX_AIF1_CAP Mixer DEC0' 0"
-	cset "name='TX1 MODE' ADC_INVALID"
 ]

--- a/ucm2/codecs/qcom-lpass/tx-macro/HeadphoneMicEnableSeq.conf
+++ b/ucm2/codecs/qcom-lpass/tx-macro/HeadphoneMicEnableSeq.conf
@@ -2,6 +2,5 @@ EnableSequence [
 	cset "name='TX DEC0 MUX' SWR_MIC"
 	cset "name='TX SMIC MUX0' ADC1"
 	cset "name='TX_AIF1_CAP Mixer DEC0' 1"
-	cset "name='TX1 MODE' ADC_NORMAL"
 	cset "name='TX_DEC0 Volume' 110"
 ]

--- a/ucm2/codecs/wcd937x/HeadphoneDisableSeq.conf
+++ b/ucm2/codecs/wcd937x/HeadphoneDisableSeq.conf
@@ -1,0 +1,6 @@
+DisableSequence [
+	cset "name='HPHL_RDAC Switch' 0"
+	cset "name='HPHR_RDAC Switch' 0"
+	cset "name='HPHL Switch' 0"
+	cset "name='HPHR Switch' 0"
+]

--- a/ucm2/codecs/wcd937x/HeadphoneEnableSeq.conf
+++ b/ucm2/codecs/wcd937x/HeadphoneEnableSeq.conf
@@ -1,0 +1,6 @@
+EnableSequence [
+	cset "name='HPHL_RDAC Switch' 1"
+	cset "name='HPHR_RDAC Switch' 1"
+	cset "name='HPHL Switch' 1"
+	cset "name='HPHR Switch' 1"
+]

--- a/ucm2/codecs/wcd937x/HeadphoneMicDisableSeq.conf
+++ b/ucm2/codecs/wcd937x/HeadphoneMicDisableSeq.conf
@@ -1,0 +1,4 @@
+DisableSequence [
+	cset "name='ADC2_MIXER Switch' 0"
+	cset "name='ADC2 Switch' 0"
+]

--- a/ucm2/codecs/wcd937x/HeadphoneMicEnableSeq.conf
+++ b/ucm2/codecs/wcd937x/HeadphoneMicEnableSeq.conf
@@ -1,0 +1,5 @@
+EnableSequence [
+	cset "name='ADC2_MIXER Switch' 1"
+	cset "name='ADC2 MUX' INP2"
+	cset "name='ADC2 Switch' 1"
+]

--- a/ucm2/codecs/wcd937x/init.conf
+++ b/ucm2/codecs/wcd937x/init.conf
@@ -1,0 +1,12 @@
+# WCD937X specific volume control settings
+
+LibraryConfig.remap.Config {
+
+	ctl.default.map {
+		# Merge two mono controls into one stereo
+		"name='HP Volume'" {
+			"name='HPHL Volume'".vindex.0 0
+			"name='HPHR Volume'".vindex.1 0
+		}
+	}
+}

--- a/ucm2/codecs/wcd938x/HeadphoneMicDisableSeq.conf
+++ b/ucm2/codecs/wcd938x/HeadphoneMicDisableSeq.conf
@@ -1,4 +1,5 @@
 DisableSequence [
 	cset "name='ADC2_MIXER Switch' 0"
 	cset "name='ADC2 Switch' 0"
+	set "name='TX1 MODE' ADC_INVALID"
 ]

--- a/ucm2/codecs/wcd938x/HeadphoneMicEnableSeq.conf
+++ b/ucm2/codecs/wcd938x/HeadphoneMicEnableSeq.conf
@@ -3,4 +3,5 @@ EnableSequence [
 	cset "name='HDR12 MUX' NO_HDR12"
 	cset "name='ADC2 MUX' INP2"
 	cset "name='ADC2 Switch' 1"
+	set "name='TX1 MODE' ADC_NORMAL"
 ]


### PR DESCRIPTION
Add WCD937X codec support.

This change will add the default, enable/disable codec sequence for Headphone and Mic on WCD937x codec,

And move TX1 MODE mixer controller to WCD938x codec sequence.
The tx-macro is a common interface for WCD937x and wcd938x and also TX1 MODE setting is not applicable for WCD937x codec.
The TX1 MODE mixer controller is derived in WCD938x codec driver, so move the TX1 MODE mixer control to wcd938x.
