### PR TITLE
USB-Audio: Add support for MOTU Ultralite mk5

### DIFF
--- a/ucm2/USB-Audio/MOTU/UltraLite-mk5-HiFi.conf
+++ b/ucm2/USB-Audio/MOTU/UltraLite-mk5-HiFi.conf
@@ -1,0 +1,449 @@
+Include.pcm_split.File "/common/pcm/split.conf"
+
+Macro [
+	{
+		SplitPCM {
+			Name "ultralite_mk5_stereo_out"
+			Direction Playback
+			Channels 2
+			HWChannels 22
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+		}
+	}
+	{
+		SplitPCM {
+			Name "ultralite_mk5_mono_in"
+			Direction Capture
+			Channels 1
+			HWChannels 20
+			HWChannelPos0 MONO
+			HWChannelPos1 MONO
+		}
+	}
+	{
+		SplitPCM {
+			Name "ultralite_mk5_stereo_in"
+			Direction Capture
+			Channels 2
+			HWChannels 20
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+		}
+	}
+]
+
+SectionDevice."Line1" {
+	Comment "USB Out Main 1-2"
+
+	Value {
+		PlaybackPriority 200
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ultralite_mk5_stereo_out"
+		Direction Playback
+		HWChannels 22
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line2" {
+	Comment "USB Out Line 3-4"
+
+	Value {
+		PlaybackPriority 180
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ultralite_mk5_stereo_out"
+		Direction Playback
+		HWChannels 22
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line3" {
+	Comment "USB Out Line 5-6"
+
+	Value {
+		PlaybackPriority 170
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ultralite_mk5_stereo_out"
+		Direction Playback
+		HWChannels 22
+		Channels 2
+		Channel0 4
+		Channel1 5
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line4" {
+	Comment "USB Out Line 7-8"
+
+	Value {
+		PlaybackPriority 160
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ultralite_mk5_stereo_out"
+		Direction Playback
+		HWChannels 22
+		Channels 2
+		Channel0 6
+		Channel1 7
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line5" {
+	Comment "USB Out Line 9-10"
+
+	Value {
+		PlaybackPriority 150
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ultralite_mk5_stereo_out"
+		Direction Playback
+		HWChannels 22
+		Channels 2
+		Channel0 8
+		Channel1 9
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Headphones1" {
+	Comment "USB Out Phones 1-2"
+
+	Value {
+		PlaybackPriority 190
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ultralite_mk5_stereo_out"
+		Direction Playback
+		HWChannels 22
+		Channels 2
+		Channel0 10
+		Channel1 11
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."SPDIF1" {
+	Comment "USB Out SPDIF 1-2"
+
+	Value {
+		PlaybackPriority 140
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ultralite_mk5_stereo_out"
+		Direction Playback
+		HWChannels 22
+		Channels 2
+		Channel0 12
+		Channel1 13
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."SPDIF2" {
+	Comment "USB Out Optical 1-2"
+
+	Value {
+		PlaybackPriority 130
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ultralite_mk5_stereo_out"
+		Direction Playback
+		HWChannels 22
+		Channels 2
+		Channel0 14
+		Channel1 15
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."SPDIF3" {
+	Comment "USB Out Optical 3-4"
+
+	Value {
+		PlaybackPriority 120
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ultralite_mk5_stereo_out"
+		Direction Playback
+		HWChannels 22
+		Channels 2
+		Channel0 16
+		Channel1 17
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."SPDIF4" {
+	Comment "USB Out Optical 5-6"
+
+	Value {
+		PlaybackPriority 110
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ultralite_mk5_stereo_out"
+		Direction Playback
+		HWChannels 22
+		Channels 2
+		Channel0 18
+		Channel1 19
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."SPDIF5" {
+	Comment "USB Out Optical 7-8"
+
+	Value {
+		PlaybackPriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ultralite_mk5_stereo_out"
+		Direction Playback
+		HWChannels 22
+		Channels 2
+		Channel0 20
+		Channel1 21
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Mic1" {
+	Comment "Mic/Line/Inst 1"
+
+	Value {
+		CapturePriority 210
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ultralite_mk5_mono_in"
+		Direction Capture
+		HWChannels 20
+		Channels 1
+		Channel0 0
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Mic2" {
+	Comment "Mic/Line/Inst 2"
+
+	Value {
+		CapturePriority 200
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ultralite_mk5_mono_in"
+		Direction Capture
+		HWChannels 20
+		Channels 1
+		Channel0 1
+		ChannelPos0 MONO
+	}
+}
+
+
+SectionDevice."Line6" {
+	Comment "Mic/Line/Inst 1-2"
+
+	ConflictingDevice [
+		"Mic1"
+		"Mic2"
+	]
+	Value {
+		CapturePriority 190
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ultralite_mk5_stereo_in"
+		Direction Capture
+		HWChannels 20
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line7" {
+	Comment "Line 3-4"
+
+	Value {
+		CapturePriority 180
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ultralite_mk5_stereo_in"
+		Direction Capture
+		HWChannels 20
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line8" {
+	Comment "Line 5-6"
+
+	Value {
+		CapturePriority 170
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ultralite_mk5_stereo_in"
+		Direction Capture
+		HWChannels 20
+		Channels 2
+		Channel0 4
+		Channel1 5
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line9" {
+	Comment "Line 7-8"
+
+	Value {
+		CapturePriority 160
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ultralite_mk5_stereo_in"
+		Direction Capture
+		HWChannels 20
+		Channels 2
+		Channel0 6
+		Channel1 7
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line10" {
+	Comment "Loopback 1-2"
+
+	Value {
+		CapturePriority 150
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ultralite_mk5_stereo_in"
+		Direction Capture
+		HWChannels 20
+		Channels 2
+		Channel0 8
+		Channel1 9
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."SPDIF6" {
+	Comment "SPDIF 1-2"
+
+	Value {
+		CapturePriority 140
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ultralite_mk5_stereo_in"
+		Direction Capture
+		HWChannels 20
+		Channels 2
+		Channel0 10
+		Channel1 11
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."SPDIF7" {
+	Comment "Optical 1-2"
+
+	Value {
+		CapturePriority 130
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ultralite_mk5_stereo_in"
+		Direction Capture
+		HWChannels 20
+		Channels 2
+		Channel0 12
+		Channel1 13
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."SPDIF8" {
+	Comment "Optical 3-4"
+
+	Value {
+		CapturePriority 120
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ultralite_mk5_stereo_in"
+		Direction Capture
+		HWChannels 20
+		Channels 2
+		Channel0 14
+		Channel1 15
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."SPDIF9" {
+	Comment "Optical 5-6"
+
+	Value {
+		CapturePriority 110
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ultralite_mk5_stereo_in"
+		Direction Capture
+		HWChannels 20
+		Channels 2
+		Channel0 16
+		Channel1 17
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."SPDIF10" {
+	Comment "Optical 7-8"
+
+	Value {
+		CapturePriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ultralite_mk5_stereo_in"
+		Direction Capture
+		HWChannels 20
+		Channels 2
+		Channel0 18
+		Channel1 19
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}

--- a/ucm2/USB-Audio/MOTU/UltraLite-mk5.conf
+++ b/ucm2/USB-Audio/MOTU/UltraLite-mk5.conf
@@ -1,0 +1,12 @@
+Comment "MOTU UltraLite mk5"
+
+SectionUseCase."HiFi" {
+	Comment "Default"
+	File "/USB-Audio/MOTU/UltraLite-mk5-HiFi.conf"
+}
+
+Define.DirectPlaybackChannels 22
+Define.DirectCaptureChannels 20
+
+Include.dhw.File "/common/direct.conf"
+

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -173,6 +173,15 @@ If.motu-m246 {
 	}
 }
 
+If.motu-ultralite-mk5 {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB07fd:000c"
+	}
+	True.Define.ProfileName "MOTU/UltraLite-mk5"
+}
+
 If.dell-wd15 {
 	Condition {
 		Type RegexMatch


### PR DESCRIPTION
Adds support for the [MOTU Ultralite mk5](https://motu.com/en-us/products/gen5/ultralite-mk5/) soundcard. I named each device after their names on the MOTU Cuemix Control application.

Successfully tested on my hardware, see the [alsa-info.sh output](http://alsa-project.org/db/?f=ca07253279e53fa354820f356f6beb5d2026d23f).