### PR TITLE
ucm2: Qualcomm: x1e80100: add USB DisplayPort playback

### DIFF
--- a/ucm2/Qualcomm/x1e80100/HiFi.conf
+++ b/ucm2/Qualcomm/x1e80100/HiFi.conf
@@ -3,7 +3,9 @@
 
 SectionVerb {
 	EnableSequence [
-		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia1' 1"
+		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia1' 0"
+		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia1' 0"
+		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia1' 0"
 		cset "name='WSA_CODEC_DMA_RX_0 Audio Mixer MultiMedia2' 1"
 		cset "name='MultiMedia3 Mixer TX_CODEC_DMA_TX_3' 1"
 		cset "name='MultiMedia4 Mixer VA_CODEC_DMA_TX_0' 1"
@@ -39,10 +41,23 @@ SectionDevice."Speaker" {
 SectionDevice."Headphones" {
 	Comment "Headphones playback"
 
+	ConflictingDevice [
+		"HDMI0"
+		"HDMI1"
+	]
+
 	Include.wcdhpe.File "/codecs/wcd938x/HeadphoneEnableSeq.conf"
 	Include.wcdhpd.File "/codecs/wcd938x/HeadphoneDisableSeq.conf"
 	Include.rxmhpe.File "/codecs/qcom-lpass/rx-macro/HeadphoneEnableSeq.conf"
 	Include.rxmhpd.File "/codecs/qcom-lpass/rx-macro/HeadphoneDisableSeq.conf"
+
+	EnableSequence [
+		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia1' 1"
+	]
+
+	DisableSequence [
+		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia1' 0"
+	]
 
 	Value {
 		PlaybackPriority 200
@@ -65,5 +80,51 @@ SectionDevice."Mic" {
 	Value {
 		CapturePriority 100
 		CapturePCM "hw:${CardId},3"
+	}
+}
+
+SectionDevice."HDMI0" {
+	Comment "USB/DisplayPort 0 playback"
+
+	ConflictingDevice [
+		"Headphones"
+		"HDMI1"
+	]
+
+	EnableSequence [
+		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia1' 1"
+	]
+
+	DisableSequence [
+		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia1' 0"
+	]
+
+	Value {
+		PlaybackPriority 200
+		PlaybackPCM "hw:${CardId},0"
+		JackControl "DP0 Jack"
+	}
+}
+
+SectionDevice."HDMI1" {
+	Comment "USB/DisplayPort 1 playback"
+
+	ConflictingDevice [
+		"Headphones"
+		"HDMI0"
+	]
+
+	EnableSequence [
+		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia1' 1"
+	]
+
+	DisableSequence [
+		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia1' 0"
+	]
+
+	Value {
+		PlaybackPriority 100
+		PlaybackPCM "hw:${CardId},0"
+		JackControl "DP1 Jack"
 	}
 }

--- a/ucm2/Qualcomm/x1e80100/HiFi.conf
+++ b/ucm2/Qualcomm/x1e80100/HiFi.conf
@@ -5,7 +5,7 @@ SectionVerb {
 	EnableSequence [
 		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia1' 0"
 		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia1' 0"
-		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia1' 0"
+		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia1' 1"
 		cset "name='WSA_CODEC_DMA_RX_0 Audio Mixer MultiMedia2' 1"
 		cset "name='MultiMedia3 Mixer TX_CODEC_DMA_TX_3' 1"
 		cset "name='MultiMedia4 Mixer VA_CODEC_DMA_TX_0' 1"
@@ -69,8 +69,32 @@ SectionDevice."Headphones" {
 	}
 }
 
+SectionDevice."Headset" {
+	Comment "Headset microphone"
+
+	ConflictingDevice [
+		"Mic"
+	]
+
+	Include.wcdmice.File "/codecs/wcd938x/HeadphoneMicEnableSeq.conf"
+	Include.wcdmicd.File "/codecs/wcd938x/HeadphoneMicDisableSeq.conf"
+	Include.txmhpe.File "/codecs/qcom-lpass/tx-macro/SoundwireMic1EnableSeq.conf"
+	Include.txmhpd.File "/codecs/qcom-lpass/tx-macro/SoundwireMicDisableSeq.conf"
+
+	Value {
+		CapturePriority 200
+		CapturePCM "hw:${CardId},2"
+		CaptureMixerElem "ADC2"
+		JackControl "Mic Jack"
+	}
+}
+
 SectionDevice."Mic" {
 	Comment "Internal microphones"
+
+	ConflictingDevice [
+		"Headset"
+	]
 
 	Include.vadm0e.File "/codecs/qcom-lpass/va-macro/DMIC0EnableSeq.conf"
 	Include.vadm0d.File "/codecs/qcom-lpass/va-macro/DMIC0DisableSeq.conf"

--- a/ucm2/codecs/wcd938x/HeadphoneMicDisableSeq.conf
+++ b/ucm2/codecs/wcd938x/HeadphoneMicDisableSeq.conf
@@ -1,5 +1,5 @@
 DisableSequence [
 	cset "name='ADC2_MIXER Switch' 0"
 	cset "name='ADC2 Switch' 0"
-	set "name='TX1 MODE' ADC_INVALID"
+	cset "name='TX1 MODE' ADC_INVALID"
 ]

--- a/ucm2/codecs/wcd938x/HeadphoneMicEnableSeq.conf
+++ b/ucm2/codecs/wcd938x/HeadphoneMicEnableSeq.conf
@@ -3,5 +3,5 @@ EnableSequence [
 	cset "name='HDR12 MUX' NO_HDR12"
 	cset "name='ADC2 MUX' INP2"
 	cset "name='ADC2 Switch' 1"
-	set "name='TX1 MODE' ADC_NORMAL"
+	cset "name='TX1 MODE' ADC_NORMAL"
 ]


### PR DESCRIPTION
Add two DisplayPort (over USB) playback devices, conflicting with the headset, because they use the same Multimedia1 frontend.