### PR TITLE
ucm2/conf.d: add symlink for Qualcomm DB820c

### DIFF
--- a/ucm2/conf.d/apq8096/DB820c.conf
+++ b/ucm2/conf.d/apq8096/DB820c.conf
@@ -1,0 +1,1 @@
+../../Qualcomm/apq8096/apq8096.conf


### PR DESCRIPTION
Since the release 6.3 Linux kernel uses driver name apq8096 for Qualcomm Dragonboard 820c. This makes alsaucm look for conf.d/apq8096/DB820c.conf and then for conf.d/apq8096/apq8096.conf, while alsa-ucm-conf has historical conf.d/DB820c/DB820c.conf symlink. Add symlink to provide correct configuration for the device.