### PR TITLE
USB-Audio: Add support for Solid State Labs SSL 2+

### DIFF
--- a/ucm2/USB-Audio/SolidStateLabs/SSL2Plus-HiFi.conf
+++ b/ucm2/USB-Audio/SolidStateLabs/SSL2Plus-HiFi.conf
@@ -1,0 +1,102 @@
+Include.pcm_split.File "/common/pcm/split.conf"
+
+Macro [
+	{
+		SplitPCM {
+			Name "ssl2plus_stereo_out"
+			Direction Playback
+			Channels 2
+			HWChannels 4
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 FL
+			HWChannelPos3 FR
+		}
+	}
+	{
+		SplitPCM {
+			Name "ssl2plus_mono_in"
+			Direction Capture
+			Channels 1
+			HWChannels 2
+			HWChannelPos0 MONO
+			HWChannelPos1 MONO
+		}
+	}
+]
+
+SectionDevice."Line1" {
+	Comment "Line Outputs 1/L + 2/R"
+
+	EnableSequence [
+		cdev "hw:${CardId}"
+	]
+
+	DisableSequence [
+		cdev "hw:${CardId}"
+	]
+
+	Value {
+		PlaybackPriority 200
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ssl2plus_stereo_out"
+		Direction Playback
+		HWChannels 4
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line2" {
+	Comment "Line Outputs 3 + 4"
+
+	Value {
+		PlaybackPriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ssl2plus_stereo_out"
+		Direction Playback
+		HWChannels 4
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Mic1" {
+	Comment "Mic/Line/Inst 1"
+
+	Value {
+		CapturePriority 200
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ssl2plus_mono_in"
+		Direction Capture
+		HWChannels 2
+		Channels 1
+		Channel0 0
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Mic2" {
+	Comment "Mic/Line/Inst 2"
+
+	Value {
+		CapturePriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ssl2plus_mono_in"
+		Direction Capture
+		HWChannels 2
+		Channels 1
+		Channel0 1
+		ChannelPos0 MONO
+	}
+}

--- a/ucm2/USB-Audio/SolidStateLabs/SSL2Plus.conf
+++ b/ucm2/USB-Audio/SolidStateLabs/SSL2Plus.conf
@@ -1,0 +1,11 @@
+Comment "Solid State Labs SSL 2+"
+
+SectionUseCase."HiFi" {
+	Comment "HiFi"
+	File "/USB-Audio/SolidStateLabs/SSL2Plus-HiFi.conf"
+}
+
+Define.DirectPlaybackChannels 4
+Define.DirectCaptureChannels 2
+
+Include.dhw.File "/common/direct.conf"

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -394,6 +394,17 @@ If.ssl2 {
 	}
 }
 
+If.ssl2plus {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB31e9:0002"
+	}
+	True.Define {
+		ProfileName "SolidStateLabs/SSL2Plus"
+	}
+}
+
 If.mixremap {
 	Condition {
 		Type String


### PR DESCRIPTION
This adds support for the [Solid State Labs SSL 2+](https://www.solidstatelogic.com/products/ssl2-plus).

Note that this *is* a distinct device to the SSL 2, support for which was added in #377. The most notable difference is that this device has two additional outputs (physically four, but two of those are mirrored).