### PR TITLE
Fix labeling of BOSS Katana ports

### DIFF
--- a/ucm2/USB-Audio/BOSS/Katana-HiFi.conf
+++ b/ucm2/USB-Audio/BOSS/Katana-HiFi.conf
@@ -1,0 +1,100 @@
+Include.pcm_split.File "/common/pcm/split.conf"
+
+Macro [
+	{
+		SplitPCM {
+			Name "katana_stereo_out"
+			Direction Playback
+			Channels 2
+			HWChannels 4
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 FL
+			HWChannelPos3 FR
+		}
+	}
+	{
+		SplitPCM {
+			Name "katana_stereo_in"
+			Direction Capture
+			Channels 2
+			HWChannels 4
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 FL
+			HWChannelPos3 FR
+		}
+	}
+]
+
+SectionDevice."PrimaryOut" {
+	Comment "Music Playback"
+
+	Value {
+		PlaybackPriority 200
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "katana_stereo_out"
+		Direction Playback
+		Channels 2
+		HWChannels 4
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."SecondaryOut" {
+	Comment "DI Playback"
+
+	Value {
+		PlaybackPriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "katana_stereo_out"
+		Direction Playback
+		Channels 2
+		HWChannels 4
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."PrimaryIn" {
+	Comment "Processed Signal"
+
+	Value {
+		CapturePriority 200
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "katana_stereo_in"
+		Direction Capture
+		Channels 2
+		HWChannels 4
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."SecondaryIn" {
+	Comment "DI Capture"
+
+	Value {
+		CapturePriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "katana_stereo_in"
+		Direction Capture
+		Channels 2
+		HWChannels 4
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}

--- a/ucm2/USB-Audio/BOSS/Katana.conf
+++ b/ucm2/USB-Audio/BOSS/Katana.conf
@@ -1,0 +1,6 @@
+Comment "BOSS Katana USB-Audio"
+
+SectionUseCase."HiFi" {
+    File "/USB-Audio/BOSS/Katana-HiFi.conf"
+    Comment "Default"
+}

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -394,6 +394,18 @@ If.ssl2 {
 	}
 }
 
+If.boss-katana {
+        Condition {
+                Type String
+                Haystack "${CardComponents}"
+		# 0582:01d8 BOSS Katana HEAD MkII
+		# Might work for other models
+		# and generations from the same series
+                Needle "USB0582:01d8"
+        }
+        True.Define.ProfileName "BOSS/Katana"
+}
+
 If.mixremap {
 	Condition {
 		Type String


### PR DESCRIPTION
I'd like to rename the MIDI ports as well but I don't know how. If you can point me where I can learn about it, I'll be glad to do so and mark this PR as finished.

I guess this fix works the same for all Katana models from all generations, but I don't have the PID available to enable it, nor the devices for testing.

Edit: Didn't post the [`alsa-info.sh` output](https://gist.github.com/aledomu/ac3b2741ca2426bc6fbc057907ad0dab).