### PR TITLE
USB-Audio: Add support for Focusrite 4th Gen devices

### DIFF
--- a/ucm2/USB-Audio/Focusrite/Scarlett-2i.conf
+++ b/ucm2/USB-Audio/Focusrite/Scarlett-2i.conf
@@ -55,6 +55,15 @@ If.gen3 {
 	True.Define.Generation "3rd"
 }
 
+If.gen4 {
+	Condition {
+		Type RegexMatch
+		String "${CardComponents}"
+		Regex "USB1235:821[89]"
+	}
+	True.Define.Generation "4th"
+}
+
 Comment "Focusrite Scarlett ${var:Model} ${var:Generation} Gen"
 
 SectionUseCase."HiFi" {

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -267,7 +267,9 @@ If.focusrite-scarlett-2i {
 		# 8205 Solo 2nd Gen
 		# 8210 2i2 3rd Gen
 		# 8211 Solo 3rd Gen
-		Regex "USB1235:8(0(0[6a]|1c)|2(0[025]|1[01]))"
+		# 8218 Solo 4th Gen
+		# 8219 2i2 4th Gen
+		Regex "USB1235:8(0(0[6a]|1c)|2(0[025]|1[0189]))"
 	}
 	True.Define {
 		ProfileName "Focusrite/Scarlett-2i"


### PR DESCRIPTION
Extending the existing support for Focusrite Scarlett Solo and 2i2 interfaces with support for the 4th Gen devices.

I have a Focusrite Scarlett 2i2 which is what I have tested with and used to get the device ID.
For the Solo device, I grabbed the device ID from [linux-hardware.org](https://linux-hardware.org/?id=usb:1235-8218).