### PR TITLE
ucm2: soundwire: rt722: add ConflictingDevice in each device

### DIFF
--- a/ucm2/sof-soundwire/rt722.conf
+++ b/ucm2/sof-soundwire/rt722.conf
@@ -10,6 +10,10 @@ If.codecmic {
 		SectionDevice."Mic" {
 			Comment	"SoundWire microphones"
 
+			ConflictingDevice [
+				"Headset"
+			]
+
 			EnableSequence [
 				cset "name='rt722 FU1E Capture Switch' 1"
 			]
@@ -39,6 +43,10 @@ If.codecspk {
 		SectionDevice."Speaker" {
 			Comment "Speaker"
 
+			ConflictingDevice [
+				"Headphones"
+			]
+
 			EnableSequence [
 				cset "name='Speaker Switch' on"
 			]
@@ -60,6 +68,10 @@ If.codecspk {
 SectionDevice."Headphones" {
 	Comment	"Headphones"
 
+	ConflictingDevice [
+		"Speaker"
+	]
+
 	EnableSequence [
 		cset "name='Headphone Switch' on"
 	]
@@ -77,6 +89,10 @@ SectionDevice."Headphones" {
 
 SectionDevice."Headset" {
 	Comment "Headset Microphone"
+
+	ConflictingDevice [
+		"Mic"
+	]
 
 	EnableSequence [
 		cset "name='rt722 FU0F Capture Switch' 1"


### PR DESCRIPTION
This patch allows only one input and one output to be opened simultaneously.