### PR TITLE
ucm2: Add Roland Bridge Cast V2

### DIFF
--- a/ucm2/USB-Audio/Roland/BridgeCastV2-Hifi.conf
+++ b/ucm2/USB-Audio/Roland/BridgeCastV2-Hifi.conf
@@ -1,0 +1,170 @@
+Include.pcm_split.File "/common/pcm/split.conf"
+
+Macro [
+	{
+		SplitPCM {
+			Name "bc_stereo_out"
+			Direction Playback
+			Channels 2
+			HWChannels 14
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 FL
+			HWChannelPos3 FR
+			HWChannelPos4 FL
+			HWChannelPos5 FR
+			HWChannelPos6 FL
+			HWChannelPos7 FR
+			HWChannelPos8 FL
+			HWChannelPos9 FR
+			HWChannelPos10 FL
+			HWChannelPos11 FR
+			HWChannelPos12 FL
+			HWChannelPos13 FR
+		}
+	}
+	{
+		SplitPCM {
+			Name "bc_stereo_in"
+			Direction Capture
+			Channels 2
+			HWChannels 6
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 FL
+			HWChannelPos3 FR
+			HWChannelPos4 FL
+			HWChannelPos5 FR
+		}
+	}
+]
+
+SectionDevice."Line1" {
+	Comment "Chat L/R"
+
+	Value {
+		PlaybackPriority 100
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "bc_stereo_out"
+		Direction Playback
+		HWChannels 14
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line2" {
+	Comment "Game L/R"
+
+	Value {
+		PlaybackPriority 200
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "bc_stereo_out"
+		Direction Playback
+		HWChannels 14
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line3" {
+	Comment "Music L/R"
+
+	Value {
+		PlaybackPriority 300
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "bc_stereo_out"
+		Direction Playback
+		HWChannels 14
+		Channels 2
+		Channel0 12
+		Channel1 13
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line4" {
+	Comment "System L/R"
+
+	Value {
+		PlaybackPriority 400
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "bc_stereo_out"
+		Direction Playback
+		HWChannels 14
+		Channels 2
+		Channel0 10
+		Channel1 11
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line5" {
+	Comment "StreamMix"
+
+	Value {
+		CapturePriority 300
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "bc_stereo_in"
+		Direction Capture
+		HWChannels 6
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line6" {
+	Comment "Mic"
+
+	Value {
+		CapturePriority 200
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "bc_stereo_in"
+		Direction Capture
+		HWChannels 6
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line7" {
+	Comment "SFX"
+
+	Value {
+		CapturePriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "bc_stereo_in"
+		Direction Capture
+		HWChannels 6
+		Channels 2
+		Channel0 4
+		Channel1 5
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}

--- a/ucm2/USB-Audio/Roland/BridgeCastV2.conf
+++ b/ucm2/USB-Audio/Roland/BridgeCastV2.conf
@@ -1,0 +1,6 @@
+Comment "Roland BridgeCast V2 Hifi-Mode"
+
+SectionUseCase."HiFi" {
+	Comment "BridgeCast V2 MultiChannel"
+	File "/USB-Audio/Roland/BridgeCastV2-Hifi.conf"
+}

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -161,6 +161,15 @@ If.roland-bridgecast {
 	True.Define.ProfileName "Roland/BridgeCast"
 }
 
+If.roland-bridgecastv2 {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB0582:031e"
+	}
+	True.Define.ProfileName "Roland/BridgeCastV2"
+}
+
 If.motu-m246 {
 	Condition {
 		Type RegexMatch


### PR DESCRIPTION
Roland Bridge Cast recently had a firmware update which brings in e.g. virtual surround and is dubbed as "V2" and has a separate usb device id than the existing Bridge Cast in the repo. This PR adds the changes needed for the new firmware to be mapped correctly, as a new USB audio device.

Changelog: https://www.roland.com/global/support/by_product/bridge_cast/updates_drivers/7e9b7ea2-2c20-4749-a423-0ff28709cdac/

Thanks to [geoffreybennett](https://old.reddit.com/user/geoffreybennett) on reddit for helping me understand how to debug this stuff. Thread: https://old.reddit.com/r/linuxaudio/comments/1fq06z8/roland_bridge_cast_no_longer_having_separate/?cache-bust=1727469957022