### PR TITLE
ucm2: USB-Audio: add Steinberg UR22C (USB0499:172f)

### DIFF
--- a/ucm2/USB-Audio/Steinberg/UR22C-HiFi.conf
+++ b/ucm2/USB-Audio/Steinberg/UR22C-HiFi.conf
@@ -1,0 +1,57 @@
+Include.pcm_split.File "/common/pcm/split.conf"
+
+Macro [
+	{
+		SplitPCM {
+			Name "steinberg_ur22c_mono_in"
+			Direction Capture
+			Channels 1
+			HWChannels 2
+			HWChannelPos0 MONO
+			HWChannelPos1 MONO
+		}
+	}
+]
+
+SectionDevice."Line 1" {
+	Comment "Stereo Line (output)"
+
+	Value {
+		PlaybackPriority 200
+	}
+	Value {
+	PlaybackPCM "hw:${CardId}"
+	}
+}
+
+SectionDevice."Line 2" {
+	Comment "Mono Line (input 1)"
+
+	Value {
+		CapturePriority 600
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "steinberg_ur22c_mono_in"
+		Direction Capture
+		HWChannels 2
+		Channels 1
+		Channel0 0
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Line 3" {
+	Comment "Mono Line (input 2)"
+
+	Value {
+		CapturePriority 500
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "steinberg_ur22c_mono_in"
+		Direction Capture
+		HWChannels 2
+		Channels 1
+		Channel0 1
+		ChannelPos0 MONO
+	}
+}

--- a/ucm2/USB-Audio/Steinberg/UR22C.conf
+++ b/ucm2/USB-Audio/Steinberg/UR22C.conf
@@ -1,0 +1,11 @@
+Comment "Steinberg UR22C USB-Audio"
+
+SectionUseCase."HiFi" {
+	Comment "HiFi"
+	File "/USB-Audio/Steinberg/UR22C-HiFi.conf"
+}
+
+Define.DirectPlaybackChannels 2
+Define.DirectCaptureChannels 2
+
+Include.dhw.File "/common/direct.conf"

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -113,6 +113,15 @@ If.gigabyte-aorus-main {
 	True.Define.ProfileName "Gigabyte/Aorus-Master-Main-Audio"
 }
 
+If.steinberg-ur22c {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB0499:172f"
+	}
+	True.Define.ProfileName "Steinberg/UR22C"
+}
+
 If.steinberg-ur24c {
 	Condition {
 		Type String


### PR DESCRIPTION
Similar to UR24C and UR44C, but with 2 inputs 2 outputs.

Signed-off-by: Celeste Liu <CoelacanthusHex@gmail.com>