### PR TITLE
acppdmmach: add support for ACP 7.0

### DIFF
--- a/ucm2/HDA/HDA.conf
+++ b/ucm2/HDA/HDA.conf
@@ -3,7 +3,7 @@ Syntax 6
 Define.Use ""	# a non-empty string to use UCM configuration for HDA devices
 Define.Done ""	# a non-empty string to skip the end error
 
-Define.AcpCardId "$${find-card:field=name,return=id,regex='^acp(|6[23x])$'}"
+Define.AcpCardId "$${find-card:field=name,return=id,regex='^acp(|6[23x]|-pdm-mach)$'}"
 Define.DeviceMic "Mic"
 
 If.dualcodec {

--- a/ucm2/conf.d/acp-pdm-mach/acp-pdm-mach.conf
+++ b/ucm2/conf.d/acp-pdm-mach/acp-pdm-mach.conf
@@ -1,0 +1,1 @@
+../../common/linked-card.conf


### PR DESCRIPTION
Starting with ACP 7.0 there is a generic 'acppdmmach' driver that will be utilized.