### PR TITLE
Revert "ucm2: Qualcomm: x1e80100: add USB DisplayPort playback"

### DIFF
--- a/ucm2/Qualcomm/x1e80100/HiFi.conf
+++ b/ucm2/Qualcomm/x1e80100/HiFi.conf
@@ -3,8 +3,6 @@
 
 SectionVerb {
 	EnableSequence [
-		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia1' 0"
-		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia1' 0"
 		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia1' 1"
 		cset "name='WSA_CODEC_DMA_RX_0 Audio Mixer MultiMedia2' 1"
 		cset "name='MultiMedia3 Mixer TX_CODEC_DMA_TX_3' 1"
@@ -41,23 +39,10 @@ SectionDevice."Speaker" {
 SectionDevice."Headphones" {
 	Comment "Headphones playback"
 
-	ConflictingDevice [
-		"HDMI0"
-		"HDMI1"
-	]
-
 	Include.wcdhpe.File "/codecs/wcd938x/HeadphoneEnableSeq.conf"
 	Include.wcdhpd.File "/codecs/wcd938x/HeadphoneDisableSeq.conf"
 	Include.rxmhpe.File "/codecs/qcom-lpass/rx-macro/HeadphoneEnableSeq.conf"
 	Include.rxmhpd.File "/codecs/qcom-lpass/rx-macro/HeadphoneDisableSeq.conf"
-
-	EnableSequence [
-		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia1' 1"
-	]
-
-	DisableSequence [
-		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia1' 0"
-	]
 
 	Value {
 		PlaybackPriority 200
@@ -104,51 +89,5 @@ SectionDevice."Mic" {
 	Value {
 		CapturePriority 100
 		CapturePCM "hw:${CardId},3"
-	}
-}
-
-SectionDevice."HDMI0" {
-	Comment "USB/DisplayPort 0 playback"
-
-	ConflictingDevice [
-		"Headphones"
-		"HDMI1"
-	]
-
-	EnableSequence [
-		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia1' 1"
-	]
-
-	DisableSequence [
-		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia1' 0"
-	]
-
-	Value {
-		PlaybackPriority 200
-		PlaybackPCM "hw:${CardId},0"
-		JackControl "DP0 Jack"
-	}
-}
-
-SectionDevice."HDMI1" {
-	Comment "USB/DisplayPort 1 playback"
-
-	ConflictingDevice [
-		"Headphones"
-		"HDMI0"
-	]
-
-	EnableSequence [
-		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia1' 1"
-	]
-
-	DisableSequence [
-		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia1' 0"
-	]
-
-	Value {
-		PlaybackPriority 100
-		PlaybackPCM "hw:${CardId},0"
-		JackControl "DP1 Jack"
 	}
 }


### PR DESCRIPTION
This reverts commit 1dcb58e4fac989bafe0705e49a7f029727207fb3.

The recently added DisplayPort support depends on kernel changes that never made it upstream and has some usability issues that remain to be resolved.

Revert for now to avoid breaking existing setups.