### PR TITLE
Qualcomm: fix codec initialisation

### DIFF
--- a/ucm2/Qualcomm/sm8550/HDK/SM8550-HDK.conf
+++ b/ucm2/Qualcomm/sm8550/HDK/SM8550-HDK.conf
@@ -17,7 +17,7 @@ BootSequence [
 
 Include.card-init.File "/lib/card-init.conf"
 Include.ctl-remap.File "/lib/ctl-remap.conf"
-Include.codec-init.File "/codecs/wsa884x/two-speakers/init.conf"
-Include.codec-init.File "/codecs/wcd938x/init.conf"
-Include.codec-init.File "/codecs/qcom-lpass/wsa-macro/init.conf"
-Include.codec-init.File "/codecs/qcom-lpass/rx-macro/init.conf"
+Include.wsa-init.File "/codecs/wsa884x/two-speakers/init.conf"
+Include.wcd-init.File "/codecs/wcd938x/init.conf"
+Include.wsam-init.File "/codecs/qcom-lpass/wsa-macro/init.conf"
+Include.rxm-init.File "/codecs/qcom-lpass/rx-macro/init.conf"

--- a/ucm2/Qualcomm/sm8650/MTP/SM8650-MTP.conf
+++ b/ucm2/Qualcomm/sm8650/MTP/SM8650-MTP.conf
@@ -7,5 +7,5 @@ SectionUseCase."HiFi" {
 
 Include.card-init.File "/lib/card-init.conf"
 Include.ctl-remap.File "/lib/ctl-remap.conf"
-Include.codec-init.File "/codecs/wsa884x/two-speakers/init.conf"
-Include.codec-init.File "/codecs/qcom-lpass/wsa-macro/init.conf"
+Include.wsa-init.File "/codecs/wsa884x/two-speakers/init.conf"
+Include.wsam-init.File "/codecs/qcom-lpass/wsa-macro/init.conf"

--- a/ucm2/Qualcomm/sm8650/QRD/SM8650-QRD.conf
+++ b/ucm2/Qualcomm/sm8650/QRD/SM8650-QRD.conf
@@ -7,7 +7,7 @@ SectionUseCase."HiFi" {
 
 Include.card-init.File "/lib/card-init.conf"
 Include.ctl-remap.File "/lib/ctl-remap.conf"
-Include.codec-init.File "/codecs/wsa884x/two-speakers/init.conf"
-Include.codec-init.File "/codecs/wcd939x/init.conf"
-Include.codec-init.File "/codecs/qcom-lpass/wsa-macro/init.conf"
-Include.codec-init.File "/codecs/qcom-lpass/rx-macro/init.conf"
+Include.wsa-init.File "/codecs/wsa884x/two-speakers/init.conf"
+Include.wcd-init.File "/codecs/wcd939x/init.conf"
+Include.wsam-init.File "/codecs/qcom-lpass/wsa-macro/init.conf"
+Include.rxm-init.File "/codecs/qcom-lpass/rx-macro/init.conf"


### PR DESCRIPTION
Fix the Qualcomm configurations that are using the same identifier for lazy includes of codec initialisation files which means that only the last one is actually included.