### PR TITLE
Update ucm conf for MediaTek Genio platforms

### DIFF
--- a/ucm2/MediaTek/mt8370-evk/HiFi.conf
+++ b/ucm2/MediaTek/mt8370-evk/HiFi.conf
@@ -1,37 +1,53 @@
-SectionDevice."HDMI1" {
-	Comment "HDMI output"
-
-	Value {
-		PlaybackPriority 300
-		PlaybackPCM "hw:${CardId},5"
-		JackControl "HDMI Jack"
+If.HDMI {
+	Condition {
+		Type ControlExists
+		Control "iface=CARD,name='HDMI Jack'"
 	}
+	True {
+		SectionDevice."HDMI1" {
+			Comment "HDMI output"
 
-	EnableSequence [
-		cset "name='HDMI_OUT_MUX' 1"
-	]
+			EnableSequence [
+				cset "name='HDMI_OUT_MUX' 1"
+			]
 
-	DisableSequence [
-		cset "name='HDMI_OUT_MUX' 0"
-	]
+			DisableSequence [
+				cset "name='HDMI_OUT_MUX' 0"
+			]
+
+			Value {
+				PlaybackPriority 300
+				PlaybackPCM "hw:${CardId},5"
+				JackControl "HDMI Jack"
+			}
+		}
+	}
 }
 
-SectionDevice."HDMI2" {
-	Comment "DP output"
-
-	Value {
-		PlaybackPriority 300
-		PlaybackPCM "hw:${CardId},5"
-		JackControl "DP Jack"
+If.DP {
+	Condition {
+		Type ControlExists
+		Control "iface=CARD,name='DP Jack'"
 	}
+	True {
+		SectionDevice."HDMI2" {
+			Comment "DP output"
 
-	EnableSequence [
-		cset "name='DPTX_OUT_MUX' 1"
-	]
+			EnableSequence [
+				cset "name='DPTX_OUT_MUX' 1"
+			]
 
-	DisableSequence [
-		cset "name='DPTX_OUT_MUX' 0"
-	]
+			DisableSequence [
+				cset "name='DPTX_OUT_MUX' 0"
+			]
+
+			Value {
+				PlaybackPriority 300
+				PlaybackPCM "hw:${CardId},5"
+				JackControl "DP Jack"
+			}
+		}
+	}
 }
 
 SectionDevice."Speaker" {

--- a/ucm2/MediaTek/mt8370-evk/HiFi.conf
+++ b/ucm2/MediaTek/mt8370-evk/HiFi.conf
@@ -91,6 +91,7 @@ SectionDevice."Headphones" {
 		PlaybackPriority 500
 		PlaybackChannels 2
 		PlaybackPCM "hw:${CardId},0"
+		JackControl "Headphone Jack"
 	}
 }
 
@@ -109,6 +110,7 @@ SectionDevice."Headset" {
 		CapturePriority 500
 		CaptureChannels 1
 		CapturePCM "hw:${CardId},10"
+		JackControl "Headset Mic Jack"
 	}
 }
 

--- a/ucm2/MediaTek/mt8390-evk/HiFi.conf
+++ b/ucm2/MediaTek/mt8390-evk/HiFi.conf
@@ -1,37 +1,53 @@
-SectionDevice."HDMI1" {
-	Comment "HDMI output"
-
-	Value {
-		PlaybackPriority 300
-		PlaybackPCM "hw:${CardId},5"
-		JackControl "HDMI Jack"
+If.HDMI {
+	Condition {
+		Type ControlExists
+		Control "iface=CARD,name='HDMI Jack'"
 	}
+	True {
+		SectionDevice."HDMI1" {
+			Comment "HDMI output"
 
-	EnableSequence [
-		cset "name='HDMI_OUT_MUX' 1"
-	]
+			EnableSequence [
+				cset "name='HDMI_OUT_MUX' 1"
+			]
 
-	DisableSequence [
-		cset "name='HDMI_OUT_MUX' 0"
-	]
+			DisableSequence [
+				cset "name='HDMI_OUT_MUX' 0"
+			]
+
+			Value {
+				PlaybackPriority 300
+				PlaybackPCM "hw:${CardId},5"
+				JackControl "HDMI Jack"
+			}
+		}
+	}
 }
 
-SectionDevice."HDMI2" {
-	Comment "DP output"
-
-	Value {
-		PlaybackPriority 300
-		PlaybackPCM "hw:${CardId},5"
-		JackControl "DP Jack"
+If.DP {
+	Condition {
+		Type ControlExists
+		Control "iface=CARD,name='DP Jack'"
 	}
+	True {
+		SectionDevice."HDMI2" {
+			Comment "DP output"
 
-	EnableSequence [
-		cset "name='DPTX_OUT_MUX' 1"
-	]
+			EnableSequence [
+				cset "name='DPTX_OUT_MUX' 1"
+			]
 
-	DisableSequence [
-		cset "name='DPTX_OUT_MUX' 0"
-	]
+			DisableSequence [
+				cset "name='DPTX_OUT_MUX' 0"
+			]
+
+			Value {
+				PlaybackPriority 300
+				PlaybackPCM "hw:${CardId},5"
+				JackControl "DP Jack"
+			}
+		}
+	}
 }
 
 SectionDevice."Speaker" {

--- a/ucm2/MediaTek/mt8390-evk/HiFi.conf
+++ b/ucm2/MediaTek/mt8390-evk/HiFi.conf
@@ -91,6 +91,7 @@ SectionDevice."Headphones" {
 		PlaybackPriority 500
 		PlaybackChannels 2
 		PlaybackPCM "hw:${CardId},0"
+		JackControl "Headphone Jack"
 	}
 }
 
@@ -109,6 +110,7 @@ SectionDevice."Headset" {
 		CapturePriority 500
 		CaptureChannels 1
 		CapturePCM "hw:${CardId},10"
+		JackControl "Headset Mic Jack"
 	}
 }
 

--- a/ucm2/MediaTek/mt8395-evk/HiFi.conf
+++ b/ucm2/MediaTek/mt8395-evk/HiFi.conf
@@ -100,6 +100,7 @@ SectionDevice."Headphones" {
 		PlaybackPriority 400
 		PlaybackChannels 2
 		PlaybackPCM "hw:${CardId},0"
+		JackControl "Headphone Jack"
 	}
 }
 
@@ -118,6 +119,7 @@ SectionDevice."Headset" {
 		CapturePriority 500
 		CaptureChannels 3
 		CapturePCM "hw:${CardId},15"
+		JackControl "Headset Mic Jack"
 	}
 }
 

--- a/ucm2/MediaTek/mt8395-evk/HiFi.conf
+++ b/ucm2/MediaTek/mt8395-evk/HiFi.conf
@@ -1,37 +1,53 @@
-SectionDevice."HDMI1" {
-	Comment "HDMI output"
-
-	Value {
-		PlaybackPriority 200
-		PlaybackPCM "hw:${CardId},5"
-		JackControl "HDMI Jack"
+If.HDMI {
+	Condition {
+		Type ControlExists
+		Control "iface=CARD,name='HDMI Jack'"
 	}
+	True {
+		SectionDevice."HDMI1" {
+			Comment "HDMI output"
 
-	EnableSequence [
-		cset "name='HDMI_OUT_MUX' 1"
-	]
+			EnableSequence [
+				cset "name='HDMI_OUT_MUX' 1"
+			]
 
-	DisableSequence [
-		cset "name='HDMI_OUT_MUX' 0"
-	]
+			DisableSequence [
+				cset "name='HDMI_OUT_MUX' 0"
+			]
+
+			Value {
+				PlaybackPriority 200
+				PlaybackPCM "hw:${CardId},5"
+				JackControl "HDMI Jack"
+			}
+		}
+	}
 }
 
-SectionDevice."HDMI2" {
-	Comment "DP output"
-
-	Value {
-		PlaybackPriority 200
-		PlaybackPCM "hw:${CardId},5"
-		JackControl "DP Jack"
+If.DP {
+	Condition {
+		Type ControlExists
+		Control "iface=CARD,name='DP Jack'"
 	}
+	True {
+		SectionDevice."HDMI2" {
+			Comment "DP output"
 
-	EnableSequence [
-		cset "name='DPTX_OUT_MUX' 1"
-	]
+			EnableSequence [
+				cset "name='DPTX_OUT_MUX' 1"
+			]
 
-	DisableSequence [
-		cset "name='DPTX_OUT_MUX' 0"
-	]
+			DisableSequence [
+				cset "name='DPTX_OUT_MUX' 0"
+			]
+
+			Value {
+				PlaybackPriority 200
+				PlaybackPCM "hw:${CardId},5"
+				JackControl "DP Jack"
+			}
+		}
+	}
 }
 
 SectionDevice."HDMI3" {


### PR DESCRIPTION
1. Add dynamic configuration to detect HDMI/DP devices for mt8370-evk, mt8390-evk and mt8395-evk.
2. Add headset jack detection support for mt8370-evk, mt8390-evk and mt8395-evk.