### PR TITLE
Add support for ASRock X870E Taichi

### DIFF
--- a/ucm2/USB-Audio/Realtek/ALC4080-HiFi.conf
+++ b/ucm2/USB-Audio/Realtek/ALC4080-HiFi.conf
@@ -115,7 +115,7 @@ If.asrock-taichi {
 	Condition {
 		Type RegexMatch
 		String "${CardComponents}"
-		Regex "USB(26ce:0a0[68])"
+		Regex "USB(26ce:0a0[68b])"
 	}
 	True.Define {
 		Line1Name ""

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -88,7 +88,8 @@ If.realtek-alc4080 {
 		# 0db0:d6e7 MSI MPG X670E Carbon Wifi
 		# 26ce:0a06 ASRock X670E/Z790 Taichi
 		# 26ce:0a08 ASRock Z790 PG-ITX/TB4
-		Regex "USB((0414:a0(0e|1[0124]))|(0b05:(19(84|9[69])|1a(16|2[07]|5[23c]|97|f1)))|(0db0:(005a|124b|151f|1feb|3130|36e7|4(19c|22d|240|88c)|543d|62a4|6c[0c]9|70d3|7696|82c7|8af7|961e|a(073|228|47c|74b)|b202|d1d7|d6e7))|(26ce:0a0[68]))"
+		# 26ce:0a0b ASRock X870E Taichi
+		Regex "USB((0414:a0(0e|1[0124]))|(0b05:(19(84|9[69])|1a(16|2[07]|5[23c]|97|f1)))|(0db0:(005a|124b|151f|1feb|3130|36e7|4(19c|22d|240|88c)|543d|62a4|6c[0c]9|70d3|7696|82c7|8af7|961e|a(073|228|47c|74b)|b202|d1d7|d6e7))|(26ce:0a0[68b]))"
 	}
 	True.Define.ProfileName "Realtek/ALC4080"
 }


### PR DESCRIPTION
Included id 26ce:0a0b to realtek-alc4080 list.
USB Audio S/PDIF Output, USB Audio Rear input and USB Audio Front Headphones seems to work now without issues with HiFi 2.0 channels.