### PR TITLE
USB-Audio: ALC4080: Add support for MSI MPG X870E CARBON WIFI (0db0:0b58)

### DIFF
--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -83,6 +83,7 @@ If.realtek-alc4080 {
 		# 0db0:a228 MSI MPG Z590M GAMING EDGE WIFI
 		# 0db0:a47c MSI MEG X570S Ace Max
 		# 0db0:a74b MSI MPG Z790 Edge Wifi
+		# 0db0:0b58 MSI MPG X870E CARBON WIFI
 		# 0db0:b202 MSI MAG Z690 Tomahawk Wifi
 		# 0db0:cd0e MSI X870 Tomahawk
 		# 0db0:d1d7 MSI PRO Z790-A WIFI
@@ -90,7 +91,7 @@ If.realtek-alc4080 {
 		# 26ce:0a06 ASRock X670E/Z790 Taichi
 		# 26ce:0a08 ASRock Z790 PG-ITX/TB4
 		# 26ce:0a0b ASRock X870E Taichi
-		Regex "USB((0414:a0(0e|1[0124]))|(0b05:(19(84|9[69])|1a(16|2[07]|5[23c]|97|f1)))|(0db0:(005a|124b|151f|1feb|3130|36e7|4(19c|22d|240|88c)|543d|62a4|6c[0c]9|70d3|7696|82c7|8af7|961e|a(073|228|47c|74b)|b202|cd0e|d1d7|d6e7))|(26ce:0a0[68b]))"
+		Regex "USB((0414:a0(0e|1[0124]))|(0b05:(19(84|9[69])|1a(16|2[07]|5[23c]|97|f1)))|(0db0:(005a|124b|151f|1feb|3130|36e7|4(19c|22d|240|88c)|543d|62a4|6c[0c]9|70d3|7696|82c7|8af7|961e|a(073|228|47c|74b)|0b58|b202|cd0e|d1d7|d6e7))|(26ce:0a0[68b]))"
 	}
 	True.Define.ProfileName "Realtek/ALC4080"
 }


### PR DESCRIPTION
This PR updates the regex for MSI MPG X870E CARBON WIFI motherboard.

```
$ lsusb | ag audio
Bus 003 Device 007: ID 0db0:0b58 Micro Star International USB Audio
```

```
Audio	Realtek® ALC4080 Codec
```
https://www.msi.com/Motherboard/MPG-X870E-CARBON-WIFI/Specification