### PR TITLE
Change 26ce:0a08 to list multiple motherboards

### DIFF
--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -89,7 +89,7 @@ If.realtek-alc4080 {
 		# 0db0:d1d7 MSI PRO Z790-A WIFI
 		# 0db0:d6e7 MSI MPG X670E Carbon Wifi
 		# 26ce:0a06 ASRock X670E/Z790 Taichi
-		# 26ce:0a08 ASRock Z790 PG-ITX/TB4
+		# 26ce:0a08 ASRock [Z790 PG-ITX/TB4, X870 Steel Legend]
 		# 26ce:0a0b ASRock X870E Taichi
 		Regex "USB((0414:a0(0e|1[0124]))|(0b05:(19(84|9[69])|1a(16|2[07]|5[23c]|97|f1)))|(0db0:(005a|0b58|124b|151f|1feb|3130|36e7|4(19c|22d|240|88c)|543d|62a4|6c[0c]9|70d3|7696|82c7|8af7|961e|a(073|228|47c|74b)|b202|cd0e|d1d7|d6e7))|(26ce:0a0[68b]))"
 	}


### PR DESCRIPTION
The hardware id `26ce:0a08` seems to be re-used by multiple motherboards at ASRock. Identify them within `[brackets]` to point out the specific boards in question.