### PR TITLE
UCM2: Intel: sof-hda-dsp: Fix handling of empty sys_vendor string

### DIFF
--- a/ucm2/Intel/sof-hda-dsp/HiFi-sof.conf
+++ b/ucm2/Intel/sof-hda-dsp/HiFi-sof.conf
@@ -6,8 +6,8 @@ Define.SOFVendor "$${sys:devices/virtual/dmi/id/sys_vendor}"
 
 If.SOFVendor {
 	Condition {
-		Type Empty
-		String "${var:SOFVendor}"
+		Type String
+		Empty "${var:SOFVendor}"
 	}
 	True.Define.SOFVendor "${sys:devices/virtual/dmi/id/board_vendor}"
 }


### PR DESCRIPTION
The mistake in UCM syntax caused in alsaucm start error:

ALSA lib ucm_cond.c:367:(if_eval) unknown If.Condition.Type

Fixes: 13022a97711d ("sof-hda-dsp: Fix the case where sysfs dmi
       sys_vendor attribute is not set")