### PR TITLE
Fix JackControl name

### DIFF
--- a/ucm2/Intel/avs/avs_nau8825/avs_nau8825-HiFi.conf
+++ b/ucm2/Intel/avs/avs_nau8825/avs_nau8825-HiFi.conf
@@ -21,7 +21,7 @@ SectionDevice."Mic" {
 	Value {
 		CapturePCM "hw:${CardId},1"
 		CaptureCTL "Mic"
-		JackControl "Headset Mic"
+		JackControl "Headset Mic Jack"
 	}
 
 	EnableSequence [


### PR DESCRIPTION
Not sure whether it makes a difference but that is the name reported by `amixer events`.