### PR TITLE
sof-soundwire: cs42l43-spk: Correct PlaybackPCM and routing

### DIFF
--- a/ucm2/sof-soundwire/cs42l43-spk.conf
+++ b/ucm2/sof-soundwire/cs42l43-spk.conf
@@ -8,8 +8,8 @@ SectionDevice."Speaker" {
 	]
 
 	EnableSequence [
-		cset "name='cs42l43 Speaker L Input 1' 'DP5RX1'"
-		cset "name='cs42l43 Speaker R Input 1' 'DP5RX2'"
+		cset "name='cs42l43 Speaker L Input 1' 'DP6RX1'"
+		cset "name='cs42l43 Speaker R Input 1' 'DP6RX2'"
 	]
 
 	DisableSequence [
@@ -19,7 +19,7 @@ SectionDevice."Speaker" {
 
 	Value {
 		PlaybackPriority 100
-		PlaybackPCM "hw:${CardId},0"
+		PlaybackPCM "hw:${CardId},2"
 		PlaybackMixerElem "cs42l43 Speaker Digital"
 	}
 }


### PR DESCRIPTION
For speaker the correct PCM device to use is "hw:${CardId},2", the "hw:${CardId},0" is for headset playback.

Adjust the routing as well since with :0,2 the DP6RX1/2 needs to be selected for the speaker.