### PR TITLE
sof-soundwire: cs42l43: Correct CapturePCM and routing

### DIFF
--- a/ucm2/sof-soundwire/cs42l43.conf
+++ b/ucm2/sof-soundwire/cs42l43.conf
@@ -28,19 +28,19 @@ SectionDevice."Headset" {
 		cset "name='cs42l43 ADC1 Input' 'IN1'"
 		cset "name='cs42l43 Decimator 1 Mode' 'ADC'"
 
-		cset "name='cs42l43 DP1TX1 Input' 'Decimator 1'"
-		cset "name='cs42l43 DP1TX2 Input' 'Decimator 1'"
+		cset "name='cs42l43 DP2TX1 Input' 'Decimator 1'"
+		cset "name='cs42l43 DP2TX2 Input' 'Decimator 1'"
 	]
 
 	DisableSequence [
 		cset "name='cs42l43 Decimator 1 Switch' 0"
-		cset "name='cs42l43 DP1TX1 Input' 'None'"
-		cset "name='cs42l43 DP1TX2 Input' 'None'"
+		cset "name='cs42l43 DP2TX1 Input' 'None'"
+		cset "name='cs42l43 DP2TX2 Input' 'None'"
 	]
 
 	Value {
 		CapturePriority 200
-		CapturePCM "hw:${CardId},4"
+		CapturePCM "hw:${CardId},1"
 		CaptureMixer "default:${CardId}"
 		CaptureMixerElem "cs42l43 Headset Microphone"
 		JackControl "Headset Mic Jack"


### PR DESCRIPTION
For headset microphone capture the correct PCM device to use is "hw:${CardId},1", "hw:${CardId},4" is for built in microphone capture.

Adjust the routing as well since :0,1 is connected to data port 2 on the codec.