### PR TITLE
UCM2 Profile for Roland BridgeCastX

### DIFF
--- a/ucm2/USB-Audio/Roland/BridgeCastXV2-Hifi.conf
+++ b/ucm2/USB-Audio/Roland/BridgeCastXV2-Hifi.conf
@@ -1,0 +1,174 @@
+Include.pcm_split.File "/common/pcm/split.conf"
+
+Macro [
+	{
+		SplitPCM {
+			Name "bc_stereo_out"
+			Direction Playback
+			Channels 2
+			HWChannels 16
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 FL
+			HWChannelPos3 FR
+			HWChannelPos4 FL
+			HWChannelPos5 FR
+			HWChannelPos6 FL
+			HWChannelPos7 FR
+			HWChannelPos6 FL
+			HWChannelPos7 FR
+			HWChannelPos8 FL
+			HWChannelPos9 FR
+			HWChannelPos10 FL
+			HWChannelPos11 FR
+			HWChannelPos12 FL
+			HWChannelPos13 FR
+			HWChannelPos14 FL
+			HWChannelPos15 FR
+		}
+	}
+	{
+		SplitPCM {
+			Name "bc_stereo_in"
+			Direction Capture
+			Channels 2
+			HWChannels 6
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 FL
+			HWChannelPos3 FR
+			HWChannelPos4 FL
+			HWChannelPos5 FR
+		}
+	}
+]
+
+SectionDevice."Line1" {
+	Comment "Chat L/R"
+
+	Value {
+		PlaybackPriority 100
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "bc_stereo_out"
+		Direction Playback
+		HWChannels 16
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line2" {
+	Comment "Game L/R"
+
+	Value {
+		PlaybackPriority 200
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "bc_stereo_out"
+		Direction Playback
+		HWChannels 16
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line3" {
+	Comment "Music L/R"
+
+	Value {
+		PlaybackPriority 300
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "bc_stereo_out"
+		Direction Playback
+		HWChannels 16
+		Channels 2
+		Channel0 12
+		Channel1 13
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line4" {
+	Comment "System L/R"
+
+	Value {
+		PlaybackPriority 400
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "bc_stereo_out"
+		Direction Playback
+		HWChannels 16
+		Channels 2
+		Channel0 10
+		Channel1 11
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line5" {
+	Comment "StreamMix"
+
+	Value {
+		CapturePriority 300
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "bc_stereo_in"
+		Direction Capture
+		HWChannels 6
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line6" {
+	Comment "Mic"
+
+	Value {
+		CapturePriority 200
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "bc_stereo_in"
+		Direction Capture
+		HWChannels 6
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line7" {
+	Comment "SFX"
+
+	Value {
+		CapturePriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "bc_stereo_in"
+		Direction Capture
+		HWChannels 6
+		Channels 2
+		Channel0 4
+		Channel1 5
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}

--- a/ucm2/USB-Audio/Roland/BridgeCastXV2.conf
+++ b/ucm2/USB-Audio/Roland/BridgeCastXV2.conf
@@ -1,0 +1,6 @@
+Comment "Roland BridgeCast Hifi-Mode"
+
+SectionUseCase."HiFi" {
+	Comment "BridgeCast MultiChannel"
+	File "/USB-Audio/Roland/BridgeCastXV2-Hifi.conf"
+}

--- a/ucm2/USB-Audio/Roland/BridgeCastXV2.conf
+++ b/ucm2/USB-Audio/Roland/BridgeCastXV2.conf
@@ -1,4 +1,4 @@
-Comment "Roland BridgeCast Hifi-Mode"
+Comment "Roland BridgeCast XV2 Hifi-Mode"
 
 SectionUseCase."HiFi" {
 	Comment "BridgeCast MultiChannel"

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -182,6 +182,15 @@ If.roland-bridgecastv2 {
 	True.Define.ProfileName "Roland/BridgeCastV2"
 }
 
+If.roland-bridgecastx {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB0582:0321"
+	}
+	True.Define.ProfileName "Roland/BridgeCastXV2"
+}
+
 If.motu-m246 {
 	Condition {
 		Type RegexMatch


### PR DESCRIPTION
Added Configuration for the X version of Bridge Cast. Config is based on the non X version but it's wired differently and has two more Hardware Channels. It's for the 2.0 Firmware of the Device. The "Game" channel has a virtual 5.1 mode which doesn't work properly and isn't configured.  

- Added condition to USB-Audio.conf
- Added BridgeCastXV2.conf
- Added BridgeCastXV2-Hifi.conf with configuration for channels