### PR TITLE
amd-soundwire: add support for AMD generic legacy machine driver

### DIFF
--- a/ucm2/amd-soundwire/HiFi.conf
+++ b/ucm2/amd-soundwire/HiFi.conf
@@ -1,0 +1,5 @@
+SectionVerb {
+        Value.TQ "HiFi"
+}
+
+<amd-soundwire/rt722-sdca.conf>

--- a/ucm2/amd-soundwire/amd-soundwire.conf
+++ b/ucm2/amd-soundwire/amd-soundwire.conf
@@ -1,0 +1,15 @@
+Syntax 3
+
+SectionUseCase."HiFi" {
+	File "/amd-soundwire/HiFi.conf"
+	Comment "AMD High Quality Music"
+}
+
+If.rt722_init {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "rt722"
+	}
+	True.Include.rt722_init.File "/codecs/rt722/init.conf"
+}

--- a/ucm2/amd-soundwire/rt722-sdca.conf
+++ b/ucm2/amd-soundwire/rt722-sdca.conf
@@ -1,0 +1,81 @@
+# Use case Configuration for amd-soundwire card
+
+If.RT722 {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "rt722" 
+	}
+	True {
+		SectionDevice."Headphones" {
+			Comment	"Headphones"
+
+			EnableSequence [
+				cset "name='Headphone Switch' on"
+			]
+
+			DisableSequence [
+				cset "name='Headphone Switch' off"
+			]
+
+			Value {
+				PlaybackPriority 200
+				PlaybackPCM "hw:${CardId}"
+				JackControl "Headphone Jack"
+			}
+		}
+
+		SectionDevice."Headset" {
+			Comment "Headset Microphone"
+
+			EnableSequence [
+				cset "name='Headset Mic Switch' on"
+				cset "name='rt722 FU0F Capture Switch' on"
+			]
+
+			DisableSequence [
+				cset "name='Headset Mic Switch' off"
+				cset "name='rt722 FU0F Capture Switch' off"
+			]
+
+			Value {
+				CapturePriority 200
+				CapturePCM "hw:${CardId},1"
+				JackControl "Headset Mic Jack"
+			}
+		}
+
+		SectionDevice."Speaker" {
+			Comment "Speaker"
+
+			EnableSequence [
+				cset "name='Speaker Switch' on"
+			]
+			DisableSequence [
+				cset "name='Speaker Switch' off"
+			]
+
+			Value {
+				PlaybackPriority 100
+				PlaybackPCM "hw:${CardId},2"
+			}
+		}
+
+		SectionDevice."InternalMic" {
+			Comment "Soundwire DMIC"
+
+			EnableSequence [
+				cset "name='rt722 FU1E Capture Switch' on"
+			]
+
+			DisableSequence [
+				cset "name='rt722 FU1E Capture Switch' off"
+			]
+
+			Value {
+				CapturePriority 200
+				CapturePCM "hw:${CardId},4"
+			}
+		}
+	}
+}

--- a/ucm2/conf.d/amd-soundwire/amd-soundwire.conf
+++ b/ucm2/conf.d/amd-soundwire/amd-soundwire.conf
@@ -1,0 +1,1 @@
+../../amd-soundwire/amd-soundwire.conf


### PR DESCRIPTION
Add support for AMD generic legacy(No DSP) machine driver for ACP6.3 platform using RT722 codec.