### PR TITLE
amd-soundwire: add support for AMD generic legacy machine driver

### DIFF
--- a/ucm2/conf.d/amd-soundwire/amd-soundwire.conf
+++ b/ucm2/conf.d/amd-soundwire/amd-soundwire.conf
@@ -1,0 +1,1 @@
+../../sof-soundwire/sof-soundwire.conf

--- a/ucm2/sof-soundwire/rt722.conf
+++ b/ucm2/sof-soundwire/rt722.conf
@@ -86,6 +86,21 @@ SectionDevice."Headset" {
 		cset "name='rt722 FU0F Capture Switch' 0"
 	]
 
+	If.hsmicsw {
+		Condition {
+			Type ControlExists
+			Control "name='Headset Mic Switch'"
+		}
+		True {
+			EnableSequence [
+				cset "name='Headset Mic Switch' on"
+			]
+			DisableSequence [
+				cset "name='Headset Mic Switch' off"
+			]
+		}
+	}
+
 	Value {
 		CapturePriority 200
 		CapturePCM "hw:${CardId},1"


### PR DESCRIPTION
The card components string is similar to Intel's SOF driver like, so we can  reuse sof-soundwire configuration and it is logical to reduce future maintenance, because the chips connected to soundwire bus are similar for multiple PCI bridges.

Example of the components string:

    Components : ' cfg-amp:1 hs:rt722 spk:rt722 mic:rt722'
