### PR TITLE
ucm2: sof-soundwire: Correct FixedBootSequence for dmic info

### DIFF
--- a/ucm2/sof-soundwire/sof-soundwire.conf
+++ b/ucm2/sof-soundwire/sof-soundwire.conf
@@ -156,10 +156,10 @@ If.mics-array {
 		Type String
 		Empty "${var:Mics1}"
 	}
-	False.FixedBootSequence {
+	False.FixedBootSequence [
 		# dmic array info
 		exec "-nhlt-dmic-info -o ${var:LibDir}/dmics-nhlt.json"
-	}
+	]
 }
 
 Include.hdmi-pcm.File "/common/pcm/hdmi.conf"


### PR DESCRIPTION
Replace the curly brackets with square brackets.
The curly ones break the FixedBootSequence parsing by resetting the sequence.
If the /var/lib/alsa/card0.conf.d is not present then UCM will fail because all sequences before the dmic is lost, including the card-init:

# alsactl init
alsa-lib main.c:619:(execute_cfgsave) unable to open file '/var/lib/alsa/card0.conf.d/42-sof-hdmi.conf': No such file or directory alsa-lib main.c:2456:(set_fixedboot_user) Unable to execute force boot sequence

The full sequence supposed to be:
card-init
ctl-remap
cs42l43
dmic
hdmi

Fixes: 9fa70add7638 ("sof-hda-dsp,sof-soundwire: add CaptureMicInfoFile fields for dmics")