### PR TITLE
USB-Audio: Add support for TASCAM Model 12

### DIFF
--- a/ucm2/USB-Audio/TASCAM/Model12-HiFi.conf
+++ b/ucm2/USB-Audio/TASCAM/Model12-HiFi.conf
@@ -1,0 +1,446 @@
+Include.pcm_split.File "/common/pcm/split.conf"
+
+Macro [
+	{
+		SplitPCM {
+			Name "model12_mono_in"
+			Direction Capture
+			Channels 1
+			HWChannels 12
+			HWChannelPos0 MONO
+			HWChannelPos1 MONO
+			HWChannelPos2 MONO
+			HWChannelPos3 MONO
+			HWChannelPos4 MONO
+			HWChannelPos5 MONO
+			HWChannelPos6 MONO
+			HWChannelPos7 MONO
+			HWChannelPos8 MONO
+			HWChannelPos9 MONO
+			HWChannelPos10 MONO
+			HWChannelPos11 MONO
+		}
+	}
+	{
+		SplitPCM {
+			Name "model12_stereo_in"
+			Direction Capture
+			Channels 2
+			HWChannels 12
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 FL
+			HWChannelPos3 FR
+			HWChannelPos4 FL
+			HWChannelPos5 FR
+			HWChannelPos6 FL
+			HWChannelPos7 FR
+			HWChannelPos8 FL
+			HWChannelPos9 FR
+			HWChannelPos10 FL
+			HWChannelPos11 FR
+		}
+	}
+	{
+		SplitPCM {
+			Name "model12_stereo_out"
+			Direction Playback
+			Channels 2
+			HWChannels 10
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 FL
+			HWChannelPos3 FR
+			HWChannelPos4 FL
+			HWChannelPos5 FR
+			HWChannelPos6 FL
+			HWChannelPos7 FR
+			HWChannelPos8 FL
+			HWChannelPos9 FR
+		}
+	}
+]
+
+SectionDevice."Mic1" {
+	Comment "Mono Input 1"
+
+	Value {
+		CapturePriority 1600
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "model12_mono_in"
+		Direction Capture
+		HWChannels 12
+		Channels 1
+		Channel0 0
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Mic2" {
+	Comment "Mono Input 2"
+
+	Value {
+		CapturePriority 1500
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "model12_mono_in"
+		Direction Capture
+		HWChannels 12
+		Channels 1
+		Channel0 1
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Mic3" {
+	Comment "Mono Input 3"
+
+	Value {
+		CapturePriority 1400
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "model12_mono_in"
+		Direction Capture
+		HWChannels 12
+		Channels 1
+		Channel0 2
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Mic4" {
+	Comment "Mono Input 4"
+
+	Value {
+		CapturePriority 1300
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "model12_mono_in"
+		Direction Capture
+		HWChannels 12
+		Channels 1
+		Channel0 3
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Mic5" {
+	Comment "Mono Input 5"
+
+	Value {
+		CapturePriority 1200
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "model12_mono_in"
+		Direction Capture
+		HWChannels 12
+		Channels 1
+		Channel0 4
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Mic6" {
+	Comment "Mono Input 6"
+
+	Value {
+		CapturePriority 1100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "model12_mono_in"
+		Direction Capture
+		HWChannels 12
+		Channels 1
+		Channel0 5
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Mic7" {
+	Comment "Mono Input 7"
+
+	Value {
+		CapturePriority 1000
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "model12_mono_in"
+		Direction Capture
+		HWChannels 12
+		Channels 1
+		Channel0 6
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Line1" {
+	Comment "Mono Input 8"
+
+	Value {
+		CapturePriority 900
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "model12_mono_in"
+		Direction Capture
+		HWChannels 12
+		Channels 1
+		Channel0 7
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Mic8" {
+	Comment "Mono Input 9"
+
+	Value {
+		CapturePriority 800
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "model12_mono_in"
+		Direction Capture
+		HWChannels 12
+		Channels 1
+		Channel0 8
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Line2" {
+	Comment "Mono Input 10"
+
+	Value {
+		CapturePriority 700
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "model12_mono_in"
+		Direction Capture
+		HWChannels 12
+		Channels 1
+		Channel0 9
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Line3" {
+	Comment "Stereo Input 1/2"
+	
+	ConflictingDevice [
+		"Mic1"
+		"Mic2"
+	]
+	
+	Value {
+		CapturePriority 500
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "model12_stereo_in"
+		Direction Capture
+		HWChannels 12
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line4" {
+	Comment "Stereo Input 3/4"
+	
+	ConflictingDevice [
+		"Mic3"
+		"Mic4"
+	]
+	
+	Value {
+		CapturePriority 400
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "model12_stereo_in"
+		Direction Capture
+		HWChannels 12
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line5" {
+	Comment "Stereo Input 5/6"
+	
+	ConflictingDevice [
+		"Mic5"
+		"Mic6"
+	]
+	
+	Value {
+		CapturePriority 300
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "model12_stereo_in"
+		Direction Capture
+		HWChannels 12
+		Channels 2
+		Channel0 4
+		Channel1 5
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line6" {
+	Comment "Stereo Input 7/8"
+	
+	ConflictingDevice [
+		"Mic7"
+		"Line1"
+	]
+	
+	Value {
+		CapturePriority 200
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "model12_stereo_in"
+		Direction Capture
+		HWChannels 12
+		Channels 2
+		Channel0 6
+		Channel1 7
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line7" {
+	Comment "Stereo Input 9/10"
+	
+	ConflictingDevice [
+		"Mic8"
+		"Line2"
+	]
+	
+	Value {
+		CapturePriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "model12_stereo_in"
+		Direction Capture
+		HWChannels 12
+		Channels 2
+		Channel0 8
+		Channel1 9
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line8" {
+	Comment "Stereo Mix"
+	
+	Value {
+		CapturePriority 600
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "model12_stereo_in"
+		Direction Capture
+		HWChannels 12
+		Channels 2
+		Channel0 10
+		Channel1 11
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+
+SectionDevice."Line9" {
+	Comment "Stereo Output 1/2"
+
+	Value {
+		PlaybackPriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "model12_stereo_out"
+		Direction Playback
+		HWChannels 10
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line10" {
+	Comment "Stereo Output 3/4"
+
+	Value {
+		PlaybackPriority 200
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "model12_stereo_out"
+		Direction Playback
+		HWChannels 10
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line11" {
+	Comment "Stereo Output 5/6"
+
+	Value {
+		PlaybackPriority 300
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "model12_stereo_out"
+		Direction Playback
+		HWChannels 10
+		Channels 2
+		Channel0 4
+		Channel1 5
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line12" {
+	Comment "Stereo Output 7/8"
+
+	Value {
+		PlaybackPriority 400
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "model12_stereo_out"
+		Direction Playback
+		HWChannels 10
+		Channels 2
+		Channel0 6
+		Channel1 7
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line13" {
+	Comment "Stereo Output 9/10"
+
+	Value {
+		PlaybackPriority 500
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "model12_stereo_out"
+		Direction Playback
+		HWChannels 10
+		Channels 2
+		Channel0 8
+		Channel1 9
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}

--- a/ucm2/USB-Audio/TASCAM/Model12.conf
+++ b/ucm2/USB-Audio/TASCAM/Model12.conf
@@ -1,0 +1,11 @@
+Comment "TASCAM Model 12"
+
+SectionUseCase."HiFi" {
+	Comment "Default Alsa Profile"
+	File "/USB-Audio/TASCAM/Model12-HiFi.conf"
+}
+
+Define.DirectPlaybackChannels 10
+Define.DirectCaptureChannels 12
+
+Include.dhw.File "/common/direct.conf"

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -193,6 +193,15 @@ If.roland-bridgecastx {
 	True.Define.ProfileName "Roland/BridgeCastXV2"
 }
 
+If.tascam-m12 {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB0644:805f"
+	}
+	True.Define.ProfileName "TASCAM/Model12"
+}
+
 If.motu-m246 {
 	Condition {
 		Type RegexMatch


### PR DESCRIPTION
Adds support for the TASCAM Model 12 USB multi-track mixer. Couple of things to note:
- This profile assumes the "USB AUDIO" setting on the mixer itself is set to "MULTI INPUT".
- Under the "MULTI INPUT" mode, this mixer has 12 logical input channels (Last two are a stereo mix) and 10 logical output channels.
- Most of the accessible I/O is combo XLR/TRS jacks, so I opted to have the mono capture devices (With the exception of physical inputs 8 and 10 which are TRS only) named as "Mic" with the rest as "Line".

Otherwise, the profile is tested and working with the latest USB-Audio profiles.

[alsa-info.txt](https://github.com/user-attachments/files/18207924/alsa-info.txt)
