### PR TITLE
sun4i-codec: add routing for headphones and internal speaker

### DIFF
--- a/ucm2/Allwinner/sun4i-h616/HiFi.conf
+++ b/ucm2/Allwinner/sun4i-h616/HiFi.conf
@@ -1,0 +1,35 @@
+SectionDevice."Speaker" {
+	Comment "Internal Speaker"
+
+	EnableSequence [
+		cset "name='Speaker Switch' on"
+	]
+
+	Value {
+		PlaybackMixerElem "Line Out"
+		PlaybackPCM "hw:${CardId},0"
+	}
+
+	DisableSequence [
+		cset "name='Speaker Switch' off"
+	]
+
+	ConflictingDevice [
+		"Headphones"
+	]
+}
+
+
+SectionDevice."Headphones" {
+	Comment "Headphones"
+
+	Value {
+		PlaybackMixerElem "Line Out"
+		PlaybackPCM "hw:${CardId},0"
+		JackControl "Headphone Jack"
+	}
+
+	ConflictingDevice [
+		"Speaker"
+	]
+}

--- a/ucm2/conf.d/sun4i-codec/h616-audio-codec.conf
+++ b/ucm2/conf.d/sun4i-codec/h616-audio-codec.conf
@@ -1,0 +1,8 @@
+# UCM for Allwinner H616 Codec
+
+Syntax 3
+
+SectionUseCase."HiFi" {
+	File "/Allwinner/sun4i-h616/HiFi.conf"
+	Comment "Play HiFi quality Music"
+}


### PR DESCRIPTION
The sun4i-codec kernel driver covers a large number of Allwinner SoCs. The H616 codec has a single line-out route, which is used in concert with a Toshiba mux chip to send audio to either an internal speaker or headphone jack on a number of Anbernic handheld gaming devices.

Add a UCM configuration to allow enabling/disabling the speaker amp depending on whether headphones are in use or not.