### PR TITLE
USB-Audio: ALC4080 - add ASUS ROG Crosshair X870E Hero (USB 0b05:1b7c)

### DIFF
--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -61,6 +61,7 @@ If.realtek-alc4080 {
 		# 0b05:1a97 ASUS ROG Maximus Z790 Apex Encore
 		# 0b05:1af1 ASUS ROG Strix Z790-A Gaming Wifi II
 		# 0b05:1b9b ASUS ROG STRIX X870E-E GAMING WIFI
+		# 0b05:1b7c ASUS ROG Crosshair X870E Hero
 		# 0db0:005a MSI MPG Z690 CARBON WIFI
 		# 0db0:0b58 MSI MPG X870E CARBON WIFI
 		# 0db0:124b MSI MEG Z690 ACE
@@ -93,7 +94,7 @@ If.realtek-alc4080 {
 		# 26ce:0a06 ASRock X670E/Z790 Taichi
 		# 26ce:0a08 ASRock Z790 PG-ITX/TB4, X870 Steel Legend
 		# 26ce:0a0b ASRock X870E Taichi
-		Regex "USB((0414:a0(0e|1[0124]))|(0b05:(19(84|9[69])|1a(16|2[07]|5[23c]|97|f1)|1b9b))|(0db0:(005a|0b58|124b|151f|1feb|3130|36e7|4(19c|22d|240|88c)|543d|62a4|6c[0c]9|70d3|7696|82c7|8af7|961e|a(073|228|47c|74b)|b202|cd0e|d1d7|d6e7|e1f8))|(26ce:0a0[68b]))"
+		Regex "USB((0414:a0(0e|1[0124]))|(0b05:(19(84|9[69])|1a(16|2[07]|5[23c]|97|f1)|1b(9b|7c)))|(0db0:(005a|0b58|124b|151f|1feb|3130|36e7|4(19c|22d|240|88c)|543d|62a4|6c[0c]9|70d3|7696|82c7|8af7|961e|a(073|228|47c|74b)|b202|cd0e|d1d7|d6e7|e1f8))|(26ce:0a0[68b]))"
 	}
 	True.Define.ProfileName "Realtek/ALC4080"
 }


### PR DESCRIPTION
https://rog.asus.com/motherboards/rog-crosshair/rog-crosshair-x870e-hero/