### PR TITLE
ucm2: USB-Audio: add Presonus Revelator IO 44 (USB194f:0424)

### DIFF
--- a/ucm2/USB-Audio/Presonus/Revelator-IO-44-HiFi.conf
+++ b/ucm2/USB-Audio/Presonus/Revelator-IO-44-HiFi.conf
@@ -1,0 +1,199 @@
+Include.pcm_split.File "/common/pcm/split.conf"
+
+Macro [
+	{
+		SplitPCM {
+			Name "revelator_stereo_out"
+			Direction Playback
+			Channels 2
+			HWChannels 6
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 FL
+			HWChannelPos3 FR
+			HWChannelPos4 FL
+			HWChannelPos5 FR
+		}
+	}
+	{
+		SplitPCM {
+			Name "revelator_stereo_in"
+			Direction Capture
+			Channels 2
+			HWChannels 8
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 FL
+			HWChannelPos3 FR
+			HWChannelPos4 FL
+			HWChannelPos5 FR
+			HWChannelPos6 FL
+			HWChannelPos7 FR
+		}
+	}
+	{
+		SplitPCM {
+			Name "revelator_mono_in"
+			Direction Capture
+			Channels 1
+			HWChannels 8
+			HWChannelPos0 MONO
+			HWChannelPos1 MONO
+			HWChannelPos2 MONO
+			HWChannelPos3 MONO
+			HWChannelPos4 MONO
+			HWChannelPos5 MONO
+			HWChannelPos6 MONO
+			HWChannelPos7 MONO
+		}
+	}
+]
+
+SectionDevice."Playback" {
+	Comment "Playback L/R"
+
+	Value {
+		PlaybackPriority 100
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "revelator_stereo_out"
+		Direction Playback
+		HWChannels 2
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."VirtualOutputA" {
+	Comment "Virtual Output A L/R"
+
+	Value {
+		PlaybackPriority 200
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "revelator_stereo_out"
+		Direction Playback
+		HWChannels 2
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."VirtualOutputB" {
+	Comment "Virtual Output B L/R"
+
+	Value {
+		PlaybackPriority 300
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "revelator_stereo_out"
+		Direction Playback
+		HWChannels 2
+		Channels 2
+		Channel0 4
+		Channel1 5
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Microphone" {
+	Comment "Microphone"
+
+	Value {
+		CapturePriority 100
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "revelator_mono_in"
+		Direction Capture
+		HWChannels 8
+		Channels 1
+		Channel0 0
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."HeadsetMic" {
+	Comment "Headset Mic"
+
+	Value {
+		CapturePriority 200
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "revelator_mono_in"
+		Direction Capture
+		HWChannels 8
+		Channels 1
+		Channel0 1
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."LineIn" {
+	Comment "Line In L/R"
+
+	Value {
+		CapturePriority 300
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "revelator_stereo_in"
+		Direction Capture
+		HWChannels 8
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."StreamMixA" {
+	Comment "Stream Mix A L/R"
+
+	Value {
+		CapturePriority 400
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "revelator_stereo_in"
+		Direction Capture
+		HWChannels 8
+		Channels 2
+		Channel0 4
+		Channel1 5
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."StreamMixB" {
+	Comment "Stream Mix B L/R"
+
+	Value {
+		CapturePriority 500
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "revelator_stereo_in"
+		Direction Capture
+		HWChannels 8
+		Channels 2
+		Channel0 6
+		Channel1 7
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+

--- a/ucm2/USB-Audio/Presonus/Revelator-IO-44.conf
+++ b/ucm2/USB-Audio/Presonus/Revelator-IO-44.conf
@@ -1,0 +1,12 @@
+Comment "Presonus Revelator IO 44"
+
+SectionUseCase."HiFi" {
+	Comment "Default"
+
+	File "/USB-Audio/Presonus/Revelator-IO-44-HiFi.conf"
+}
+
+Define.DirectPlaybackChannels 6
+Define.DirectCaptureChannels 8
+
+Include.dhw.File "/common/direct.conf"

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -477,6 +477,17 @@ If.ssl2plus {
 	}
 }
 
+If.revelator {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB194f:0424"
+	}
+	True.Define {
+		ProfileName "Presonus/Revelator-IO-44"
+	}
+}
+
 If.mixremap {
 	Condition {
 		Type String


### PR DESCRIPTION
[alsa-info.txt](https://github.com/user-attachments/files/18306150/alsa-info.txt)

This adds support for [Presonus Revelator io44](https://eu.presonus.com/products/revelator-io44). This device has 3 virtual stereo channels out and 4 virtual stereo channels in as follows:

![out](https://github.com/user-attachments/assets/f4cacf14-e75e-4d33-ad64-cca4ca7ee18e)
![in](https://github.com/user-attachments/assets/60515091-51a5-4299-97c7-a12d3c091b8a)

Microphone inputs have been separated into two mono channels for convenience.

As far as I can tell, the [Universal Control](https://www.presonus.com/pages/support-documents-downloads?product=revelator-io44) software is required to configure levels and effects of these channels, but the settings can be saved to the device and operation without the software is possible outside Windows.