### PR TITLE
ucm2: Intel: avs: Add UCM files for HDA configuration

### DIFF
--- a/ucm2/Intel/avs/hdaudioB0D0/hdaudioB0D0-HiFi.conf
+++ b/ucm2/Intel/avs/hdaudioB0D0/hdaudioB0D0-HiFi.conf
@@ -1,0 +1,3 @@
+Define.DeviceMic "Mic"
+
+Include.analog.File "/HDA/HiFi-analog.conf"

--- a/ucm2/Intel/avs/hdaudioB0D0/hdaudioB0D0.conf
+++ b/ucm2/Intel/avs/hdaudioB0D0/hdaudioB0D0.conf
@@ -1,0 +1,6 @@
+Syntax 6
+
+SectionUseCase."HiFi" {
+	File "/Intel/avs/hdaudioB0D0/hdaudioB0D0-HiFi.conf"
+	Comment "Play HiFi quality Music"
+}

--- a/ucm2/conf.d/hdaudioB0D0/hdaudioB0D0.conf
+++ b/ucm2/conf.d/hdaudioB0D0/hdaudioB0D0.conf
@@ -1,0 +1,1 @@
+../../Intel/avs/hdaudioB0D0/hdaudioB0D0.conf


### PR DESCRIPTION
Add configs for devices using HDA codec.