### PR TITLE
USB-Audio: Add support for RME Fireface UCX II

### DIFF
--- a/ucm2/USB-Audio/RME/Fireface-UCX-II-HiFi.conf
+++ b/ucm2/USB-Audio/RME/Fireface-UCX-II-HiFi.conf
@@ -1,0 +1,636 @@
+Include.pcm_split.File "/common/pcm/split.conf"
+
+# This profile only exposes the most common channel configurations to limit
+# combinatorial complexity:
+#
+#  - Analog line outputs in stereo as well as 4.0 and 5.1 surround,
+#  - analog microphone and instrument inputs in mono only,
+#  - ADAT outputs and inputs in direct 8‐channel mapping, and
+#  - all other outputs and inputs in stereo.
+
+Macro [
+	{
+		SplitPCM {
+			Name "ucx2_stereo_out"
+			Direction Playback
+			Format S24_3LE
+			Channels 2
+			HWChannels 20
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 FL
+			HWChannelPos3 FR
+			HWChannelPos4 FL
+			HWChannelPos5 FR
+			HWChannelPos6 FL
+			HWChannelPos7 FR
+			HWChannelPos8 FL
+			HWChannelPos9 FR
+			HWChannelPos10 FL
+			HWChannelPos11 FR
+			HWChannelPos12 FL
+			HWChannelPos13 FR
+			HWChannelPos14 FL
+			HWChannelPos15 FR
+			HWChannelPos16 FL
+			HWChannelPos17 FR
+			HWChannelPos18 FL
+			HWChannelPos19 FR
+		}
+	}
+	{
+		SplitPCM {
+			Name "ucx2_surround40_out"
+			Direction Playback
+			Format S24_3LE
+			Channels 4
+			HWChannels 20
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 RL
+			HWChannelPos3 RR
+			HWChannelPos4 UNKNOWN
+			HWChannelPos5 UNKNOWN
+			HWChannelPos6 UNKNOWN
+			HWChannelPos7 UNKNOWN
+			HWChannelPos8 UNKNOWN
+			HWChannelPos9 UNKNOWN
+			HWChannelPos10 UNKNOWN
+			HWChannelPos11 UNKNOWN
+			HWChannelPos12 FL
+			HWChannelPos13 FR
+			HWChannelPos14 RL
+			HWChannelPos15 RR
+			HWChannelPos16 FL
+			HWChannelPos17 FR
+			HWChannelPos18 RL
+			HWChannelPos19 RR
+		}
+	}
+	{
+		SplitPCM {
+			Name "ucx2_surround51_out"
+			Direction Playback
+			Format S24_3LE
+			Channels 6
+			HWChannels 20
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 RL
+			HWChannelPos3 RR
+			HWChannelPos4 FC
+			HWChannelPos5 LFE
+			HWChannelPos6 UNKNOWN
+			HWChannelPos7 UNKNOWN
+			HWChannelPos8 UNKNOWN
+			HWChannelPos9 UNKNOWN
+			HWChannelPos10 UNKNOWN
+			HWChannelPos11 UNKNOWN
+			HWChannelPos12 FL
+			HWChannelPos13 FR
+			HWChannelPos14 RL
+			HWChannelPos15 RR
+			HWChannelPos16 FC
+			HWChannelPos17 LFE
+			HWChannelPos18 UNKNOWN
+			HWChannelPos19 UNKNOWN
+		}
+	}
+	{
+		SplitPCM {
+			Name "ucx2_adat_out"
+			Direction Playback
+			Format S24_3LE
+			Channels 8
+			HWChannels 20
+			HWChannelPos0 UNKNOWN
+			HWChannelPos1 UNKNOWN
+			HWChannelPos2 UNKNOWN
+			HWChannelPos3 UNKNOWN
+			HWChannelPos4 UNKNOWN
+			HWChannelPos5 UNKNOWN
+			HWChannelPos6 UNKNOWN
+			HWChannelPos7 UNKNOWN
+			HWChannelPos8 UNKNOWN
+			HWChannelPos9 UNKNOWN
+			HWChannelPos10 UNKNOWN
+			HWChannelPos11 UNKNOWN
+			HWChannelPos12 UNKNOWN
+			HWChannelPos13 UNKNOWN
+			HWChannelPos14 UNKNOWN
+			HWChannelPos15 UNKNOWN
+			HWChannelPos16 UNKNOWN
+			HWChannelPos17 UNKNOWN
+			HWChannelPos18 UNKNOWN
+			HWChannelPos19 UNKNOWN
+		}
+	}
+	{
+		SplitPCM {
+			Name "ucx2_mono_in"
+			Direction Capture
+			Format S24_3LE
+			Channels 1
+			HWChannels 20
+			HWChannelPos0 MONO
+			HWChannelPos1 MONO
+			HWChannelPos2 MONO
+			HWChannelPos3 MONO
+			HWChannelPos4 MONO
+			HWChannelPos5 MONO
+			HWChannelPos6 MONO
+			HWChannelPos7 MONO
+			HWChannelPos8 MONO
+			HWChannelPos9 MONO
+			HWChannelPos10 MONO
+			HWChannelPos11 MONO
+			HWChannelPos12 MONO
+			HWChannelPos13 MONO
+			HWChannelPos14 MONO
+			HWChannelPos15 MONO
+			HWChannelPos16 MONO
+			HWChannelPos17 MONO
+			HWChannelPos18 MONO
+			HWChannelPos19 MONO
+		}
+	}
+	{
+		SplitPCM {
+			Name "ucx2_stereo_in"
+			Direction Capture
+			Format S24_3LE
+			Channels 2
+			HWChannels 20
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 FL
+			HWChannelPos3 FR
+			HWChannelPos4 FL
+			HWChannelPos5 FR
+			HWChannelPos6 FL
+			HWChannelPos7 FR
+			HWChannelPos8 FL
+			HWChannelPos9 FR
+			HWChannelPos10 FL
+			HWChannelPos11 FR
+			HWChannelPos12 FL
+			HWChannelPos13 FR
+			HWChannelPos14 FL
+			HWChannelPos15 FR
+			HWChannelPos16 FL
+			HWChannelPos17 FR
+			HWChannelPos18 FL
+			HWChannelPos19 FR
+		}
+	}
+	{
+		SplitPCM {
+			Name "ucx2_adat_in"
+			Direction Capture
+			Format S24_3LE
+			Channels 8
+			HWChannels 20
+			HWChannelPos0 UNKNOWN
+			HWChannelPos1 UNKNOWN
+			HWChannelPos2 UNKNOWN
+			HWChannelPos3 UNKNOWN
+			HWChannelPos4 UNKNOWN
+			HWChannelPos5 UNKNOWN
+			HWChannelPos6 UNKNOWN
+			HWChannelPos7 UNKNOWN
+			HWChannelPos8 UNKNOWN
+			HWChannelPos9 UNKNOWN
+			HWChannelPos10 UNKNOWN
+			HWChannelPos11 UNKNOWN
+			HWChannelPos12 UNKNOWN
+			HWChannelPos13 UNKNOWN
+			HWChannelPos14 UNKNOWN
+			HWChannelPos15 UNKNOWN
+			HWChannelPos16 UNKNOWN
+			HWChannelPos17 UNKNOWN
+			HWChannelPos18 UNKNOWN
+			HWChannelPos19 UNKNOWN
+		}
+	}
+]
+
+# Analog outputs
+
+SectionDevice.Headphones {
+	Comment "Headphones"
+
+	Value {
+		PlackbackPriority 255
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ucx2_stereo_out"
+		Direction Playback
+		HWChannels 20
+		Channels 2
+		Channel0 6
+		Channel1 7
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line 1" {
+	Comment "Line Output 1+2"
+
+	Value {
+		PlackbackPriority 192
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ucx2_stereo_out"
+		Direction Playback
+		HWChannels 20
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line 2" {
+	Comment "Line Output 3+4"
+
+	Value {
+		PlackbackPriority 191
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ucx2_stereo_out"
+		Direction Playback
+		HWChannels 20
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line 3" {
+	Comment "Line Output 5+6"
+
+	Value {
+		PlackbackPriority 190
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ucx2_stereo_out"
+		Direction Playback
+		HWChannels 20
+		Channels 2
+		Channel0 4
+		Channel1 5
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+# Analog outputs in 4.0 surround configuration
+
+SectionDevice."Line 4" {
+	Comment "Line Output 1-4 (4.0 Surround)"
+
+	ConflictingDevice [
+		"Line 1"
+		"Line 2"
+	]
+
+	Value {
+		PlackbackPriority 160
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ucx2_surround40_out"
+		Direction Playback
+		HWChannels 20
+		Channels 4
+		Channel0 0
+		Channel1 1
+		Channel2 2
+		Channel3 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+		ChannelPos2 RL
+		ChannelPos3 RR
+	}
+}
+
+# Analog outputs in 5.1 surround configuration
+
+SectionDevice."Line 5" {
+	Comment "Line Output 1-6 (5.1 Surround)"
+
+	Value {
+		PlackbackPriority 144
+	}
+
+	ConflictingDevice [
+		"Line 1"
+		"Line 2"
+		"Line 3"
+		"Line 4"
+	]
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ucx2_surround51_out"
+		Direction Playback
+		HWChannels 20
+		Channels 6
+		Channel0 0
+		Channel1 1
+		Channel2 2
+		Channel3 3
+		Channel4 4
+		Channel5 5
+		ChannelPos0 FL
+		ChannelPos1 FR
+		ChannelPos2 RL
+		ChannelPos3 RR
+		ChannelPos4 FC
+		ChannelPos5 LFE
+	}
+}
+
+# Analog inputs
+
+SectionDevice."Mic 1" {
+	Comment "Line Input 1 (Microphone)"
+
+	Value {
+		CapturePriority 176
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ucx2_mono_in"
+		Direction Capture
+		HWChannels 20
+		Channels 1
+		Channel0 0
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Mic 2" {
+ 	Comment "Line Input 2 (Microphone)"
+
+	Value {
+		CapturePriority 175
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ucx2_mono_in"
+		Direction Capture
+		HWChannels 20
+		Channels 1
+		Channel0 1
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Line 6" {
+	Comment "Line Input 3 (Instrument)"
+
+	Value {
+		CapturePriority 174
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ucx2_mono_in"
+		Direction Capture
+		HWChannels 20
+		Channels 1
+		Channel0 2
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Line 7" {
+	Comment "Line Input 4 (Instrument)"
+
+	Value {
+		CapturePriority 173
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ucx2_mono_in"
+		Direction Capture
+		HWChannels 20
+		Channels 1
+		Channel0 3
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Line 8" {
+	Comment "Line Input 5+6"
+
+	Value {
+		CapturePriority 172
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ucx2_stereo_in"
+		Direction Capture
+		HWChannels 20
+		Channels 2
+		Channel0 4
+		Channel1 5
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line 9" {
+	Comment "Line Input 7+8"
+
+	Value {
+		CapturePriority 171
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ucx2_stereo_in"
+		Direction Capture
+		HWChannels 20
+		Channels 2
+		Channel0 6
+		Channel1 7
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+# Digital (consumer) outputs
+
+SectionDevice."SPDIF 1" {
+	Comment "AES3 (S/PDIF) Coax Output"
+
+	Value {
+		PlackbackPriority 112
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ucx2_stereo_out"
+		Direction Playback
+		HWChannels 20
+		Channels 2
+		Channel0 8
+		Channel1 9
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."SPDIF 2" {
+	Comment "S/PDIF Optical Output"
+
+	ConflictingDevice [
+		"Direct 1"
+	]
+
+	Value {
+		PlackbackPriority 111
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ucx2_stereo_out"
+		Direction Playback
+		HWChannels 20
+		Channels 2
+		Channel0 12
+		Channel1 13
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+# Digital (consumer) inputs
+
+SectionDevice."SPDIF 3" {
+	Comment "AES3 (S/PDIF) Coax Input"
+
+	Value {
+		CapturePriority 112
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ucx2_stereo_in"
+		Direction Capture
+		HWChannels 20
+		Channels 2
+		Channel0 8
+		Channel1 9
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+# Digital (professional) outputs
+
+SectionDevice."SPDIF 4" {
+	Comment "AES3 XLR Ouptut"
+
+	Value {
+		PlackbackPriority 80
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ucx2_stereo_out"
+		Direction Playback
+		HWChannels 20
+		Channels 2
+		Channel0 10
+		Channel1 11
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Direct 1" {
+	Comment "ADAT Optical Output"
+
+	Value {
+		PlackbackPriority 48
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ucx2_adat_out"
+		Direction Playback
+		HWChannels 20
+		Channels 8
+		Channel0 12
+		Channel1 13
+		Channel2 14
+		Channel3 15
+		Channel4 16
+		Channel5 17
+		Channel6 18
+		Channel7 19
+		ChannelPos0 UNKNOWN
+		ChannelPos1 UNKNOWN
+		ChannelPos2 UNKNOWN
+		ChannelPos3 UNKNOWN
+		ChannelPos4 UNKNOWN
+		ChannelPos5 UNKNOWN
+		ChannelPos6 UNKNOWN
+		ChannelPos7 UNKNOWN
+	}
+}
+
+# Digital (professional) inputs
+
+SectionDevice."SPDIF 5" {
+	Comment "AES3 (S/PDIF) XLR Input"
+
+	Value {
+		CapturePriority 80
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ucx2_stereo_in"
+		Direction Capture
+		HWChannels 20
+		Channels 2
+		Channel0 10
+		Channel1 11
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Direct 2" {
+	Comment "ADAT Optical Input"
+
+	Value {
+		CapturePriority 48
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ucx2_adat_in"
+		Direction Capture
+		HWChannels 20
+		Channels 8
+		Channel0 12
+		Channel1 13
+		Channel2 14
+		Channel3 15
+		Channel4 16
+		Channel5 17
+		Channel6 18
+		Channel7 19
+		ChannelPos0 UNKNOWN
+		ChannelPos1 UNKNOWN
+		ChannelPos2 UNKNOWN
+		ChannelPos3 UNKNOWN
+		ChannelPos4 UNKNOWN
+		ChannelPos5 UNKNOWN
+		ChannelPos6 UNKNOWN
+		ChannelPos7 UNKNOWN
+	}
+}

--- a/ucm2/USB-Audio/RME/Fireface-UCX-II.conf
+++ b/ucm2/USB-Audio/RME/Fireface-UCX-II.conf
@@ -1,0 +1,39 @@
+Comment "Fireface UCX II"
+
+# The Fireface UCX II provides 20 playback and capture channels each:
+# - channels  0  to  7 are analog inputs and outputs
+# - channels  8 and  9 are AES3 (S/PDIF) via coax
+# - channels 10 and 11 are AES3 (S/PDIF) via XLR
+# - channels 12  to 19 are ADAT Optical Interface (8 channels)
+#                           or S/PDIF (output only, 12 and 13) via TOSLINK
+#
+# Physical connector layout:
+#  top to bottom, left to right, viewed from device front
+#
+# Front:
+# - 1 MIC / LINE: XLR / 1/4" TRS combo, balanced mono input, 48 V phantom power
+# - 2 MIC / LINE: XLR / 1/4" TRS combo, balanced mono input, 48 V phantom power
+# - 3 LINE / INSTR.: TRS 1/4", balanced mono input
+# - 4 LINE / INSTR.: TRS 1/4", balanced mono input
+# - Headphones symbol: TRS 1/4", unbalanced stereo output
+#
+# Back:
+# - LINE INPUTS (BALANCED) [5, 6; 7, 8]: TRS 1/4", balanced mono inputs
+# - LINE OUTPUTS (BALANCED) [1, 2; 3, 4; 5, 6]: TRS 1/4", balanced mono outputs
+# - ADAT IN: TOSLINK, ADAT Optical Interface
+# - ADATA OUT: TOSLINK, ADAT Optical Interface or S/PDIF
+# - AES/EBU & SPDIF: 9-pin D-Sub with breakout cable (2 RCA and 2 XLR)
+#   - RCA in: AES3 or S/PDIF (automatic)
+#   - RCA out: configurable for AES3 (Professional) or S/PDIF (Consumer)
+#   - XLR in: AES3 or S/PDIF (automatic)
+#   - XLR out: AES3 only
+
+SectionUseCase."HiFi" {
+	Comment "Default"
+	File "/USB-Audio/RME/Fireface-UCX-II-HiFi.conf"
+}
+
+Define.DirectPlaybackChannels 20
+Define.DirectCaptureChannels 20
+
+Include.dhw.File "/common/direct.conf"

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -438,6 +438,15 @@ If.zedi10 {
 	True.Define.ProfileName "AllenAndHeath/Zedi10"
 }
 
+If.fireface-ucx-ii {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB2a39:3fd9"
+	}
+	True.Define.ProfileName "RME/Fireface-UCX-II"
+}
+
 If.id4-0003 {
 	Condition {
 		Type String


### PR DESCRIPTION
This adds support for the RME Fireface UCX II interface.

User manual: <https://rme-audio.de/downloads/fface_ucx2_e.pdf>

### Device interface

The interface provides 20 playback and capture channels each:
- channels  0  to  7 are analog inputs and outputs
- channels  8 and  9 are AES3 (S/PDIF) via coax
- channels 10 and 11 are AES3 (S/PDIF) via XLR
- channels 12  to 19 are ADAT Optical Interface (8 channels) or S/PDIF (output only, 12 and 13) via TOSLINK

The interface supports three _Class Compliant_ playback modes:

- _8 Ch. + Phones_:
  - channels 0+1 are mirrored to 6+7 (headphones L+R), 8+9 (S/PDIF L+R) and 12+13 (ADAT 1/2)
  - channels 2+3 are mirrored to 10+11 (AES3 L+R) and 14+15 (ADAT 3/4)
  - channels 4+5 are mirrored to 16+17 (ADAT 5/6)
  - channels 6+7 are mirrored to 18+19 (ADAT 7/8)
- _8 Ch. Playback_:
  - channels 0+1 are mirrored to 8+9 (S/PDIF L+R) and 12+13 (ADAT 1/2)
  - channels 2+3 are mirrored to 10+11 (AES3 L+R) and 14+15 (ADAT 3/4)
  - channels 4+5 are mirrored to 16+17 (ADAT 5/6)
  - channels 6+7 are mirrored to 18+19 (ADAT 7/8)
- _20 Ch. Playback_: no channel mirroring

The device exposes all 20 channels in all three playback modes.

No mixer controls are available with the current driver.

### Physical connector layout

top to bottom, left to right, viewed from device front

#### Front

- _1 MIC / LINE_:  XLR / TRS ¼" combo, balanced mono input, 48 V phantom power
- _2 MIC / LINE_:  XLR / TRS ¼" combo, balanced mono input, 48 V phantom power
- _3 LINE / INSTR._: TRS ¼", balanced mono input
- _4 LINE / INSTR._: TRS ¼", balanced mono input
- _🎧︎_ (headphones symbol): TRS ¼", unbalanced stereo output

#### Back

- _LINE INPUTS (BALANCED)_  [_5_, _6_; _7_, _8_]: TRS ¼", balanced mono inputs
- _LINE OUTPUTS (BALANCED)_ [_1_, _2_; _3_, _4_; _5_, _6_]: TRS ¼", balanced mono outputs
- _ADAT IN_: TOSLINK, ADAT Optical Interface
- _ADAT OUT_: TOSLINK, ADAT Optical Interface or  or S/PDIF
- _AES/EBU & SPDIF_: 9‐pin D-Sub with breakout cable (2 × RCA and 2 × XLR)
  - RCA in: AES3 or S/PDIF (automatic detection)
  - RCA out: configurable for AES3 (_Professional_) or S/PDIF (_Consumer_)
  - XLR in: AES3 or S/PDIF (automatic detection)
  - XLR out: AES3 only

### Channel configurations

The _HiFi_ use case only exposes the most common channel configurations to limit combinatorial complexity:

- Analog line outputs in stereo as well as 4.0 and 5.1 surround,
- analog microphone and instrument inputs in mono only,
- ADAT Optical outputs and inputs in direct 8‐channel mapping, and
- all other outputs and inputs in stereo.

[alsa-info.txt](https://github.com/user-attachments/files/18814815/alsa-info.txt)