### PR TITLE
Split the GoXLR configuration into Full Device and Mini

### DIFF
--- a/ucm2/USB-Audio/GoXLR/GoXLR-Mini-HiFi.conf
+++ b/ucm2/USB-Audio/GoXLR/GoXLR-Mini-HiFi.conf
@@ -1,0 +1,197 @@
+Include.pcm_split.File "/common/pcm/split.conf"
+
+Macro [
+	{
+		SplitPCM {
+			Name "goxlr_mini_stereo_out"
+			Direction Playback
+			Channels 2
+			HWChannels 10
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 FL
+			HWChannelPos3 FR
+			HWChannelPos4 FL
+			HWChannelPos5 FR
+			HWChannelPos6 FL
+			HWChannelPos7 FR
+			HWChannelPos8 FL
+			HWChannelPos9 FR
+		}
+	}
+	{
+		SplitPCM {
+			Name "goxlr_mini_stereo_in"
+			Direction Capture
+			Channels 2
+			HWChannels 21
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 FL
+			HWChannelPos3 FR
+			HWChannelPos4 FL
+			HWChannelPos5 FR
+			HWChannelPos6 FL
+			HWChannelPos7 FR
+			HWChannelPos8 FL
+			HWChannelPos9 FR
+			HWChannelPos10 FL
+			HWChannelPos11 FR
+			HWChannelPos12 FL
+			HWChannelPos13 FR
+			HWChannelPos14 FL
+			HWChannelPos15 FR
+			HWChannelPos16 FL
+			HWChannelPos17 FR
+			HWChannelPos18 FL
+			HWChannelPos19 FR
+			HWChannelPos20 FL
+			HWChannelPos21 FR
+			HWChannelPos22 MONO
+		}
+	}
+]
+
+SectionDevice."Speaker" {
+	Comment "System"
+
+	Value {
+		PlaybackPriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "goxlr_mini_stereo_out"
+		Direction Playback
+		HWChannels 10
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line1" {
+	Comment "Game"
+
+	Value {
+		PlaybackPriority 300
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "goxlr_mini_stereo_out"
+		Direction Playback
+		HWChannels 10
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line2" {
+	Comment "Music"
+
+	Value {
+		PlaybackPriority 400
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "goxlr_mini_stereo_out"
+		Direction Playback
+		HWChannels 10
+		Channels 2
+		Channel0 6
+		Channel1 7
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Headphones" {
+	Comment "Chat"
+
+	Value {
+		PlaybackPriority 200
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "goxlr_mini_stereo_out"
+		Direction Playback
+		HWChannels 10
+		Channels 2
+		Channel0 4
+		Channel1 5
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line3" {
+	Comment "Sample"
+
+	Value {
+		PlaybackPriority 500
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "goxlr_mini_stereo_out"
+		Direction Playback
+		HWChannels 10
+		Channels 2
+		Channel0 8
+		Channel1 9
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line4" {
+	Comment "Broadcast Stream Mix"
+
+	Value {
+		CapturePriority 200
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "goxlr_mini_stereo_in"
+		Direction Capture
+		HWChannels 21
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Headset" {
+	Comment "Chat Mic"
+
+	Value {
+		CapturePriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "goxlr_mini_stereo_in"
+		Direction Capture
+		HWChannels 21
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line5" {
+	Comment "Sampler"
+
+	Value {
+		CapturePriority 300
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "goxlr_mini_stereo_in"
+		Direction Capture
+		HWChannels 21
+		Channels 2
+		Channel0 4
+		Channel1 5
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}

--- a/ucm2/USB-Audio/GoXLR/GoXLR-Mini.conf
+++ b/ucm2/USB-Audio/GoXLR/GoXLR-Mini.conf
@@ -1,0 +1,11 @@
+Comment "GoXLR Mini USB-Audio"
+
+SectionUseCase."HiFi" {
+	Comment "Default Alsa Profile"
+	File "/USB-Audio/GoXLR/GoXLR-Mini-HiFi.conf"
+}
+
+Define.DirectPlaybackChannels 10
+Define.DirectCaptureChannels 21
+
+Include.dhw.File "/common/direct.conf"

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -284,9 +284,18 @@ If.goxlr {
 	Condition {
 		Type RegexMatch
 		String "${CardComponents}"
-		Regex "USB1220:8fe[04]"
+		Regex "USB1220:8fe0"
 	}
 	True.Define.ProfileName "GoXLR/GoXLR"
+}
+
+If.goxlr-mini {
+	Condition {
+		Type RegexMatch
+		String "${CardComponents}"
+		Regex "USB1220:8fe4"
+	}
+	True.Define.ProfileName "GoXLR/GoXLR-Mini"
 }
 
 If.focusrite-scarlett-2i {


### PR DESCRIPTION
This commit splits the GoXLR and GoXLR Mini into separate configurations.

The GoXLR Mini will always (at this point) have 21 channels defined, where as the full sized GoXLR will have either 23 or 25 depending on Firmware (23 is FAR more common at this point, as the firmware with 25 channels is still in beta).

Separating out the two devices should at least partially solve the recent issue with Pipewire.