### PR TITLE
USB-Audio: GoXLR - fix the channel detection for mini, cleanups

### DIFF
--- a/ucm2/USB-Audio/GoXLR/GoXLR-HiFi.conf
+++ b/ucm2/USB-Audio/GoXLR/GoXLR-HiFi.conf
@@ -1,56 +1,49 @@
 Include.pcm_split.File "/common/pcm/split.conf"
 
-Macro [
-	{
-		SplitPCM {
-			Name "goxlr_stereo_out"
-			Direction Playback
-			Channels 2
-			HWChannels 10
-			HWChannelPos0 FL
-			HWChannelPos1 FR
-			HWChannelPos2 FL
-			HWChannelPos3 FR
-			HWChannelPos4 FL
-			HWChannelPos5 FR
-			HWChannelPos6 FL
-			HWChannelPos7 FR
-			HWChannelPos8 FL
-			HWChannelPos9 FR
-		}
-	}
-	{
-		SplitPCM {
-			Name "goxlr_stereo_in"
-			Direction Capture
-			Channels 2
-			HWChannels 23
-			HWChannelPos0 FL
-			HWChannelPos1 FR
-			HWChannelPos2 FL
-			HWChannelPos3 FR
-			HWChannelPos4 FL
-			HWChannelPos5 FR
-			HWChannelPos6 FL
-			HWChannelPos7 FR
-			HWChannelPos8 FL
-			HWChannelPos9 FR
-			HWChannelPos10 FL
-			HWChannelPos11 FR
-			HWChannelPos12 FL
-			HWChannelPos13 FR
-			HWChannelPos14 FL
-			HWChannelPos15 FR
-			HWChannelPos16 FL
-			HWChannelPos17 FR
-			HWChannelPos18 FL
-			HWChannelPos19 FR
-			HWChannelPos20 FL
-			HWChannelPos21 FR
-			HWChannelPos22 MONO
-		}
-	}
-]
+Macro.playback.SplitPCM {
+	Name "goxlr_stereo_out"
+	Direction Playback
+	Channels 2
+	HWChannels "${var:PlaybackChannels}"
+	HWChannelPos0 FL
+	HWChannelPos1 FR
+	HWChannelPos2 FL
+	HWChannelPos3 FR
+	HWChannelPos4 FL
+	HWChannelPos5 FR
+	HWChannelPos6 FL
+	HWChannelPos7 FR
+	HWChannelPos8 FL
+	HWChannelPos9 FR
+}
+
+Macro.capture.SplitPCM {
+	Name "goxlr_stereo_in"
+	Direction Capture
+	Channels 2
+	HWChannels "${var:CaptureChannels}"
+	HWChannelPos0 FL
+	HWChannelPos1 FR
+	HWChannelPos2 FL
+	HWChannelPos3 FR
+	HWChannelPos4 FL
+	HWChannelPos5 FR
+	HWChannelPos6 FL
+	HWChannelPos7 FR
+	HWChannelPos8 FL
+	HWChannelPos9 FR
+	HWChannelPos10 FL
+	HWChannelPos11 FR
+	HWChannelPos12 FL
+	HWChannelPos13 FR
+	HWChannelPos14 FL
+	HWChannelPos15 FR
+	HWChannelPos16 FL
+	HWChannelPos17 FR
+	HWChannelPos18 FL
+	HWChannelPos19 FR
+	HWChannelPos20 MONO
+}
 
 SectionDevice."Speaker" {
 	Comment "System"
@@ -61,7 +54,7 @@ SectionDevice."Speaker" {
 	Macro.pcm_split.SplitPCMDevice {
 		Name "goxlr_stereo_out"
 		Direction Playback
-		HWChannels 10
+		HWChannels "${var:PlaybackChannels}"
 		Channels 2
 		Channel0 0
 		Channel1 1
@@ -79,7 +72,7 @@ SectionDevice."Line1" {
 	Macro.pcm_split.SplitPCMDevice {
 		Name "goxlr_stereo_out"
 		Direction Playback
-		HWChannels 10
+		HWChannels "${var:PlaybackChannels}"
 		Channels 2
 		Channel0 2
 		Channel1 3
@@ -97,7 +90,7 @@ SectionDevice."Line2" {
 	Macro.pcm_split.SplitPCMDevice {
 		Name "goxlr_stereo_out"
 		Direction Playback
-		HWChannels 10
+		HWChannels "${var:PlaybackChannels}"
 		Channels 2
 		Channel0 6
 		Channel1 7
@@ -115,7 +108,7 @@ SectionDevice."Headphones" {
 	Macro.pcm_split.SplitPCMDevice {
 		Name "goxlr_stereo_out"
 		Direction Playback
-		HWChannels 10
+		HWChannels "${var:PlaybackChannels}"
 		Channels 2
 		Channel0 4
 		Channel1 5
@@ -133,7 +126,7 @@ SectionDevice."Line3" {
 	Macro.pcm_split.SplitPCMDevice {
 		Name "goxlr_stereo_out"
 		Direction Playback
-		HWChannels 10
+		HWChannels "${var:PlaybackChannels}"
 		Channels 2
 		Channel0 8
 		Channel1 9
@@ -151,7 +144,7 @@ SectionDevice."Line4" {
 	Macro.pcm_split.SplitPCMDevice {
 		Name "goxlr_stereo_in"
 		Direction Capture
-		HWChannels 23
+		HWChannels "${var:CaptureChannels}"
 		Channels 2
 		Channel0 0
 		Channel1 1
@@ -169,7 +162,7 @@ SectionDevice."Headset" {
 	Macro.pcm_split.SplitPCMDevice {
 		Name "goxlr_stereo_in"
 		Direction Capture
-		HWChannels 23
+		HWChannels "${var:CaptureChannels}"
 		Channels 2
 		Channel0 2
 		Channel1 3
@@ -187,7 +180,7 @@ SectionDevice."Line5" {
 	Macro.pcm_split.SplitPCMDevice {
 		Name "goxlr_stereo_in"
 		Direction Capture
-		HWChannels 23
+		HWChannels "${var:CaptureChannels}"
 		Channels 2
 		Channel0 4
 		Channel1 5

--- a/ucm2/USB-Audio/GoXLR/GoXLR.conf
+++ b/ucm2/USB-Audio/GoXLR/GoXLR.conf
@@ -1,11 +1,47 @@
-Comment "GoXLR USB-Audio"
+Define {
+	PlaybackChannels 10
+	CaptureChannels 23	# change to 25 for beta firmware
+	Model "GoXLR"
+}
+
+If.mini {
+	Condition {
+		Type RegexMatch
+		String "${CardComponents}"
+		Regex "USB1220:8fe4"
+	}
+	True.Define {
+		Model "GoXLR Mini"
+		CaptureChannels 21
+	}
+}
+
+If.beta {
+	Condition {
+		Type String
+		# alsa-lib 1.2.14+ is required to support this!
+		# String1 "${sys-card:[type=hex,pos=0x9c]device/../descriptors}"
+		String1 ""
+		String2 "19"	# 0x19 == 25
+	}
+	True.Define {
+		CaptureChannels 25
+	}
+}
+
+Comment "${var:Model} USB"
 
 SectionUseCase."HiFi" {
 	Comment "Default Alsa Profile"
 	File "/USB-Audio/GoXLR/GoXLR-HiFi.conf"
 }
 
-Define.DirectPlaybackChannels 10
-Define.DirectCaptureChannels 23
+If.direct {
+	Condition { Type AlwaysTrue }
+	True {
+		Define.DirectPlaybackChannels "${var:PlaybackChannels}"
+		Define.DirectCaptureChannels "${var:CaptureChannels}"
+	}
+}
 
 Include.dhw.File "/common/direct.conf"


### PR DESCRIPTION
Note that detection for 25 channels requires commit [1] (alsa-lib 1.2.14+).

[1] https://github.com/alsa-project/alsa-lib/commit/7fbd47ce797939862025ef424865570dcdc2565b

BugLink: https://github.com/alsa-project/alsa-ucm-conf/issues/444