### PR TITLE
ucm2: Add support for Lenovo Yoga 7x and T14s 

### DIFF
--- a/ucm2/Qualcomm/x1e80100/LENOVO-Slim-7x.conf
+++ b/ucm2/Qualcomm/x1e80100/LENOVO-Slim-7x.conf
@@ -1,0 +1,11 @@
+Syntax 4
+
+SectionUseCase."HiFi" {
+	File "/Qualcomm/x1e80100/Slim7x-HiFi.conf"
+	Comment "HiFi quality Music."
+}
+
+Include.card-init.File "/lib/card-init.conf"
+Include.ctl-remap.File "/lib/ctl-remap.conf"
+Include.wsa-init.File "/codecs/wsa884x/four-speakers/init.conf"
+Include.wsam-init.File "/codecs/qcom-lpass/wsa-macro/four-speakers/init.conf"

--- a/ucm2/Qualcomm/x1e80100/LENOVO-T14s.conf
+++ b/ucm2/Qualcomm/x1e80100/LENOVO-T14s.conf
@@ -1,0 +1,19 @@
+Syntax 4
+
+SectionUseCase."HiFi" {
+	File "/Qualcomm/x1e80100/T14s-HiFi.conf"
+	Comment "HiFi quality Music."
+}
+
+BootSequence [
+	cset "name='HPHL Volume' 20"
+	cset "name='HPHR Volume' 20"
+	cset "name='ADC2 Volume' 10"
+]
+
+Include.card-init.File "/lib/card-init.conf"
+Include.ctl-remap.File "/lib/ctl-remap.conf"
+Include.wcd-init.File "/codecs/wcd938x/init.conf"
+Include.wsa-init.File "/codecs/wsa884x/two-speakers/init.conf"
+Include.wsam-init.File "/codecs/qcom-lpass/wsa-macro/init.conf"
+Include.rxm-init.File "/codecs/qcom-lpass/rx-macro/init.conf"

--- a/ucm2/Qualcomm/x1e80100/Slim7x-HiFi.conf
+++ b/ucm2/Qualcomm/x1e80100/Slim7x-HiFi.conf
@@ -1,0 +1,49 @@
+# Use case configuration for X1E80100.
+# Author: Srinivas Kandagatla <srinivas.kandagatla@linaro.org>
+
+SectionVerb {
+	EnableSequence [
+		cset "name='WSA_CODEC_DMA_RX_0 Audio Mixer MultiMedia2' 1"
+		cset "name='MultiMedia4 Mixer VA_CODEC_DMA_TX_0' 1"
+	]
+
+	Include.wsae.File "/codecs/wsa884x/four-speakers/DefaultEnableSeq.conf"
+	Include.wsm1e.File "/codecs/qcom-lpass/wsa-macro/Wsa1SpeakerEnableSeq.conf"
+	Include.wsm2e.File "/codecs/qcom-lpass/wsa-macro/Wsa2SpeakerEnableSeq.conf"
+
+	Value {
+		TQ "HiFi"
+	}
+}
+
+SectionDevice."Speaker" {
+	Comment "Speaker playback"
+
+	Include.wsmspk1e.File "/codecs/qcom-lpass/wsa-macro/Wsa1SpeakerEnableSeq.conf"
+	Include.wsmspk2e.File "/codecs/qcom-lpass/wsa-macro/Wsa2SpeakerEnableSeq.conf"
+	Include.wsmspk1d.File "/codecs/qcom-lpass/wsa-macro/Wsa1SpeakerDisableSeq.conf"
+	Include.wsmspk2d.File "/codecs/qcom-lpass/wsa-macro/Wsa2SpeakerDisableSeq.conf"
+	Include.wsaspk.File "/codecs/wsa884x/four-speakers/SpeakerSeq.conf"
+
+	Value {
+		PlaybackChannels 4
+		PlaybackPriority 100
+		PlaybackPCM "hw:${CardId},1"
+		PlaybackMixer "default:${CardId}"
+		PlaybackMixerElem "Speakers"
+	}
+}
+
+SectionDevice."Mic" {
+	Comment "Internal microphones"
+
+	Include.vadm0e.File "/codecs/qcom-lpass/va-macro/DMIC0EnableSeq.conf"
+	Include.vadm0d.File "/codecs/qcom-lpass/va-macro/DMIC0DisableSeq.conf"
+	Include.vadm1e.File "/codecs/qcom-lpass/va-macro/DMIC1EnableSeq.conf"
+	Include.vadm1d.File "/codecs/qcom-lpass/va-macro/DMIC1DisableSeq.conf"
+
+	Value {
+		CapturePriority 100
+		CapturePCM "hw:${CardId},3"
+	}
+}

--- a/ucm2/Qualcomm/x1e80100/T14s-HiFi.conf
+++ b/ucm2/Qualcomm/x1e80100/T14s-HiFi.conf
@@ -1,0 +1,89 @@
+# Use case configuration for X1E80100.
+# Author: Srinivas Kandagatla <srinivas.kandagatla@linaro.org>
+
+SectionVerb {
+	EnableSequence [
+		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia1' 1"
+		cset "name='WSA_CODEC_DMA_RX_0 Audio Mixer MultiMedia2' 1"
+		cset "name='MultiMedia3 Mixer TX_CODEC_DMA_TX_3' 1"
+		cset "name='MultiMedia4 Mixer VA_CODEC_DMA_TX_0' 1"
+	]
+
+	Include.wsae.File "/codecs/wsa884x/two-speakers/DefaultEnableSeq.conf"
+	Include.wsm1e.File "/codecs/qcom-lpass/wsa-macro/Wsa1SpeakerEnableSeq.conf"
+
+	Value {
+		TQ "HiFi"
+	}
+}
+
+SectionDevice."Speaker" {
+	Comment "Speaker playback"
+
+	Include.wsmspk1e.File "/codecs/qcom-lpass/wsa-macro/Wsa1SpeakerEnableSeq.conf"
+	Include.wsmspk1d.File "/codecs/qcom-lpass/wsa-macro/Wsa1SpeakerDisableSeq.conf"
+	Include.wsaspk.File "/codecs/wsa884x/two-speakers/SpeakerSeq.conf"
+
+	Value {
+		PlaybackChannels 2
+		PlaybackPriority 100
+		PlaybackPCM "hw:${CardId},1"
+		PlaybackMixer "default:${CardId}"
+		PlaybackMixerElem "Speakers"
+	}
+}
+
+SectionDevice."Headphones" {
+	Comment "Headphones playback"
+
+	Include.wcdhpe.File "/codecs/wcd938x/HeadphoneEnableSeq.conf"
+	Include.wcdhpd.File "/codecs/wcd938x/HeadphoneDisableSeq.conf"
+	Include.rxmhpe.File "/codecs/qcom-lpass/rx-macro/HeadphoneEnableSeq.conf"
+	Include.rxmhpd.File "/codecs/qcom-lpass/rx-macro/HeadphoneDisableSeq.conf"
+
+	EnableSequence [
+		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia1' 1"
+	]
+
+	DisableSequence [
+		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia1' 0"
+	]
+
+	Value {
+		PlaybackPriority 200
+		PlaybackPCM "hw:${CardId},0"
+		PlaybackMixer "default:${CardId}"
+		PlaybackMixerElem "HP"
+		JackControl "Headphone Jack"
+	}
+}
+
+SectionDevice."Headset" {
+	Comment "Headset microphone"
+
+	Include.wcdmice.File "/codecs/wcd938x/HeadphoneMicEnableSeq.conf"
+	Include.wcdmicd.File "/codecs/wcd938x/HeadphoneMicDisableSeq.conf"
+	Include.txmhpe.File "/codecs/qcom-lpass/tx-macro/SoundwireMic1EnableSeq.conf"
+	Include.txmhpd.File "/codecs/qcom-lpass/tx-macro/SoundwireMicDisableSeq.conf"
+
+	Value {
+		CapturePriority 200
+		CapturePCM "hw:${CardId},2"
+		CaptureMixerElem "ADC2"
+		JackControl "Mic Jack"
+	}
+}
+
+SectionDevice."Mic" {
+	Comment "Internal microphones"
+
+	Include.vadm0e.File "/codecs/qcom-lpass/va-macro/DMIC0EnableSeq.conf"
+	Include.vadm0d.File "/codecs/qcom-lpass/va-macro/DMIC0DisableSeq.conf"
+	Include.vadm1e.File "/codecs/qcom-lpass/va-macro/DMIC1EnableSeq.conf"
+	Include.vadm1d.File "/codecs/qcom-lpass/va-macro/DMIC1DisableSeq.conf"
+
+	Value {
+		CapturePriority 100
+		CapturePCM "hw:${CardId},3"
+	}
+}

--- a/ucm2/Qualcomm/x1e80100/x1e80100.conf
+++ b/ucm2/Qualcomm/x1e80100/x1e80100.conf
@@ -1,0 +1,10 @@
+Syntax 4
+
+If.LENOVOX14s {
+	Condition {
+		Type RegexMatch
+		String "${sys:devices/virtual/dmi/id/board_vendor}-${sys:devices/virtual/dmi/id/product_family}"
+		Regex "LENOVO.*ThinkPad T14s Gen 6.*"
+	}
+	True.Include.x14s.File "/Qualcomm/x1e80100/LENOVO-T14s.conf"
+}

--- a/ucm2/Qualcomm/x1e80100/x1e80100.conf
+++ b/ucm2/Qualcomm/x1e80100/x1e80100.conf
@@ -8,3 +8,11 @@ If.LENOVOX14s {
 	}
 	True.Include.x14s.File "/Qualcomm/x1e80100/LENOVO-T14s.conf"
 }
+If.LENOVOSlim7x {
+	Condition {
+		Type RegexMatch
+		String "${sys:devices/virtual/dmi/id/board_vendor}-${sys:devices/virtual/dmi/id/product_family}"
+		Regex "LENOVO.*Yoga Slim 7.*"
+	}
+	True.Include.7x.File "/Qualcomm/x1e80100/LENOVO-Slim-7x.conf"
+}

--- a/ucm2/conf.d/x1e80100/x1e80100.conf
+++ b/ucm2/conf.d/x1e80100/x1e80100.conf
@@ -1,0 +1,1 @@
+../../Qualcomm/x1e80100/x1e80100.conf


### PR DESCRIPTION
This patch series adds support for Lenovo T14s and Yoga Slim 7x based on Qualcomm x1e80100 SoC. 