### PR TITLE
DRAFT [for alsa-lib-1.2.14]: USB-Audio: GoXLR: enable detection of beta firmware (25 channels)

### DIFF
--- a/ucm2/USB-Audio/GoXLR/GoXLR.conf
+++ b/ucm2/USB-Audio/GoXLR/GoXLR.conf
@@ -20,8 +20,7 @@ If.beta {
 	Condition {
 		Type String
 		# alsa-lib 1.2.14+ (Syntax 8) is required to support this!
-		# String1 "${sys-card:[type=hex,pos=0x9c]device/../descriptors}"
-		String1 ""
+		String1 "${sys-card:[type=hex,pos=0x9c]device/../descriptors}"
 		String2 "19"	# 0x19 == 25
 	}
 	True.Define {

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -1,4 +1,4 @@
-Syntax 7
+Syntax 8
 
 Define.ProfileName ""
 Define.MixerRemap ""


### PR DESCRIPTION
'Syntax 8' is required (alsa-lib 1.2.14+)

Fixes: 17f9b4f ("USB-Audio: GoXLR - fix the channel detection for mini, cleanups")
Link: https://github.com/alsa-project/alsa-ucm-conf/issues/444