### PR TITLE
sof-soundwire: rt1318: add playback control switch

### DIFF
--- a/ucm2/codecs/rt1318/init.conf
+++ b/ucm2/codecs/rt1318/init.conf
@@ -1,5 +1,26 @@
 # RT1318 specific switch control settings
 
+Define.SpeakerMixerElem "rt1318-1 DAC"
+
+If.twoAmpsStereoToOne {
+	Condition {
+		Type RegexMatch
+		Regex "2"
+		String "${var:SpeakerAmps}"
+	}
+	True {
+		Define.SpeakerMixerElem "rt1318 DAC"
+		LibraryConfig.remap.Config {
+			ctl.default.map {
+				"name='rt1318 DAC Playback Switch'" {
+					"name='rt1318-1 DAC Switch'".vindex.0 [ 0 1 ]
+					"name='rt1318-2 DAC Switch'".vindex.1 [ 0 1 ]
+				}
+			}
+		}
+	}
+}
+
 If.oneAmp {
 	Condition {
 		Type ControlExists

--- a/ucm2/sof-soundwire/rt1318.conf
+++ b/ucm2/sof-soundwire/rt1318.conf
@@ -41,5 +41,7 @@ SectionDevice."Speaker" {
 	Value {
 	      PlaybackPriority 100
 	      PlaybackPCM "hw:${CardId},2"
+	      PlaybackMixer "default:${CardId}"
+	      PlaybackMixerElem "${var:SpeakerMixerElem}"
 	}
 }


### PR DESCRIPTION
rt1318: add playback control switch

[v2] This patch defines a remapped one 'rt1318 DAC Playback Switch' whether the cases are in one amp or two amps.
[v3] This patch defines 'rt1318-1 DAC' as PlaybackMixerElem when equipped with only one amp
and defines a remapped one 'rt1318 DAC Playback Switch' when using two amps.