### PR TITLE
ucm2: Qualcomm: fix typo in Lenovo T14s matching

### DIFF
--- a/ucm2/Qualcomm/x1e80100/x1e80100.conf
+++ b/ucm2/Qualcomm/x1e80100/x1e80100.conf
@@ -1,12 +1,12 @@
 Syntax 4
 
-If.LENOVOX14s {
+If.LENOVOT14s {
 	Condition {
 		Type RegexMatch
 		String "${sys:devices/virtual/dmi/id/board_vendor}-${sys:devices/virtual/dmi/id/product_family}"
 		Regex "LENOVO.*ThinkPad T14s Gen 6.*"
 	}
-	True.Include.x14s.File "/Qualcomm/x1e80100/LENOVO-T14s.conf"
+	True.Include.t14s.File "/Qualcomm/x1e80100/LENOVO-T14s.conf"
 }
 
 If.LENOVOSlim7x {


### PR DESCRIPTION
The original commit referenced an incorrect laptop model in the matching code. Use the correct model. This introduces no functional changes.

Fixes: e17dde6fd1c3 ("ucm2: Qualcomm: add Lenovo T14s support")

cc @Srinivas-Kandagatla 