### PR TITLE
USB-Audio: ALC4080 - add rear microphone support for 0414:a014

### DIFF
--- a/ucm2/USB-Audio/Realtek/ALC4080-HiFi.conf
+++ b/ucm2/USB-Audio/Realtek/ALC4080-HiFi.conf
@@ -91,6 +91,11 @@ If.gigabyte-aorus-ultra {
 	True.Define {
 		Mic1Name "Front Microphone"
 		Mic1PCM "hw:${CardId},0"
+		Mic2Name "Rear Microphone"
+		Mic2Mixer "Mic"
+		Mic2Mindex "1"
+		Mic2Jack "name='Mic - Input Jack',index=1"
+		Mic2PCM "hw:${CardId},1"
 		SpdifName ""
 		Line1Name ""
 	}


### PR DESCRIPTION
0414:a014 Gigabyte B850I Aorus Pro (rev 1.0)

Link: https://github.com/alsa-project/alsa-ucm-conf/issues/528