### PR TITLE
USB-Audio: Add Roland BridgeCast One | adapted

### DIFF
--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -188,18 +188,11 @@ If.roland-bridgecast {
 
 If.roland-bridgecastv2 {
 	Condition {
-		Type String
-		Haystack "${CardComponents}"
-		Needle "USB0582:031e"
-	}
-	True.Define.ProfileName "Roland/BridgeCastV2"
-}
-
-If.roland-bridgecastone {
-	Condition {
-		Type String
-		Haystack "${CardComponents}"
-		Needle "USB0582:030d"
+		Type RegexMatch
+		String "${CardComponents}"
+		# 0582:031e Bridge Cast Firmware V2
+		# 0582:030d Bridge Cast One
+		Regex "USB0582:03((1e)|(0d))"
 	}
 	True.Define.ProfileName "Roland/BridgeCastV2"
 }

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -195,6 +195,15 @@ If.roland-bridgecastv2 {
 	True.Define.ProfileName "Roland/BridgeCastV2"
 }
 
+If.roland-bridgecastone {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB0582:030d"
+	}
+	True.Define.ProfileName "Roland/BridgeCastV2"
+}
+
 If.roland-bridgecastx {
 	Condition {
 		Type String


### PR DESCRIPTION
Add Roland BridgeCast One
uses the same config as the bridge cast v2 as it has the same outputs and it worked in my test.

0582:030d