### PR TITLE
Add UCM2 support for ASUS ROG Strix B850-I Gaming WiFi

### DIFF
--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -62,6 +62,7 @@ If.realtek-alc4080 {
 		# 0b05:1af1 ASUS ROG Strix Z790-A Gaming Wifi II
 		# 0b05:1b7c ASUS ROG Crosshair X870E Hero
 		# 0b05:1b9b ASUS ROG STRIX X870E-E GAMING WIFI
+		# 0b05:1be1 ASUS ROG Strix B850-I Gaming WiFi
 		# 0db0:005a MSI MPG Z690 CARBON WIFI
 		# 0db0:0b58 MSI MPG X870E CARBON WIFI
 		# 0db0:124b MSI MEG Z690 ACE
@@ -95,7 +96,7 @@ If.realtek-alc4080 {
 		# 26ce:0a06 ASRock X670E/Z790 Taichi
 		# 26ce:0a08 ASRock Z790 PG-ITX/TB4, X870 Steel Legend
 		# 26ce:0a0b ASRock X870E Taichi
-		Regex "USB((0414:a0(0e|1[0124]))|(0b05:(19(84|9[69])|1a(16|2[07]|5[23c]|97|f1)|1b(7c|9b)))|(0db0:(005a|0b58|124b|151f|1feb|3130|36e7|4(19c|22d|240|88c)|543d|62a4|6c[0c]9|70d3|7696|82c7|8af7|961e|9e6d|a(073|228|47c|74b)|b202|cd0e|d1d7|d6e7|e1f8))|(26ce:0a0[68b]))"
+		Regex "USB((0414:a0(0e|1[0124]))|(0b05:(19(84|9[69])|1a(16|2[07]|5[23c]|97|f1)|1b(7c|9b|e1)))|(0db0:(005a|0b58|124b|151f|1feb|3130|36e7|4(19c|22d|240|88c)|543d|62a4|6c[0c]9|70d3|7696|82c7|8af7|961e|9e6d|a(073|228|47c|74b)|b202|cd0e|d1d7|d6e7|e1f8))|(26ce:0a0[68b]))"
 	}
 	True.Define.ProfileName "Realtek/ALC4080"
 }


### PR DESCRIPTION
[Link to open issue](https://github.com/alsa-project/alsa-ucm-conf/issues/534#issue-2948397275)

I referenced [this guide](https://askubuntu.com/a/1469066) to get SPDIF out working on my ASUS B850-I Gaming WiFi

[alsa-info.txt](https://github.com/user-attachments/files/19499096/alsa-info.txt)

In case it's relevant, using a sample rate of 48kHz is required. I found that other sample rate produces very low quality, garbled audio. I read that this is because SPDIF only supports 48kHz in hardware, and any other sample rates require the Realtek drivers.

