### PR TITLE
USB-Audio: Add focusrite scarlett 18i20 lineup

### DIFF
--- a/ucm2/USB-Audio/Focusrite/Scarlett-18i20-HiFi.conf
+++ b/ucm2/USB-Audio/Focusrite/Scarlett-18i20-HiFi.conf
@@ -1,0 +1,552 @@
+Include.pcm_split.File "/common/pcm/split.conf"
+
+# This profile exposes the most common channel configurations to ensure basic functionality.
+
+Macro [
+	{
+		SplitPCM {
+			Name "18i20_stereo_out"
+			Direction Playback
+			Format S24_3LE
+			Channels 2
+			HWChannels 20
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 FL
+			HWChannelPos3 FR
+			HWChannelPos4 FL
+			HWChannelPos5 FR
+			HWChannelPos6 FL
+			HWChannelPos7 FR
+			HWChannelPos8 FL
+			HWChannelPos9 FR
+			HWChannelPos10 FL
+			HWChannelPos11 FR
+			HWChannelPos12 FL
+			HWChannelPos13 FR
+			HWChannelPos14 FL
+			HWChannelPos15 FR
+			HWChannelPos16 FL
+			HWChannelPos17 FR
+			HWChannelPos18 FL
+			HWChannelPos19 FR
+		}
+	}
+	{
+		SplitPCM {
+			Name "18i20_mono_in"
+			Direction Capture
+			Format S24_3LE
+			Channels 1
+			HWChannels 20
+			HWChannelPos0 MONO
+			HWChannelPos1 MONO
+			HWChannelPos2 MONO
+			HWChannelPos3 MONO
+			HWChannelPos4 MONO
+			HWChannelPos5 MONO
+			HWChannelPos6 MONO
+			HWChannelPos7 MONO
+			HWChannelPos8 MONO
+			HWChannelPos9 MONO
+			HWChannelPos10 MONO
+			HWChannelPos11 MONO
+			HWChannelPos12 MONO
+			HWChannelPos13 MONO
+			HWChannelPos14 MONO
+			HWChannelPos15 MONO
+			HWChannelPos16 MONO
+			HWChannelPos17 MONO
+			HWChannelPos18 MONO
+			HWChannelPos19 MONO
+		}
+	}
+	{
+		SplitPCM {
+			Name "scarlett18i20_stereo_in"
+			Direction Capture
+			Format S24_3LE
+			Channels 2
+			HWChannels 20
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 FL
+			HWChannelPos3 FR
+			HWChannelPos4 FL
+			HWChannelPos5 FR
+			HWChannelPos6 FL
+			HWChannelPos7 FR
+			HWChannelPos8 FL
+			HWChannelPos9 FR
+			HWChannelPos10 FL
+			HWChannelPos11 FR
+			HWChannelPos12 FL
+			HWChannelPos13 FR
+			HWChannelPos14 FL
+			HWChannelPos15 FR
+			HWChannelPos16 FL
+			HWChannelPos17 FR
+			HWChannelPos18 FL
+			HWChannelPos19 FR
+		}
+	}
+	{
+		SplitPCM {
+			Name "18i20_adat_out"
+			Direction Playback
+			Format S24_3LE
+			Channels 8
+			HWChannels 20
+			HWChannelPos0 UNKNOWN
+			HWChannelPos1 UNKNOWN
+			HWChannelPos2 UNKNOWN
+			HWChannelPos3 UNKNOWN
+			HWChannelPos4 UNKNOWN
+			HWChannelPos5 UNKNOWN
+			HWChannelPos6 UNKNOWN
+			HWChannelPos7 UNKNOWN
+			HWChannelPos8 UNKNOWN
+			HWChannelPos9 UNKNOWN
+			HWChannelPos10 UNKNOWN
+			HWChannelPos11 UNKNOWN
+			HWChannelPos12 UNKNOWN
+			HWChannelPos13 UNKNOWN
+			HWChannelPos14 UNKNOWN
+			HWChannelPos15 UNKNOWN
+			HWChannelPos16 UNKNOWN
+			HWChannelPos17 UNKNOWN
+			HWChannelPos18 UNKNOWN
+			HWChannelPos19 UNKNOWN
+		}
+	}
+	{
+		SplitPCM {
+			Name "18i20_adat_in"
+			Direction Capture
+			Format S24_3LE
+			Channels 8
+			HWChannels 20
+			HWChannelPos0 UNKNOWN
+			HWChannelPos1 UNKNOWN
+			HWChannelPos2 UNKNOWN
+			HWChannelPos3 UNKNOWN
+			HWChannelPos4 UNKNOWN
+			HWChannelPos5 UNKNOWN
+			HWChannelPos6 UNKNOWN
+			HWChannelPos7 UNKNOWN
+			HWChannelPos8 UNKNOWN
+			HWChannelPos9 UNKNOWN
+			HWChannelPos10 UNKNOWN
+			HWChannelPos11 UNKNOWN
+			HWChannelPos12 UNKNOWN
+			HWChannelPos13 UNKNOWN
+			HWChannelPos14 UNKNOWN
+			HWChannelPos15 UNKNOWN
+			HWChannelPos16 UNKNOWN
+			HWChannelPos17 UNKNOWN
+			HWChannelPos18 UNKNOWN
+			HWChannelPos19 UNKNOWN
+		}
+	}
+]
+
+# Analog Outputs
+
+SectionDevice."Line 1" {
+	# not using .Headphones because this device has multiple headphone ports
+	Comment "Headphones 1"
+
+	Value {
+		PlaybackPriority 255
+	}
+	
+	Macro.pcm_split.SplitPCMDevice {
+		Name "18i20_stereo_out"
+		Direction Playback
+		HWChannels 20
+		Channels 2
+		Channel0 6
+		Channel1 7
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line 2" {
+	Comment "Headphones 2"
+
+	Value {
+		PlaybackPriority 254
+	}
+	
+	Macro.pcm_split.SplitPCMDevice {
+		Name "18i20_stereo_out"
+		Direction Playback
+		HWChannels 20
+		Channels 2
+		Channel0 8
+		Channel1 9
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line 3" {
+	Comment "Line Output 1+2"
+
+	Value {
+		PlaybackPriority 192
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "18i20_stereo_out"
+		Direction Playback
+		HWChannels 20
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line 4" {
+	Comment "Line Output 3+4"
+
+	Value {
+		PlaybackPriority 191
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "18i20_stereo_out"
+		Direction Playback
+		HWChannels 20
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line 5" {
+	Comment "Line Output 5+6"
+
+	Value {
+		PlaybackPriority 190
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "18i20_stereo_out"
+		Direction Playback
+		HWChannels 20
+		Channels 2
+		Channel0 4
+		Channel1 5
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line 6" {
+	Comment "Line Output 7+8"
+
+	ConflictingDevice [
+		"Line 1"
+	]
+
+	Value {
+		PlaybackPriority 189
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "18i20_stereo_out"
+		Direction Playback
+		HWChannels 20
+		Channels 2
+		Channel0 6
+		Channel1 7
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line 7" {
+	Comment "Line Output 9+10"
+
+	Value {
+		PlaybackPriority 188
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "18i20_stereo_out"
+		Direction Playback
+		HWChannels 20
+		Channels 2
+		Channel0 8
+		Channel1 9
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+# Analog Inputs
+
+SectionDevice."Mic 1" {
+	Comment "Input 1 (Mic)"
+
+	Value {
+		CapturePriority 176
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "18i20_mono_in"
+		Direction Capture
+		HWChannels 20
+		Channels 1
+		Channel0 0
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Mic 2" {
+	Comment "Input 2 (Mic)"
+
+	Value {
+		CapturePriority 175
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "18i20_mono_in"
+		Direction Capture
+		HWChannels 20
+		Channels 1
+		Channel0 1
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Line 8" {
+	Comment "Input 3"
+
+	Value {
+		CapturePriority 174
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "18i20_mono_in"
+		Direction Capture
+		HWChannels 20
+		Channels 1
+		Channel0 2
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Line 9" {
+	Comment "Input 4"
+
+	Value {
+		CapturePriority 173
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "18i20_mono_in"
+		Direction Capture
+		HWChannels 20
+		Channels 1
+		Channel0 3
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Line 10" {
+	Comment "Input 5"
+
+	Value {
+		CapturePriority 172
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "18i20_mono_in"
+		Direction Capture
+		HWChannels 20
+		Channels 1
+		Channel0 4
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Line 11" {
+	Comment "Input 6"
+
+	Value {
+		CapturePriority 171
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "18i20_mono_in"
+		Direction Capture
+		HWChannels 20
+		Channels 1
+		Channel0 5
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Line 12" {
+	Comment "Input 7"
+
+	Value {
+		CapturePriority 170
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "18i20_mono_in"
+		Direction Capture
+		HWChannels 20
+		Channels 1
+		Channel0 6
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Line 13" {
+	Comment "Input 8"
+
+	Value {
+		CapturePriority 169
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "18i20_mono_in"
+		Direction Capture
+		HWChannels 20
+		Channels 1
+		Channel0 7
+		ChannelPos0 MONO
+	}
+}
+
+# Digital (Consumer) Outputs
+
+SectionDevice."SPDIF 1" {
+	Comment "S/PDIF Output"
+
+	Value {
+		PlaybackPriority 112
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "18i20_stereo_out"
+		Direction Playback
+		HWChannels 20
+		Channels 2
+		Channel0 10
+		Channel1 11
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+# Digital (Professional) Outputs
+
+SectionDevice."Direct 1" {
+	Comment "ADAT Optical Output"
+
+	Value {
+		PlaybackPriority 48
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "18i20_adat_out"
+		Direction Playback
+		HWChannels 20
+		Channels 8
+		Channel0 12
+		Channel1 13
+		Channel2 14
+		Channel3 15
+		Channel4 16
+		Channel5 17
+		Channel6 18
+		Channel7 19
+		ChannelPos0 UNKNOWN
+		ChannelPos1 UNKNOWN
+		ChannelPos2 UNKNOWN
+		ChannelPos3 UNKNOWN
+		ChannelPos4 UNKNOWN
+		ChannelPos5 UNKNOWN
+		ChannelPos6 UNKNOWN
+		ChannelPos7 UNKNOWN
+	}
+}
+
+# Digital (Consumer) Inputs
+
+SectionDevice."SPDIF 2" {
+	Comment "S/PDIF Input 1"
+
+	Value {
+		CapturePriority 112
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "18i20_mono_in"
+		Direction Capture
+		HWChannels 20
+		Channels 1
+		Channel0 10
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."SPDIF 3" {
+	Comment "S/PDIF Input 2"
+
+	Value {
+		CapturePriority 111
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "18i20_mono_in"
+		Direction Capture
+		HWChannels 20
+		Channels 1
+		Channel0 11
+		ChannelPos0 MONO
+	}
+}
+
+# Digital (Professional) Inputs
+
+SectionDevice."Direct 2" {
+	Comment "ADAT Optical Input"
+
+	Value {
+		CapturePriority 48
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "18i20_adat_in"
+		Direction Capture
+		HWChannels 20
+		Channels 8
+		Channel0 12
+		Channel1 13
+		Channel2 14
+		Channel3 15
+		Channel4 16
+		Channel5 17
+		Channel6 18
+		Channel7 19
+		ChannelPos0 UNKNOWN
+		ChannelPos1 UNKNOWN
+		ChannelPos2 UNKNOWN
+		ChannelPos3 UNKNOWN
+		ChannelPos4 UNKNOWN
+		ChannelPos5 UNKNOWN
+		ChannelPos6 UNKNOWN
+		ChannelPos7 UNKNOWN
+	}
+}

--- a/ucm2/USB-Audio/Focusrite/Scarlett-18i20.conf
+++ b/ucm2/USB-Audio/Focusrite/Scarlett-18i20.conf
@@ -1,0 +1,98 @@
+# The 18i20 provides 20 playback and capture channels each:
+#
+# +----+---------------+-----------------+
+# | Ch |     Inputs    |      Outputs    |
+# +====+===============+=================+
+# |  0 |   Line/XLR 1  |      Line 1     |
+# |    |               | (Speaker Out L) |
+# +----+---------------+-----------------+
+# |  1 |   Line/XLR 2  |      Line 2     |
+# |    |               | (Speaker Out R) |
+# +----+---------------+-----------------+
+# |  2 |     Line 3    |      Line 3     |
+# +----+---------------+-----------------+
+# |  3 |     Line 4    |      Line 4     |
+# +----+---------------+-----------------+
+# |  4 |     Line 5    |      Line 5     |
+# +----+---------------+-----------------+
+# |  5 |     Line 6    |      Line 6     |
+# +----+---------------+-----------------+
+# |  6 |     Line 7    |      Line 7     |
+# |    |               | (Mirrored for   |
+# |    |               |  Headphone 1 L) |
+# +----+---------------+-----------------+
+# |  7 |     Line 8    |      Line 8     |
+# |    |               | (Mirrored for   |
+# |    |               |  Headphone 1 R) |
+# +----+---------------+-----------------+
+# |  8 |               |      Line 9     |
+# |    |               |  (Mirrored for  |
+# |    |               |  Headphone 2 L) |
+# +----+---------------+-----------------+
+# |  9 |               |     Line 10     |
+# |    |               | (Mirrored for   |
+# |    |               |  Headphone 2 R) |
+# +----+---------------+-----------------+
+# | 10 |   S/PDIF 1    |     S/PDIF 1    |
+# +----+---------------+-----------------+
+# | 11 |   S/PDIF 2    |     S/PDIF 2    |
+# +----+---------------+-----------------+
+# | 12 |   ADAT 1.1    |     ADAT 1.1    |
+# +----+---------------+-----------------+
+# | 13 |   ADAT 1.2    |     ADAT 1.2    |
+# +----+---------------+-----------------+
+# | 14 |   ADAT 1.3    |     ADAT 1.3    |
+# +----+---------------+-----------------+
+# | 15 |   ADAT 1.4    |     ADAT 1.4    |
+# +----+---------------+-----------------+
+# | 16 |   ADAT 1.5    |     ADAT 1.5    |
+# +----+---------------+-----------------+
+# | 17 |   ADAT 1.6    |     ADAT 1.6    |
+# +----+---------------+-----------------+
+# | 18 |   ADAT 1.7    |     ADAT 1.7    |
+# +----+---------------+-----------------+
+# | 19 |   ADAT 1.8    |     ADAT 1.8    |
+# +----+---------------+-----------------+
+# 
+Define {
+	Generation "1st"
+}
+
+If.gen2 {
+	Condition {
+		Type RegexMatch
+		String "${CardComponents}"
+		Regex "USB1235:8201"
+	}
+	True.Define.Generation "2nd"
+}
+
+If.gen3 {
+	Condition {
+		Type RegexMatch
+		String "${CardComponents}"
+		Regex "USB1235:8215"
+	}
+	True.Define.Generation "3rd"
+}
+
+If.gen4 {
+	Condition {
+		Type RegexMatch
+		String "${CardComponents}"
+		Regex "USB1235:821d"
+	}
+	True.Define.Generation "4th"
+}
+
+Comment "Focusrite Scarlett 18i20 ${var:Generation} Gen"
+
+SectionUseCase."HiFi" {
+	Comment "HiFi"
+	File "/USB-Audio/Focusrite/Scarlett-18i20-HiFi.conf"
+}
+
+Define.DirectPlaybackChannels 20
+Define.DirectCaptureChannels 20
+
+Include.dhw.File "/common/direct.conf"

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -330,6 +330,19 @@ If.focusrite-scarlett-2i {
 	}
 }
 
+If.focusrite-scarlett-18i20 {
+    Condition {
+        Type RegexMatch
+        String "${CardComponents}"
+		# 800C 1st Gen
+		# 8201 2nd Gen
+		# 8215 3rd Gen
+		# 821d 4th Gen
+        Regex "USB1235:8(00C|2(01|1(5|d)))"
+    }
+    True.Define.ProfileName "Focusrite/Scarlett-18i20"
+}
+
 If.behringer-umc202hd {
 	Condition {
 		Type String


### PR DESCRIPTION
Other solutions exist to add full mixing and routing with these devices. This PR adds basic functionality in an out-of-the-box style for 1st gen, 2nd gen, 3rd gen, and 4th gen.

IO includes XLR, Line, S/PDIF, ADAT, and Headphone ports.