### PR TITLE
ucm2: sof-soundwire: Correct include file path for dsp.conf

### DIFF
--- a/ucm2/sof-soundwire/sof-soundwire.conf
+++ b/ucm2/sof-soundwire/sof-soundwire.conf
@@ -185,7 +185,7 @@ If.HdmiIec61937 {
 }
 
 # Define macros to set up processing controls
-Include.dsp-variables.File "../Intel/sof-hda-dsp/dsp.conf"
+Include.dsp-variables.File "/Intel/sof-hda-dsp/dsp.conf"
 
 # Set BootSequence and FixedBootSequence for drc, eqiir, eqfir
 Macro.SpeakerDrc.SofDrcBootSetup "endpoint='PostMixerSpeaker' direction='Playback'"


### PR DESCRIPTION
The file path must be given as absolut and not relative, otherwise the dsp.conf file will not be found:
$ alsaucm dump text
ALSA lib utils.c:364:(uc_mgr_config_load_into) could not open configuration file /usr/share/alsa/ucm2/conf.d/sof-soundwire/../Intel/sof-hda-dsp/dsp.conf ALSA lib parser.c:78:(uc_mgr_config_load_file) error: failed to open file /usr/share/alsa/ucm2/conf.d/sof-soundwire/../Intel/sof-hda-dsp/dsp.conf: -2 ALSA lib main.c:1554:(snd_use_case_mgr_open) error: failed to import hw:0 use case configuration -2 alsaucm: error failed to open sound card hw:0: No such file or directory

Fixes: c9d1f7eafa6c ("UCM2: sof-soundwire: Enable DRC and equalizers for")