### PR TITLE
ucm2: Qualcomm: add Lenovo ThinkBook 16 support

### DIFF
--- a/ucm2/Qualcomm/x1e80100/x1e80100.conf
+++ b/ucm2/Qualcomm/x1e80100/x1e80100.conf
@@ -6,7 +6,7 @@ If.LENOVOT14s {
 	Condition {
 		Type RegexMatch
 		String "${var:DMI_info}"
-		Regex "(LENOVO.*ThinkPad T14s Gen 6.*)|(HP.*Omnibook X.*)"
+		Regex "LENOVO.*Think((Pad T14s Gen 6.*)|(Book 16 G7 QOY))|(HP.*Omnibook X.*)"
 	}
 	True.Include.t14s.File "/Qualcomm/x1e80100/LENOVO-T14s.conf"
 }


### PR DESCRIPTION
add a Regex string, seems compatible with Thinkpad T14s

Tested-by: Jens Glathe <jens.glathe@oldschoolsolutions.biz>