### PR TITLE
ucm2: Qualcomm: add Asus Zenbook A14

### DIFF
--- a/ucm2/Qualcomm/x1e80100/x1e80100.conf
+++ b/ucm2/Qualcomm/x1e80100/x1e80100.conf
@@ -6,7 +6,7 @@ If.LENOVOT14s {
 	Condition {
 		Type RegexMatch
 		String "${var:DMI_info}"
-		Regex "LENOVO.*Think((Pad T14s Gen 6.*)|(Book 16 G7 QOY))|(HP.*Omnibook X.*)"
+		Regex "LENOVO.*Think((Pad T14s Gen 6.*)|(Book 16 G7 QOY))|(HP.*Omnibook X.*)|(ASUSTeK COMPUTER.*ASUS Zenbook A14)"
 	}
 	True.Include.t14s.File "/Qualcomm/x1e80100/LENOVO-T14s.conf"
 }


### PR DESCRIPTION
Add a Regex string, seems compatible with Lenovo T14s x2 speakers, x2 DMICs, x3 DP (x2 USB-C, x1 DP->HDMI), headphone jack.

Initial support for the platform is available on the [lists](https://lore.kernel.org/all/20250402084646.10098-1-alex.vinarskis@gmail.com/), with [Audio part ](https://github.com/alexVinarskis/linux-x1e80100-zenbook-a14/blob/master/0013-arm64-dts-qcom-support-sound-on-Asus-Zenbook-A14.patch)not being upstreamed just yet.

Tested that speakers, MICs and jack are working.

Respective audioreach-topology changes are open [for PR.](https://github.com/linux-msm/audioreach-topology/pull/14)