### PR TITLE
ucm2: MediaTek: mt8395-evk: Add support for SOF 

### DIFF
--- a/ucm2/MediaTek/mt8395-evk/HiFi.conf
+++ b/ucm2/MediaTek/mt8395-evk/HiFi.conf
@@ -77,7 +77,7 @@ SectionDevice."Speaker" {
 	Value {
 		PlaybackPriority 300
 		PlaybackChannels 2
-		PlaybackPCM "hw:${CardId},0"
+		PlaybackPCM "hw:${CardId},${var:PlayDevN}"
 	}
 }
 
@@ -99,7 +99,7 @@ SectionDevice."Headphones" {
 	Value {
 		PlaybackPriority 400
 		PlaybackChannels 2
-		PlaybackPCM "hw:${CardId},0"
+		PlaybackPCM "hw:${CardId},${var:PlayDevN}"
 		JackControl "Headphone Jack"
 	}
 }
@@ -117,8 +117,8 @@ SectionDevice."Headset" {
 
 	Value {
 		CapturePriority 500
-		CaptureChannels 3
-		CapturePCM "hw:${CardId},15"
+		CaptureChannels "${var:CapChanN}"
+		CapturePCM "hw:${CardId},${var:CapDevN}"
 		JackControl "Headset Mic Jack"
 	}
 }
@@ -146,7 +146,7 @@ SectionDevice."Mic1" {
 	Value {
 		CapturePriority 400
 		CaptureChannels 3
-		CapturePCM "hw:${CardId},15"
+		CapturePCM "hw:${CardId},${var:CapDevN}"
 	}
 }
 

--- a/ucm2/MediaTek/mt8395-evk/init.conf
+++ b/ucm2/MediaTek/mt8395-evk/init.conf
@@ -1,0 +1,34 @@
+Syntax 4
+
+SectionUseCase."HiFi" {
+	File "/MediaTek/mt8395-evk/HiFi.conf"
+	Comment "Play high quality music"
+}
+
+BootSequence [
+	cset "name='HP Mux' Audio Playback"
+	cset "name='LOL Mux' Open"
+	cset "name='MISO0_MUX' UL1_CH1"
+	cset "name='MISO1_MUX' UL1_CH1"
+	cset "name='ADC_L_Mux' Left Preamplifier"
+	cset "name='ADC_R_Mux' Right Preamplifier"
+	cset "name='ADC_3_Mux' Preamplifier"
+	cset "name='PGA_L_Mux' AIN1"
+	cset "name='PGA_R_Mux' AIN2"
+	cset "name='PGA_3_Mux' AIN3"
+	cset "name='HDMI_OUT_MUX' Connect"
+	cset "name='DPTX_OUT_MUX' Disconnect"
+	cset "name='Lineout Volume' 10"
+	cset "name='Headset Volume' 2"
+	cset "name='PGA1 Volume' 4"
+	cset "name='PGA2 Volume' 4"
+	cset "name='PGA3 Volume' 4"
+	cset "name='O000 I000 Switch' on"
+	cset "name='O001 I001 Switch' on"
+	cset "name='O034 I168 Switch' on"
+	cset "name='O035 I169 Switch' on"
+	cset "name='O040 I002 Switch' on"
+	cset "name='O041 I003 Switch' on"
+	cset "name='O176 I070 Switch' on"
+	cset "name='O177 I071 Switch' on"
+]

--- a/ucm2/MediaTek/mt8395-evk/mt8395-evk.conf
+++ b/ucm2/MediaTek/mt8395-evk/mt8395-evk.conf
@@ -1,31 +1,13 @@
 Syntax 4
 
-SectionUseCase."HiFi" {
-	File "/MediaTek/mt8395-evk/HiFi.conf"
-	Comment "Play high quality music"
+Define {
+	PlayDevN "0"
+	CapDevN "15"
+	CapChanN "3"
 }
 
 BootSequence [
-	cset "name='HP Mux' Audio Playback"
-	cset "name='LOL Mux' Open"
-	cset "name='MISO0_MUX' UL1_CH1"
-	cset "name='MISO1_MUX' UL1_CH1"
-	cset "name='ADC_L_Mux' Left Preamplifier"
-	cset "name='ADC_R_Mux' Right Preamplifier"
-	cset "name='ADC_3_Mux' Preamplifier"
-	cset "name='PGA_L_Mux' AIN1"
-	cset "name='PGA_R_Mux' AIN2"
-	cset "name='PGA_3_Mux' AIN3"
-	cset "name='HDMI_OUT_MUX' Connect"
-	cset "name='DPTX_OUT_MUX' Disconnect"
 	cset "name='MULTI_IN1_MUX' HDMI_RX_I2S"
-	cset "name='Lineout Volume' 10"
-	cset "name='Headset Volume' 2"
-	cset "name='PGA1 Volume' 4"
-	cset "name='PGA2 Volume' 4"
-	cset "name='PGA3 Volume' 4"
-	cset "name='O000 I000 Switch' on"
-	cset "name='O001 I001 Switch' on"
 	cset "name='O002 I004 Switch' on"
 	cset "name='O003 I005 Switch' on"
 	cset "name='O004 I006 Switch' on"
@@ -34,14 +16,9 @@ BootSequence [
 	cset "name='O007 I009 Switch' on"
 	cset "name='O008 I010 Switch' on"
 	cset "name='O009 I011 Switch' on"
-	cset "name='O034 I168 Switch' on"
-	cset "name='O035 I169 Switch' on"
 	cset "name='O038 I168 Switch' on"
 	cset "name='O039 I169 Switch' on"
-	cset "name='O040 I002 Switch' on"
-	cset "name='O041 I003 Switch' on"
-	cset "name='O176 I070 Switch' on"
-	cset "name='O177 I071 Switch' on"
 	cset "name='O182 I170 Switch' on"
 	cset "name='O183 I171 Switch' on"
 ]
+Include.init.File "/MediaTek/mt8395-evk/init.conf"

--- a/ucm2/MediaTek/sof-mt8395-evk/sof-mt8395-evk.conf
+++ b/ucm2/MediaTek/sof-mt8395-evk/sof-mt8395-evk.conf
@@ -1,0 +1,9 @@
+Syntax 4
+
+Define {
+	PlayDevN "16"
+	CapDevN "18"
+	CapChanN "2"
+}
+
+Include.init.File "/MediaTek/mt8395-evk/init.conf"

--- a/ucm2/conf.d/sof-mt8395-evk/sof-mt8395-evk.conf
+++ b/ucm2/conf.d/sof-mt8395-evk/sof-mt8395-evk.conf
@@ -1,0 +1,1 @@
+../../MediaTek/sof-mt8395-evk/sof-mt8395-evk.conf


### PR DESCRIPTION
Similar to #513, add support for MT8395 with SOF enabled.

We use different playback and capture PCM. Also, split the mixers that are not yet available upstream.