### PR TITLE
acp3x-alc5682-max98357: Fix path of HiFi.conf

### DIFF
--- a/ucm2/AMD/acp3x-alc5682-max98357/acp3x-alc5682-max98357.conf
+++ b/ucm2/AMD/acp3x-alc5682-max98357/acp3x-alc5682-max98357.conf
@@ -66,7 +66,7 @@ If.found {
 		Empty "${var:Found}"
 	}
 	False.SectionUseCase."HiFi" {
-		File "/AMD/acp3xalc5682m98/HiFi.conf"
+		File "HiFi.conf"
 		Comment "Default"
 	}
 }


### PR DESCRIPTION
Closes: https://github.com/alsa-project/alsa-ucm-conf/issues/550
Fixes: 1048796e7fa9 ("Rename ucm2/AMD/acp3xalc5682m98 to ucm2/AMD/acp3x-alc5682-max98357")