### PR TITLE
tegra: max98089: update cset names

### DIFF
--- a/ucm2/Tegra/max98089/lge-x3-HiFi.conf
+++ b/ucm2/Tegra/max98089/lge-x3-HiFi.conf
@@ -11,20 +11,16 @@ SectionDevice."Speaker" {
 		cset "name='Speaker Switch' on"
 		cset "name='Int Spk Switch' on"
 
-		cset "name='Left SPK Mixer Left DAC1 Switch' on"
-		cset "name='Left SPK Mixer Left DAC2 Switch' on"
-		cset "name='Left SPK Mixer Right DAC1 Switch' on"
-		cset "name='Left SPK Mixer Right DAC2 Switch' on"
+		cset "name='Left SPK Mixer Left DAC Switch' on"
+		cset "name='Left SPK Mixer Right DAC Switch' on"
 	]
 
 	DisableSequence [
 		cset "name='Speaker Switch' off"
 		cset "name='Int Spk Switch' off"
 
-		cset "name='Left SPK Mixer Left DAC1 Switch' off"
-		cset "name='Left SPK Mixer Left DAC2 Switch' off"
-		cset "name='Left SPK Mixer Right DAC1 Switch' off"
-		cset "name='Left SPK Mixer Right DAC2 Switch' off"
+		cset "name='Left SPK Mixer Left DAC Switch' off"
+		cset "name='Left SPK Mixer Right DAC Switch' off"
 	]
 
 	Value {
@@ -46,19 +42,15 @@ SectionDevice."Headphones" {
 	EnableSequence [
 		cset "name='Headphone Switch' on"
 
-		cset "name='Left HP Mixer Left DAC1 Switch' on"
-		cset "name='Left HP Mixer Left DAC2 Switch' on"
-		cset "name='Right HP Mixer Right DAC1 Switch' on"
-		cset "name='Right HP Mixer Right DAC2 Switch' on"
+		cset "name='Left HP Mixer Left DAC Switch' on"
+		cset "name='Right HP Mixer Right DAC Switch' on"
 	]
 
 	DisableSequence [
 		cset "name='Headphone Switch' off"
 
-		cset "name='Left HP Mixer Left DAC1 Switch' off"
-		cset "name='Left HP Mixer Left DAC2 Switch' off"
-		cset "name='Right HP Mixer Right DAC1 Switch' off"
-		cset "name='Right HP Mixer Right DAC2 Switch' off"
+		cset "name='Left HP Mixer Left DAC Switch' off"
+		cset "name='Right HP Mixer Right DAC Switch' off"
 	]
 
 	Value {

--- a/ucm2/Tegra/max98089/lge-x3-VoiceCall.conf
+++ b/ucm2/Tegra/max98089/lge-x3-VoiceCall.conf
@@ -11,20 +11,16 @@ SectionDevice."Speaker" {
 		cset "name='Speaker Switch' on"
 		cset "name='Int Spk Switch' on"
 
-		cset "name='Left SPK Mixer Left DAC1 Switch' on"
-		cset "name='Left SPK Mixer Left DAC2 Switch' on"
-		cset "name='Left SPK Mixer Right DAC1 Switch' on"
-		cset "name='Left SPK Mixer Right DAC2 Switch' on"
+		cset "name='Left SPK Mixer Left DAC Switch' on"
+		cset "name='Left SPK Mixer Right DAC Switch' on"
 	]
 
 	DisableSequence [
 		cset "name='Speaker Switch' off"
 		cset "name='Int Spk Switch' off"
 
-		cset "name='Left SPK Mixer Left DAC1 Switch' off"
-		cset "name='Left SPK Mixer Left DAC2 Switch' off"
-		cset "name='Left SPK Mixer Right DAC1 Switch' off"
-		cset "name='Left SPK Mixer Right DAC2 Switch' off"
+		cset "name='Left SPK Mixer Left DAC Switch' off"
+		cset "name='Left SPK Mixer Right DAC Switch' off"
 	]
 
 	Value {
@@ -47,30 +43,22 @@ SectionDevice."Earpiece" {
 		cset "name='Receiver Switch' on"
 		cset "name='Earpiece Switch' on"
 
-		cset "name='Left REC Mixer Left DAC1 Switch' on"
-		cset "name='Left REC Mixer Left DAC2 Switch' on"
-		cset "name='Left REC Mixer Right DAC1 Switch' on"
-		cset "name='Left REC Mixer Right DAC2 Switch' on"
+		cset "name='Left REC Mixer Left DAC Switch' on"
+		cset "name='Left REC Mixer Right DAC Switch' on"
 
-		cset "name='Right REC Mixer Left DAC1 Switch' on"
-		cset "name='Right REC Mixer Left DAC2 Switch' on"
-		cset "name='Right REC Mixer Right DAC1 Switch' on"
-		cset "name='Right REC Mixer Right DAC2 Switch' on"
+		cset "name='Right REC Mixer Left DAC Switch' on"
+		cset "name='Right REC Mixer Right DAC Switch' on"
 	]
 
 	DisableSequence [
 		cset "name='Receiver Switch' off"
 		cset "name='Earpiece Switch' off"
 
-		cset "name='Left REC Mixer Left DAC1 Switch' off"
-		cset "name='Left REC Mixer Left DAC2 Switch' off"
-		cset "name='Left REC Mixer Right DAC1 Switch' off"
-		cset "name='Left REC Mixer Right DAC2 Switch' off"
+		cset "name='Left REC Mixer Left DAC Switch' off"
+		cset "name='Left REC Mixer Right DAC Switch' off"
 
-		cset "name='Right REC Mixer Left DAC1 Switch' off"
-		cset "name='Right REC Mixer Left DAC2 Switch' off"
-		cset "name='Right REC Mixer Right DAC1 Switch' off"
-		cset "name='Right REC Mixer Right DAC2 Switch' off"
+		cset "name='Right REC Mixer Left DAC Switch' off"
+		cset "name='Right REC Mixer Right DAC Switch' off"
 	]
 
 	Value {

--- a/ucm2/Tegra/max98089/lge-x3.conf
+++ b/ucm2/Tegra/max98089/lge-x3.conf
@@ -30,10 +30,8 @@ BootSequence [
 	cset "name='Internal Mic 2 Switch' off"
 	cset "name='Mic Jack Switch' off"
 
-	cset "name='Right SPK Mixer Left DAC1 Switch' on"
-	cset "name='Right SPK Mixer Left DAC2 Switch' on"
-	cset "name='Right SPK Mixer Right DAC1 Switch' on"
-	cset "name='Right SPK Mixer Right DAC2 Switch' on"
+	cset "name='Right SPK Mixer Left DAC Switch' on"
+	cset "name='Right SPK Mixer Right DAC Switch' on"
 ]
 
 SectionUseCase."HiFi" {


### PR DESCRIPTION
Adjust configs to match Linux kernel MAX98089 codec driver change.

Fixes: 725570f9 ("ASoC: max98088: Remove duplicate DACs")

Link to Linux kernel commit which caused regression:
https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/sound/soc/codecs/max98088.c?h=v6.14.4&id=725570f96321f3e0ae1c6a1f80482d2907538d07