### PR TITLE
ucm2: IO-Boards: Toradex: smarc: add support

### DIFF
--- a/ucm2/IO-Boards/Toradex/smarc/dev-HiFi.conf
+++ b/ucm2/IO-Boards/Toradex/smarc/dev-HiFi.conf
@@ -1,0 +1,39 @@
+# Use case configuration for Toradex SMARC Development Carrier Board
+# This is a carrier board for the Toradex SMARC family, where any Toradex SMARC
+# SoM (with different SoCs as iMX8MP, iMX95...) can be connected to it.
+
+SectionDevice."Headphones" {
+	Comment "Headphones"
+
+	EnableSequence [
+		cset "name='Headphone Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Headphone Switch' off"
+	]
+
+	Value {
+		PlaybackPCM "hw:${CardId}"
+		PlaybackVolume "Headphone Volume"
+		PlaybackSwitch "Headphone Switch"
+	}
+}
+
+SectionDevice."Mic" {
+	Comment "Microphone"
+
+	EnableSequence [
+		cset "name='Capture Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Capture Switch' off"
+	]
+
+	Value {
+		CapturePCM "hw:${CardId}"
+		CaptureVolume "Capture Volume"
+		CaptureSwitch "Capture Switch"
+	}
+}

--- a/ucm2/IO-Boards/Toradex/smarc/dev.conf
+++ b/ucm2/IO-Boards/Toradex/smarc/dev.conf
@@ -1,0 +1,17 @@
+# Use case configuration for Toradex SMARC Development Carrier Board
+# This is a carrier board for the Toradex SMARC family, where any Toradex SMARC
+# SoM (with different SoCs as iMX8MP, iMX95...) can be connected to it.
+
+Syntax 4
+
+SectionUseCase."HiFi" {
+	File "/IO-Boards/Toradex/smarc/dev-HiFi.conf"
+	Comment "Default"
+}
+
+BootSequence [
+	cset "name='Headphone Volume' 50%"
+	cset "name='Left Capture Inverting Mux' 'IN1L'"
+	cset "name='Right Capture Inverting Mux' 'IN1R'"
+	cset "name='Capture Volume' 31"
+]

--- a/ucm2/conf.d/simple-card/tdx-smarc-wm8904.conf
+++ b/ucm2/conf.d/simple-card/tdx-smarc-wm8904.conf
@@ -1,0 +1,1 @@
+../../IO-Boards/Toradex/smarc/dev.conf


### PR DESCRIPTION
Add support for Toradex SMARC Development board, using the WM8904 audio codec.

This is a carrier board for the Toradex SMARC family, where any SMARC SoM can be connected to it, therefore this is being added to the IO-Boards instead of a specific hardware vendor.