### PR TITLE
Device rename regression fixes

### DIFF
--- a/ucm2/Qualcomm/sc8280xp/HiFi.conf
+++ b/ucm2/Qualcomm/sc8280xp/HiFi.conf
@@ -50,8 +50,8 @@ SectionDevice."Headphones" {
 	}
 }
 
-SectionDevice."Mic" {
-	Comment "Mic"
+SectionDevice."Headset" {
+	Comment "Headset microphone"
 
 	Include.wcdmice.File "/codecs/wcd938x/HeadphoneMicEnableSeq.conf"
 	Include.wcdmicd.File "/codecs/wcd938x/HeadphoneMicDisableSeq.conf"
@@ -63,12 +63,12 @@ SectionDevice."Mic" {
 		CapturePCM "hw:${CardId},2"
 		CaptureMixerElem "ADC2"
 		JackControl "Mic Jack"
-		JackHWMute "DMic01"
+		JackHWMute "Mic"
 	}
 }
 
 SectionDevice."Mic" {
-	Comment "Microphone"
+	Comment "Internal microphones"
 
 	Include.vadm0e.File "/codecs/qcom-lpass/va-macro/DMIC0EnableSeq.conf"
 	Include.vadm0d.File "/codecs/qcom-lpass/va-macro/DMIC0DisableSeq.conf"

--- a/ucm2/Qualcomm/sm8650/QRD/HiFi.conf
+++ b/ucm2/Qualcomm/sm8650/QRD/HiFi.conf
@@ -77,8 +77,8 @@ SectionDevice."Headset" {
 		CapturePCM "hw:${CardId},2"
 		CaptureMixerElem "ADC2"
 		JackControl "Mic Jack"
-		JackHWMute "Bottom"
-		JackHWMute "Back"
+		JackHWMute "Mic1"
+		JackHWMute "Mic2"
 	}
 }
 

--- a/ucm2/Tegra/max98090/HiFi.conf
+++ b/ucm2/Tegra/max98090/HiFi.conf
@@ -33,7 +33,7 @@ SectionDevice."Headphones" {
 	Comment = "Headphones"
 
 	ConflictingDevice [
-		"Speakers"
+		"Speaker"
 	]
 
 	EnableSequence [

--- a/ucm2/USB-Audio/Behringer/Flow8-Recording-Hifi.conf
+++ b/ucm2/USB-Audio/Behringer/Flow8-Recording-Hifi.conf
@@ -157,7 +157,7 @@ SectionDevice."Line5" {
 	Comment "Line/Inst 5 (L)"
 
 	ConflictingDevice [
-		"Line56"
+		"Line9"
 	]
 
 	Value {
@@ -177,7 +177,7 @@ SectionDevice."Line6" {
 	Comment "Line/Inst(HiZ) 6 (R)"
 
 	ConflictingDevice [
-		"Line56"
+		"Line9"
 	]
 
 	Value {
@@ -197,7 +197,7 @@ SectionDevice."Line7" {
 	Comment "Line/Inst 7 (L)"
 
 	ConflictingDevice [
-		"Line78"
+		"Line10"
 	]
 
 	Value {
@@ -217,7 +217,7 @@ SectionDevice."Line8" {
 	Comment "Line/Inst(HiZ) 8 (R)"
 
 	ConflictingDevice [
-		"Line78"
+		"Line10"
 	]
 
 	Value {


### PR DESCRIPTION
A recent change renaming device sections introduced a name collision which broke the internal microphones on the Lenovo ThinkPad X13s. A number of jack hw mute and conflicting devices properties are now also referring to non-existing devices.

Please consider doing a bug fix release as soon as possible to address the X13s regression in v1.2.14.