### PR TITLE
USB-Audio: Solid State Labs SSL 2 - fix capture channels

### DIFF
--- a/ucm2/USB-Audio/SolidStateLabs/SSL2-HiFi.conf
+++ b/ucm2/USB-Audio/SolidStateLabs/SSL2-HiFi.conf
@@ -6,7 +6,7 @@ Macro [
 			Name "ssl2_mono_in"
 			Direction Capture
 			Channels 1
-			HWChannels 2
+			HWChannels 4
 			HWChannelPos0 MONO
 			HWChannelPos1 MONO
 		}
@@ -31,7 +31,7 @@ SectionDevice."Mic1" {
 	Macro.pcm_split.SplitPCMDevice {
 		Name "ssl2_mono_in"
 		Direction Capture
-		HWChannels 2
+		HWChannels 4
 		Channels 1
 		Channel0 0
 		ChannelPos0 MONO
@@ -47,7 +47,7 @@ SectionDevice."Mic2" {
 	Macro.pcm_split.SplitPCMDevice {
 		Name "ssl2_mono_in"
 		Direction Capture
-		HWChannels 2
+		HWChannels 4
 		Channels 1
 		Channel0 1
 		ChannelPos0 MONO

--- a/ucm2/USB-Audio/SolidStateLabs/SSL2.conf
+++ b/ucm2/USB-Audio/SolidStateLabs/SSL2.conf
@@ -6,6 +6,6 @@ SectionUseCase."HiFi" {
 }
 
 Define.DirectPlaybackChannels 2
-Define.DirectCaptureChannels 2
+Define.DirectCaptureChannels 4
 
 Include.dhw.File "/common/direct.conf"


### PR DESCRIPTION
Same fix as for SSL+, commit fc17ed4.
Capture configuration is the same, with 4 channels.

-- alsa-info --

Solid State Logic SSL 2 at usb-0000:00:14.0-1, high speed : USB Audio

Playback:
  Status: Stop
  Interface 1
    Altset 1
    Format: S32_LE
    Channels: 2
    Endpoint: 0x01 (1 OUT) (ASYNC)
    Rates: 44100, 48000, 88200, 96000, 176400, 192000
    Data packet interval: 125 us
    Bits: 24
    Channel map: FL FR
    Sync Endpoint: 0x81 (1 IN)
    Sync EP Interface: 2
    Sync EP Altset: 1
    Implicit Feedback Mode: Yes

Capture:
  Status: Stop
  Interface 2
    Altset 1
    Format: S32_LE
    Channels: 4
    Endpoint: 0x81 (1 IN) (ASYNC)
    Rates: 44100, 48000, 88200, 96000, 176400, 192000
    Data packet interval: 125 us
    Bits: 24
    Channel map: FL FR FC LFE