### PR TITLE
ucm2: Qualcomm: add ASUS Vivobook S 15 support

### DIFF
--- a/ucm2/Qualcomm/x1e80100/x1e80100.conf
+++ b/ucm2/Qualcomm/x1e80100/x1e80100.conf
@@ -6,7 +6,7 @@ If.LENOVOT14s {
 	Condition {
 		Type RegexMatch
 		String "${var:DMI_info}"
-		Regex "LENOVO.*Think((Pad T14s Gen 6.*)|(Book 16 G7 QOY))|(HP.*Omnibook X.*)|(ASUSTeK COMPUTER.*ASUS Zenbook A14)|(Microsoft Corporation.*Surface.*Microsoft Surface Laptop, 7th Edition)"
+		Regex "LENOVO.*Think((Pad T14s Gen 6.*)|(Book 16 G7 QOY))|(HP.*Omnibook X.*)|ASUSTeK COMPUTER.*ASUS (Zenbook A14|Vivobook S 15)|(Microsoft Corporation.*Surface.*Microsoft Surface Laptop, 7th Edition)"
 	}
 	True.Include.t14s.File "/Qualcomm/x1e80100/LENOVO-T14s.conf"
 }


### PR DESCRIPTION
S15 supports:
	- 2 speakers.
	- 2 dmics
	- headset with mic.

This patch adds support to all these, however only speakers, dmic and headset playback is tested.