### PR TITLE
USB-Audio: Changed GoXLR 'Stream Mix' channel names to match the latest Windows release

### DIFF
--- a/ucm2/USB-Audio/GoXLR/GoXLR-HiFi.conf
+++ b/ucm2/USB-Audio/GoXLR/GoXLR-HiFi.conf
@@ -140,7 +140,7 @@ SectionDevice."Line3" {
 }
 
 SectionDevice."Line4" {
-	Comment "Broadcast Stream Mix"
+	Comment "Stream Mix 1"
 
 	Value {
 		CapturePriority 200
@@ -200,7 +200,7 @@ If.mix2 {
 		String2 "25"
 	}
 	True.SectionDevice."Line6" {
-		Comment "Broadcast Stream Mix 2"
+		Comment "Stream Mix 2"
 
 		Value {
 			CapturePriority 200


### PR DESCRIPTION
This change is to match the Broadcast Mix channel names to the latest release of the GoXLR App on Windows.