### PR TITLE
ucm2: sof-soundwire: add rt712-vb device

### DIFF
--- a/ucm2/codecs/rt712/init.conf
+++ b/ucm2/codecs/rt712/init.conf
@@ -1,8 +1,30 @@
 # RT712 specific volume control settings
 
-BootSequence [
-	cset "name='rt712 FU05 Playback Volume' 87"
-	cset "name='rt712 ADC 23 Mux' 'MIC2'"
-	cset "name='rt712 FU0F Capture Volume' 57"
-	cset "name='rt712 FU0F Capture Switch' 1"
-]
+If.rt712_init {
+	Condition {
+		Type RegexMatch
+		Regex "(rt712(-sdca)?)"
+		String "${var:MultiMicShadow}"
+	}
+	True {
+		# RT712-VB integrated with DMIC
+		BootSequence [
+			cset "name='rt712 FU05 Playback Volume' 87"
+			cset "name='rt712 ADC 23 Mux' 'MIC2'"
+			cset "name='rt712 FU0F Capture Volume' 57"
+			cset "name='rt712 FU0F Capture Switch' 1"
+			cset "name='rt712 FU1E Capture Switch' 1"
+			cset "name='rt712 FU1E Capture Volume' 47"
+			cset "name='rt712 ADC 0A Mux' 'DMIC1'"
+			cset "name='rt712 ADC 0B Mux' 'DMIC2'"
+		]
+	}
+	False {
+		BootSequence [
+			cset "name='rt712 FU05 Playback Volume' 87"
+			cset "name='rt712 ADC 23 Mux' 'MIC2'"
+			cset "name='rt712 FU0F Capture Volume' 57"
+			cset "name='rt712 FU0F Capture Switch' 1"
+		]
+	}
+}

--- a/ucm2/sof-soundwire/rt712.conf
+++ b/ucm2/sof-soundwire/rt712.conf
@@ -85,3 +85,32 @@ SectionDevice."Headset" {
 		JackControl "Headset Mic Jack"
 	}
 }
+
+If.codecmic {
+	Condition {
+		Type RegexMatch
+		Regex "(rt712(-sdca)?)"
+		String "${var:MultiMicShadow}"
+	}
+	True {
+		SectionDevice."Mic" {
+			Comment "SoundWire Microphones"
+
+			EnableSequence [
+				cset "name='rt712 FU1E Capture Switch' 1"
+			]
+
+			DisableSequence [
+				cset "name='rt712 FU1E Capture Switch' 0"
+			]
+
+			Value {
+				CapturePriority 100
+				CapturePCM "hw:${CardId},4"
+				CaptureSwitch "rt712 FU1E Capture Switch"
+				CaptureVolume "rt712 FU1E Capture Volume"
+				CaptureMixerElem "rt712 FU1E"
+			}
+		}
+	}
+}


### PR DESCRIPTION
This patch supports RT712VB device integrated with DMIC in one Soundwire interface.