### PR TITLE
Qualcomm: Add QCS9075-IQ-EVK HiFi config

### DIFF
--- a/ucm2/Qualcomm/qcs9075/qcs9075-iq-evk-snd-card/HiFi.conf
+++ b/ucm2/Qualcomm/qcs9075/qcs9075-iq-evk-snd-card/HiFi.conf
@@ -1,0 +1,29 @@
+SectionVerb {
+	Value {
+		TQ "HiFi"
+	}
+	EnableSequence [
+		cset "name='PRIMARY_SDR_MI2S_RX Audio Mixer MULTIMEDIA0' 1"
+		cset "name='MULTIMEDIA1 Audio Mixer TERTIARY_SDR_MI2S_TX' 1"
+	]
+}
+
+SectionDevice."Speaker" {
+	Comment "Speaker playback"
+
+	Value {
+		PlaybackPriority 100
+		PlaybackPCM "hw:${CardId},0"
+		PlaybackMixer "default:${CardId}"
+		PlaybackMixerElem "Speakers"
+	}
+}
+
+SectionDevice."Mic" {
+	Comment "Mic"
+
+	Value {
+		CapturePriority 100
+		CapturePCM "hw:${CardId},1"
+	}
+}

--- a/ucm2/Qualcomm/qcs9075/qcs9075-iq-evk-snd-card/qcs9075-iq-evk-snd-card.conf
+++ b/ucm2/Qualcomm/qcs9075/qcs9075-iq-evk-snd-card/qcs9075-iq-evk-snd-card.conf
@@ -1,0 +1,6 @@
+Syntax 4
+
+SectionUseCase."HiFi" {
+	File "/Qualcomm/qcs9075/qcs9075-iq-evk-snd-card/HiFi.conf"
+	Comment "HiFi quality Music"
+}

--- a/ucm2/conf.d/qcs9075/qcs9075-iq-evk-snd-card.conf
+++ b/ucm2/conf.d/qcs9075/qcs9075-iq-evk-snd-card.conf
@@ -1,0 +1,6 @@
+Syntax 4
+
+SectionUseCase."HiFi" {
+	File "/Qualcomm/qcs9075/qcs9075-iq-evk-snd-card/HiFi.conf"
+	Comment "HiFi quality Music."
+}


### PR DESCRIPTION
Add UCM2 configs for the Qualcomm QCS9075-IQ-EVK Board to handle:
	- I2S Speaker Amplifier
	- I2S Mic