### PR TITLE
UCM2: Intel: sof-hda-dsp: HiFi: Fix handling of mono DMICs

### DIFF
--- a/ucm2/Intel/sof-hda-dsp/HiFi.conf
+++ b/ucm2/Intel/sof-hda-dsp/HiFi.conf
@@ -34,6 +34,16 @@ If.dmic {
 				True {
 					CaptureChannels 4
 				}
+				False.If.mono {
+					Condition {
+						Type RegexMatch
+						Regex "cfg-dmics:[1]"
+						String "${CardComponents}"
+					}
+					True {
+						CaptureChannels 1
+					}
+				}
 			}
 			If.vol {
 				Condition {


### PR DESCRIPTION
When a single DMIC is present in the system we need to set the CaptureChannels to 1 since the PCM device only supports mono, PA/PW will reject the profile since it cannot open the DMIC PCM device.