### PR TITLE
ucm2: sof-soundwire: add rt712+rt1320 amplifier

### DIFF
--- a/ucm2/sof-soundwire/rt712+rt1320.conf
+++ b/ucm2/sof-soundwire/rt712+rt1320.conf
@@ -1,0 +1,51 @@
+# Use case Configuration for sof-soundwire card
+
+#
+# Arguments:
+#   Amp - amplifier number (1,2 etc.)
+#   Sel - channel selection (L,R R,L L,L R,R L,L+R R,L+R L+R,L L+R,R L+R,L+R)
+#
+DefineMacro.rt1320spk {
+	EnableSequence [
+		cset "name='rt1320-${var:__Amp} RX Channel Select' ${var:__Sel}"
+		cset "name='rt1320-${var:__Amp} OT23 L Switch' 1"
+		cset "name='rt1320-${var:__Amp} OT23 R Switch' 1"
+	]
+	DisableSequence [
+		cset "name='rt1320-${var:__Amp} OT23 L Switch' 0"
+		cset "name='rt1320-${var:__Amp} OT23 R Switch' 0"
+	]
+}
+
+DefineMacro.rt1320AmpNum.If.0 {
+	Condition {
+		Type ControlExists
+		Control "name='rt1320-2 OT23 L Switch'"
+	}
+	True {
+		Macro.num1.rt1320spk { Amp 1 Sel "L,L" }
+		Macro.num2.rt1320spk { Amp 2 Sel "R,R" }
+	}
+	False {
+		Macro.num1.rt1320spk { Amp 1 Sel "L,R" }
+	}
+}
+
+SectionDevice."Speaker" {
+	Comment	"Speaker"
+
+	Macro.num1.rt1320AmpNum { }
+
+	EnableSequence [
+		cset "name='Speaker Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Speaker Switch' off"
+	]
+
+	Value {
+	      PlaybackPriority 100
+	      PlaybackPCM "hw:${CardId},2"
+	}
+}

--- a/ucm2/sof-soundwire/sof-soundwire.conf
+++ b/ucm2/sof-soundwire/sof-soundwire.conf
@@ -22,7 +22,7 @@ Define {
 
 DefineRegex {
 	SpeakerCodec {
-		Regex " spk:([a-z0-9]+((-sdca)|(-spk)|(-bridge))?)"
+		Regex " spk:([a-z0-9]+((-sdca)|(-spk)|(-bridge))?(\\+[a-z0-9]+)?)"
 		String "${CardComponents}"
 	}
 	SpeakerChannels {


### PR DESCRIPTION
This patch makes SpeakerCodec could get rt712+rt1320 string from spk:rt712+rt1320 component string. 
According to the control name, we will know that one or two amplifiers exist.