### PR TITLE
add UCM2 support for MSI MAG B850M Mortar Wifi (ALC4080)

### DIFF
--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -89,6 +89,7 @@ If.realtek-alc4080 {
 		# 0db0:a47c MSI MEG X570S Ace Max
 		# 0db0:a74b MSI MPG Z790 Edge Wifi
 		# 0db0:b202 MSI MAG Z690 Tomahawk Wifi
+		# 0db0:cc78 MSI MAG B850M Mortar Wifi
 		# 0db0:cd0e MSI X870 Tomahawk
 		# 0db0:d1d7 MSI PRO Z790-A WIFI
 		# 0db0:d6e7 MSI MPG X670E Carbon Wifi
@@ -96,7 +97,7 @@ If.realtek-alc4080 {
 		# 26ce:0a06 ASRock X670E/Z790 Taichi
 		# 26ce:0a08 ASRock Z790 PG-ITX/TB4, X870 Steel Legend
 		# 26ce:0a0b ASRock X870E Taichi
-		Regex "USB((0414:a0(0e|1[0124]))|(0b05:(19(84|9[69])|1a(16|2[07]|5[23c]|97|f1)|1b(7c|9b|e1)))|(0db0:(005a|0b58|124b|151f|1feb|3130|36e7|4(19c|22d|240|88c)|543d|62a4|6c[0c]9|70d3|7696|82c7|8af7|961e|9e6d|a(073|228|47c|74b)|b202|cd0e|d1d7|d6e7|e1f8))|(26ce:0a0[68b]))"
+		Regex "USB((0414:a0(0e|1[0124]))|(0b05:(19(84|9[69])|1a(16|2[07]|5[23c]|97|f1)|1b(7c|9b|e1)))|(0db0:(005a|0b58|124b|151f|1feb|3130|36e7|4(19c|22d|240|88c)|543d|62a4|6c[0c]9|70d3|7696|82c7|8af7|961e|9e6d|a(073|228|47c|74b)|b202|c(c78|d0e)|d1d7|d6e7|e1f8))|(26ce:0a0[68b]))"
 	}
 	True.Define.ProfileName "Realtek/ALC4080"
 }


### PR DESCRIPTION
Solves problems with front panel audio and S/PDIF sound output for MSI MAG B850M Mortar Wifi, which uses the Realtek ALC4080 audio chip.
I also tested line in (back side) and microphone input (front panel).
[alsa-info.txt](https://alsa-project.org/db/?f=70ed25ea247c3ac8c253755a5c70e86d67501191)

Thanks in advance.