### PR TITLE
ucm2: USB-Audio: Add Teufel CAGE PRO

### DIFF
--- a/ucm2/USB-Audio/Teufel/CAGE-PRO-HiFi.conf
+++ b/ucm2/USB-Audio/Teufel/CAGE-PRO-HiFi.conf
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025 Harald Sitter <sitter@kde.org>
+
+SectionDevice."Headset" {
+	Comment "Chat"
+	Value {
+		PlaybackPCM "hw:${CardId},0"
+		PlaybackMixerElem "PCM"
+		CapturePCM "hw:${CardId},0"
+		CaptureMixerElem "Mic"
+		CaptureChannels 1
+	}
+}
+
+SectionDevice."Headphones" {
+	Comment "Game"
+	Value {
+		PlaybackPCM "hw:${CardId},1"
+		PlaybackMixerElem "PCM,1"
+	}
+}

--- a/ucm2/USB-Audio/Teufel/CAGE-PRO.conf
+++ b/ucm2/USB-Audio/Teufel/CAGE-PRO.conf
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025 Harald Sitter <sitter@kde.org>
+
+Comment "Lautsprecher Teufel GmbH CAGE PRO"
+
+SectionUseCase."HiFi" {
+	Comment "Default"
+	File "/USB-Audio/Teufel/CAGE-PRO-HiFi.conf"
+}

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -559,6 +559,16 @@ If.beacn-studio {
 	}
 	True.Define.ProfileName "Beacn/Beacn-Studio"
 }
+
+If.teufel-cage-pro {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB2cc2:0033"
+	}
+	True.Define.ProfileName "Teufel/CAGE-PRO"
+}
+
 If.mixremap {
 	Condition {
 		Type String


### PR DESCRIPTION
two stereo outputs: one for "game" and one for "chat". one mono input