### PR TITLE
ucm2: codecs: lpass-rx-macro: move mixers that do not belong

### DIFF
--- a/ucm2/codecs/qcom-lpass/rx-macro/HeadphoneDisableSeq.conf
+++ b/ucm2/codecs/qcom-lpass/rx-macro/HeadphoneDisableSeq.conf
@@ -7,5 +7,4 @@ DisableSequence [
 	cset "name='RX INT1 DEM MUX' NORMAL_DSM_OUT"
 	cset "name='RX_COMP1 Switch' 0"
 	cset "name='RX_COMP2 Switch' 0"
-	cset "name='RX HPH Mode' CLS_H_INVALID"
 ]

--- a/ucm2/codecs/qcom-lpass/rx-macro/HeadphoneEnableSeq.conf
+++ b/ucm2/codecs/qcom-lpass/rx-macro/HeadphoneEnableSeq.conf
@@ -1,6 +1,5 @@
 EnableSequence [
 	cset "name='RX_HPH PWR Mode' LOHIFI"
-	cset "name='RX HPH Mode' CLS_H_ULP"
 	cset "name='RX_MACRO RX0 MUX' AIF1_PB"
 	cset "name='RX_MACRO RX1 MUX' AIF1_PB"
 	cset "name='RX INT0_1 MIX1 INP0' RX0"

--- a/ucm2/codecs/wcd934x/HeadphoneDisableSeq.conf
+++ b/ucm2/codecs/wcd934x/HeadphoneDisableSeq.conf
@@ -5,4 +5,5 @@ DisableSequence [
 	cset "name='RX INT2_1 MIX1 INP0' ZERO"
 	cset "name='RX INT1 DEM MUX' NORMAL_DSM_OUT"
 	cset "name='RX INT2 DEM MUX' NORMAL_DSM_OUT"
+	cset "name='RX HPH Mode' CLS_H_INVALID"
 ]

--- a/ucm2/codecs/wcd934x/HeadphoneEnableSeq.conf
+++ b/ucm2/codecs/wcd934x/HeadphoneEnableSeq.conf
@@ -5,4 +5,5 @@ EnableSequence [
 	cset "name='RX INT2_1 MIX1 INP0' RX3"
 	cset "name='RX INT1 DEM MUX' CLSH_DSM_OUT"
 	cset "name='RX INT2 DEM MUX' CLSH_DSM_OUT"
+	cset "name='RX HPH Mode' CLS_H_ULP"
 ]

--- a/ucm2/codecs/wcd937x/HeadphoneDisableSeq.conf
+++ b/ucm2/codecs/wcd937x/HeadphoneDisableSeq.conf
@@ -3,4 +3,5 @@ DisableSequence [
 	cset "name='HPHR_RDAC Switch' 0"
 	cset "name='HPHL Switch' 0"
 	cset "name='HPHR Switch' 0"
+	cset "name='RX HPH Mode' CLS_H_INVALID"
 ]

--- a/ucm2/codecs/wcd937x/HeadphoneEnableSeq.conf
+++ b/ucm2/codecs/wcd937x/HeadphoneEnableSeq.conf
@@ -3,4 +3,5 @@ EnableSequence [
 	cset "name='HPHR_RDAC Switch' 1"
 	cset "name='HPHL Switch' 1"
 	cset "name='HPHR Switch' 1"
+	cset "name='RX HPH Mode' CLS_H_ULP"
 ]

--- a/ucm2/codecs/wcd938x/HeadphoneDisableSeq.conf
+++ b/ucm2/codecs/wcd938x/HeadphoneDisableSeq.conf
@@ -5,4 +5,5 @@ DisableSequence [
 	cset "name='HPHR Switch' 0"
 	cset "name='CLSH Switch' 0"
 	cset "name='LO Switch' 0"
+	cset "name='RX HPH Mode' CLS_H_INVALID"
 ]

--- a/ucm2/codecs/wcd938x/HeadphoneEnableSeq.conf
+++ b/ucm2/codecs/wcd938x/HeadphoneEnableSeq.conf
@@ -7,4 +7,5 @@ EnableSequence [
 	cset "name='HPHL_COMP Switch' 0"
 	cset "name='CLSH Switch' 1"
 	cset "name='LO Switch' 1"
+	cset "name='RX HPH Mode' CLS_H_ULP"
 ]

--- a/ucm2/codecs/wcd939x/HeadphoneDisableSeq.conf
+++ b/ucm2/codecs/wcd939x/HeadphoneDisableSeq.conf
@@ -6,4 +6,5 @@ DisableSequence [
 	cset "name='HPHL Switch' 0"
 	cset "name='HPHR Switch' 0"
 	cset "name='CLSH Switch' 0"
+	cset "name='RX HPH Mode' CLS_H_INVALID"
 ]

--- a/ucm2/codecs/wcd939x/HeadphoneEnableSeq.conf
+++ b/ucm2/codecs/wcd939x/HeadphoneEnableSeq.conf
@@ -6,4 +6,5 @@ EnableSequence [
 	cset "name='HPHL Switch' 1"
 	cset "name='HPHR Switch' 1"
 	cset "name='CLSH Switch' 1"
+	cset "name='RX HPH Mode' CLS_H_ULP"
 ]


### PR DESCRIPTION
Some of the mixers ended up in rx-macro which actually are part of WCD codecs.
Move such mixers to their respective codecs.