### PR TITLE
ucm2: Qualcomm: add Dell XPS 9345

### DIFF
--- a/ucm2/Qualcomm/x1e80100/Dell-Xps-9345.conf
+++ b/ucm2/Qualcomm/x1e80100/Dell-Xps-9345.conf
@@ -1,0 +1,11 @@
+Syntax 4
+
+SectionUseCase."HiFi" {
+	File "/Qualcomm/x1e80100/Xps9345-HiFi.conf"
+	Comment "HiFi quality Music."
+}
+
+Include.card-init.File "/lib/card-init.conf"
+Include.ctl-remap.File "/lib/ctl-remap.conf"
+Include.wsa-init.File "/codecs/wsa884x/four-speakers/init.conf"
+Include.wsam-init.File "/codecs/qcom-lpass/wsa-macro/four-speakers/init.conf"

--- a/ucm2/Qualcomm/x1e80100/Xps9345-HiFi.conf
+++ b/ucm2/Qualcomm/x1e80100/Xps9345-HiFi.conf
@@ -1,0 +1,49 @@
+# Use case configuration for X1E80100.
+# Author: Srinivas Kandagatla <srinivas.kandagatla@linaro.org>
+
+SectionVerb {
+	EnableSequence [
+		cset "name='WSA_CODEC_DMA_RX_0 Audio Mixer MultiMedia2' 1"
+		cset "name='MultiMedia4 Mixer VA_CODEC_DMA_TX_0' 1"
+	]
+
+	Include.wsae.File "/codecs/wsa884x/four-speakers/DefaultEnableSeq.conf"
+	Include.wsm1e.File "/codecs/qcom-lpass/wsa-macro/Wsa1SpeakerEnableSeq.conf"
+	Include.wsm2e.File "/codecs/qcom-lpass/wsa-macro/Wsa2SpeakerEnableSeq.conf"
+
+	Value {
+		TQ "HiFi"
+	}
+}
+
+SectionDevice."Speaker" {
+	Comment "Speaker playback"
+
+	Include.wsmspk1e.File "/codecs/qcom-lpass/wsa-macro/Wsa1SpeakerEnableSeq.conf"
+	Include.wsmspk2e.File "/codecs/qcom-lpass/wsa-macro/Wsa2SpeakerEnableSeq.conf"
+	Include.wsmspk1d.File "/codecs/qcom-lpass/wsa-macro/Wsa1SpeakerDisableSeq.conf"
+	Include.wsmspk2d.File "/codecs/qcom-lpass/wsa-macro/Wsa2SpeakerDisableSeq.conf"
+	Include.wsaspk.File "/codecs/wsa884x/four-speakers/SpeakerSeq.conf"
+
+	Value {
+		PlaybackChannels 4
+		PlaybackPriority 100
+		PlaybackPCM "hw:${CardId},1"
+		PlaybackMixer "default:${CardId}"
+		PlaybackMixerElem "Speakers"
+	}
+}
+
+SectionDevice."Mic" {
+	Comment "Internal microphones"
+
+	Include.vadm0e.File "/codecs/qcom-lpass/va-macro/DMIC0EnableSeq.conf"
+	Include.vadm0d.File "/codecs/qcom-lpass/va-macro/DMIC0DisableSeq.conf"
+	Include.vadm1e.File "/codecs/qcom-lpass/va-macro/DMIC1EnableSeq.conf"
+	Include.vadm1d.File "/codecs/qcom-lpass/va-macro/DMIC1DisableSeq.conf"
+
+	Value {
+		CapturePriority 100
+		CapturePCM "hw:${CardId},3"
+	}
+}

--- a/ucm2/Qualcomm/x1e80100/x1e80100.conf
+++ b/ucm2/Qualcomm/x1e80100/x1e80100.conf
@@ -41,3 +41,13 @@ If.DellLatitude7455 {
 	}
 	True.Include.latitude.File "/Qualcomm/x1e80100/Dell-Latitude-7455.conf"
 }
+
+# 4x WSA Speakers | 2x Microphones | 2x DP/HDMI
+If.DellXps9345 {
+	Condition {
+		Type RegexMatch
+		String "${var:DMI_info}-${sys:devices/virtual/dmi/id/product_name}"
+		Regex "Dell Inc.*XPS 13 9345.*"
+	}
+	True.Include.xps.File "/Qualcomm/x1e80100/Dell-Xps-9345.conf"
+}


### PR DESCRIPTION
Add a Regex string, seems to be mostly compatible with Yoga Slim7x. x4 speakers, x2 DMICs (unlike Yoga's 4), x2 DP, no headphone jack. DMI_info evaluates to `Dell Inc.-XPS-0DXPNM`. It appears to be okay to re-use Yoga, as [only 2 microphone channels are considered](https://github.com/alsa-project/alsa-ucm-conf/blob/master/ucm2/Qualcomm/x1e80100/Slim7x-HiFi.conf#L40-L43).

Audio part of Dell XPS 9345 DT is available [out of tree](https://github.com/alexVinarskis/linux-x1e80100-dell-tributo), will be submitted to the lists shortly. audioreach-topology was [merged a while ago](https://github.com/linux-msm/audioreach-topology/pull/20).

Tested that speakers, MICs are working.

**Known issues:** L and R sides are swapped due to kernel driver not taking DT labels into account just yet, and particular platform having WSAs connected to different soundwires interfaces than the rest of x1e80100 devices. Identified by Abel Vesa at Linaro. Fix will be on the kernel and/or DT side.
