### PR TITLE
ucm2: Qualcomm: Add MONACO-EVK HiFi config

### DIFF
--- a/ucm2/Qualcomm/qcs8300/monaco-evk/HiFi.conf
+++ b/ucm2/Qualcomm/qcs8300/monaco-evk/HiFi.conf
@@ -1,0 +1,30 @@
+SectionVerb {
+	Value {
+		TQ "HiFi"
+	}
+	EnableSequence [
+		cset "name='PRIMARY_MI2S_RX Audio Mixer MultiMedia1' 1"
+		cset "name='MultiMedia2 Mixer SECONDARY_MI2S_TX' 1"
+	]
+}
+
+SectionDevice."Speaker" {
+	Comment "Speaker playback"
+
+	Value {
+		PlaybackPriority 100
+		PlaybackPCM "hw:${CardId},0"
+		PlaybackMixer "default:${CardId}"
+		PlaybackMixerElem "Speakers"
+	}
+}
+
+SectionDevice."Mic" {
+	Comment "Mic"
+
+	Value {
+		CapturePriority 100
+		CapturePCM "hw:${CardId},1"
+		CaptureChannels 1
+	}
+}

--- a/ucm2/Qualcomm/qcs8300/monaco-evk/MONACO-EVK.conf
+++ b/ucm2/Qualcomm/qcs8300/monaco-evk/MONACO-EVK.conf
@@ -1,0 +1,6 @@
+Syntax 4
+
+SectionUseCase."HiFi" {
+	File "/Qualcomm/qcs8300/monaco-evk/HiFi.conf"
+	Comment "HiFi quality Music"
+}

--- a/ucm2/conf.d/qcs8300/MONACO-EVK.conf
+++ b/ucm2/conf.d/qcs8300/MONACO-EVK.conf
@@ -1,0 +1,1 @@
+../../Qualcomm/qcs8300/monaco-evk/MONACO-EVK.conf


### PR DESCRIPTION
Add UCM2 configs for the Qualcomm MONACO-EVK Board to handle:
	- I2S Speaker Amplifier
	- I2S Mic