### PR TITLE
ucm2: Qualcomm: add Lenovo Ideapad 5 (Slim 5x / 2in1) support

### DIFF
--- a/ucm2/Qualcomm/x1e80100/x1e80100.conf
+++ b/ucm2/Qualcomm/x1e80100/x1e80100.conf
@@ -6,7 +6,7 @@ If.LENOVOT14s {
 	Condition {
 		Type RegexMatch
 		String "${var:DMI_info}"
-		Regex "LENOVO.*Think((Pad T14s Gen 6.*)|(Book 16 G7 QOY))|(HP.*Omnibook X.*)|ASUSTeK COMPUTER.*ASUS (Zenbook A14|Vivobook S 15)|(Microsoft Corporation.*Surface.*Microsoft Surface Laptop, 7th Edition)"
+		Regex "LENOVO.*(Think(Pad T14s Gen 6.*|Book 16 G7 QOY)|Ideapad.*5.*)|(HP.*Omnibook X.*)|ASUSTeK COMPUTER.*ASUS (Zenbook A14|Vivobook S 15)|(Microsoft Corporation.*Surface.*Microsoft Surface Laptop, 7th Edition)"
 	}
 	True.Include.t14s.File "/Qualcomm/x1e80100/LENOVO-T14s.conf"
 }


### PR DESCRIPTION
Same layout as T14s, 2 speakers, headphone jack, DMIC

Tested on Ideapad 5 2in1 14Q8X9. 