### PR TITLE
ucm2: Qualcomm: add Radxa Dragon Q6A

### DIFF
--- a/ucm2/Qualcomm/qcs6490/QCS6490-Radxa-Dragon-Q6A/HiFi.conf
+++ b/ucm2/Qualcomm/qcs6490/QCS6490-Radxa-Dragon-Q6A/HiFi.conf
@@ -1,0 +1,73 @@
+SectionVerb {
+	EnableSequence [
+		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia1' 1"
+		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia2' 0"
+		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia2' 1"
+		cset "name='MultiMedia3 Mixer TX_CODEC_DMA_TX_3' 1"
+	]
+
+	Value {
+		TQ "HiFi"
+	}
+}
+
+SectionDevice."Headphones" {
+	Comment "Headphones playback"
+
+	Include.wcdhpe.File "/codecs/wcd938x/HeadphoneEnableSeq.conf"
+	Include.wcdhpd.File "/codecs/wcd938x/HeadphoneDisableSeq.conf"
+	Include.rxmhpe.File "/codecs/qcom-lpass/rx-macro/HeadphoneEnableSeq.conf"
+	Include.rxmhpd.File "/codecs/qcom-lpass/rx-macro/HeadphoneDisableSeq.conf"
+
+	EnableSequence [
+		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia1' 1"
+	]
+
+	DisableSequence [
+		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia1' 0"
+	]
+
+	Value {
+		PlaybackPriority 200
+		PlaybackPCM "hw:${CardId},0"
+		PlaybackMixer "default:${CardId}"
+		PlaybackMixerElem "HP"
+		JackControl "Headphone Jack"
+	}
+}
+
+SectionDevice."DisplayPort" {
+	Comment "DisplayPort playback"
+
+	EnableSequence [
+		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia2' 0"
+		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia2' 1"
+	]
+
+	DisableSequence [
+		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia2' 0"
+		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia2' 1"
+	]
+
+	Value {
+		PlaybackPriority 100
+		PlaybackPCM "hw:${CardId},1"
+		JackControl "DP0 Jack"
+	}
+}
+
+SectionDevice."Headset" {
+	Comment "Headset microphone"
+
+	Include.wcdmice.File "/codecs/wcd938x/HeadphoneMicEnableSeq.conf"
+	Include.wcdmicd.File "/codecs/wcd938x/HeadphoneMicDisableSeq.conf"
+	Include.txmhpe.File "/codecs/qcom-lpass/tx-macro/HeadphoneMicEnableSeq.conf"
+	Include.txmhpd.File "/codecs/qcom-lpass/tx-macro/HeadphoneMicDisableSeq.conf"
+
+	Value {
+		CapturePriority 100
+		CapturePCM "hw:${CardId},2"
+		CaptureMixerElem "ADC2"
+		JackControl "Mic Jack"
+	}
+}

--- a/ucm2/Qualcomm/qcs6490/QCS6490-Radxa-Dragon-Q6A/QCS6490-Radxa-Dragon-Q6A.conf
+++ b/ucm2/Qualcomm/qcs6490/QCS6490-Radxa-Dragon-Q6A/QCS6490-Radxa-Dragon-Q6A.conf
@@ -1,0 +1,17 @@
+Syntax 4
+
+SectionUseCase."HiFi" {
+	File "/Qualcomm/qcs6490/QCS6490-Radxa-Dragon-Q6A/HiFi.conf"
+	Comment "HiFi quality Music."
+}
+
+BootSequence [
+	cset "name='HPHL Volume' 2"
+	cset "name='HPHR Volume' 2"
+	cset "name='ADC2 Volume' 10"
+]
+
+Include.card-init.File "/lib/card-init.conf"
+Include.ctl-remap.File "/lib/ctl-remap.conf"
+Include.wcd-init.File "/codecs/wcd938x/init.conf"
+Include.rxm-init.File "/codecs/qcom-lpass/rx-macro/init.conf"

--- a/ucm2/conf.d/qcs6490/QCS6490-Radxa-Dragon-Q6A.conf
+++ b/ucm2/conf.d/qcs6490/QCS6490-Radxa-Dragon-Q6A.conf
@@ -1,0 +1,1 @@
+../../Qualcomm/qcs6490/QCS6490-Radxa-Dragon-Q6A/QCS6490-Radxa-Dragon-Q6A.conf


### PR DESCRIPTION
This is an upcoming SBC (single board computer) based on QCS6490. Full specs:

- Headphone jack using WCD9380 codec
- Onboard DisplayPort to HDMI bridge using Radxa RA620
- MI2S0 available via the 40-Pin GPIO header (unused by default)
- AMICs using WCD9380 codec via a dedicated MIC header (unused by default)

The kernel device tree part is not yet but going to be upstreamed soon.