### PR TITLE
ucm2: Qualcomm: x1e80100: Add X1E001DE-DEVKIT configuration

### DIFF
--- a/ucm2/Qualcomm/x1e80100/DEVKIT-HiFi.conf
+++ b/ucm2/Qualcomm/x1e80100/DEVKIT-HiFi.conf
@@ -1,0 +1,6 @@
+# Use case configuration for X1E001DE DEVKIT, same as CRD.
+Include.HiFi.File "HiFi.conf"
+
+# There are speaker pins available on the mainboard, but nothing is connected
+# there, so remove the Speaker device by default.
+RemoveDevice."Speaker" "Speaker"

--- a/ucm2/Qualcomm/x1e80100/X1E001DE-DEVKIT.conf
+++ b/ucm2/Qualcomm/x1e80100/X1E001DE-DEVKIT.conf
@@ -1,0 +1,19 @@
+Syntax 4
+
+SectionUseCase."HiFi" {
+	File "/Qualcomm/x1e80100/DEVKIT-HiFi.conf"
+	Comment "HiFi quality Music."
+}
+
+BootSequence [
+	cset "name='HPHL Volume' 20"
+	cset "name='HPHR Volume' 20"
+	cset "name='ADC2 Volume' 10"
+]
+
+Include.card-init.File "/lib/card-init.conf"
+Include.ctl-remap.File "/lib/ctl-remap.conf"
+Include.wcd-init.File "/codecs/wcd938x/init.conf"
+Include.wsa-init.File "/codecs/wsa884x/four-speakers/init.conf"
+Include.wsam-init.File "/codecs/qcom-lpass/wsa-macro/four-speakers/init.conf"
+Include.rxm-init.File "/codecs/qcom-lpass/rx-macro/init.conf"

--- a/ucm2/conf.d/x1e80100/X1E001DE-DEVKIT.conf
+++ b/ucm2/conf.d/x1e80100/X1E001DE-DEVKIT.conf
@@ -1,0 +1,1 @@
+../../Qualcomm/x1e80100/X1E001DE-DEVKIT.conf


### PR DESCRIPTION
The X1E001DE Devkit needs basically the same audio configuration as the X1E80100 CRD, so just include the HiFi.conf intended for the CRD. The only difference is that there are no speakers connected to the pin header on the mainboard by default, so remove the speakers from the available outputs.

If someone wants to connect speakers there they could drop the RemoveDevice line after verifying that it works correctly for their speakers. At the moment we do not have any way to automatically detect if there are speakers connected or not.