### PR TITLE
Add UCM for RME Fireface UCX

### DIFF
--- a/ucm2/USB-Audio/RME/Fireface-UCX-HiFi.conf
+++ b/ucm2/USB-Audio/RME/Fireface-UCX-HiFi.conf
@@ -1,0 +1,607 @@
+Include.pcm_split.File "/common/pcm/split.conf"
+
+# This profile only exposes the most common channel configurations to limit
+# combinatorial complexity:
+#
+#  - Analog line outputs in stereo as well as 4.0 and 5.1 surround,
+#  - analog microphone and instrument inputs in mono only,
+#  - ADAT outputs and inputs in direct 8‐channel mapping, and
+#  - all other outputs and inputs in stereo.
+
+Macro [
+	{
+		SplitPCM {
+			Name "ucx_stereo_out"
+			Direction Playback
+			Format S24_3LE
+			Channels 2
+			HWChannels 18
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 FL
+			HWChannelPos3 FR
+			HWChannelPos4 FL
+			HWChannelPos5 FR
+			HWChannelPos6 FL
+			HWChannelPos7 FR
+			HWChannelPos8 FL
+			HWChannelPos9 FR
+			HWChannelPos10 FL
+			HWChannelPos11 FR
+			HWChannelPos12 FL
+			HWChannelPos13 FR
+			HWChannelPos14 FL
+			HWChannelPos15 FR
+			HWChannelPos16 FL
+			HWChannelPos17 FR
+		}
+	}
+	{
+		SplitPCM {
+			Name "ucx_surround40_out"
+			Direction Playback
+			Format S24_3LE
+			Channels 4
+			HWChannels 18
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 RL
+			HWChannelPos3 RR
+			HWChannelPos4 UNKNOWN
+			HWChannelPos5 UNKNOWN
+			HWChannelPos6 UNKNOWN
+			HWChannelPos7 UNKNOWN
+			HWChannelPos8 UNKNOWN
+			HWChannelPos9 UNKNOWN
+			HWChannelPos10 FL
+			HWChannelPos11 FR
+			HWChannelPos12 RL
+			HWChannelPos13 RR
+			HWChannelPos14 FL
+			HWChannelPos15 FR
+			HWChannelPos16 RL
+			HWChannelPos17 RR
+		}
+	}
+	{
+		SplitPCM {
+			Name "ucx_surround51_out"
+			Direction Playback
+			Format S24_3LE
+			Channels 6
+			HWChannels 18
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 RL
+			HWChannelPos3 RR
+			HWChannelPos4 FC
+			HWChannelPos5 LFE
+			HWChannelPos6 UNKNOWN
+			HWChannelPos7 UNKNOWN
+			HWChannelPos8 UNKNOWN
+			HWChannelPos9 UNKNOWN
+			HWChannelPos10 FL
+			HWChannelPos11 FR
+			HWChannelPos12 RL
+			HWChannelPos13 RR
+			HWChannelPos14 FC
+			HWChannelPos15 LFE
+			HWChannelPos16 UNKNOWN
+			HWChannelPos17 UNKNOWN
+		}
+	}
+	{
+		SplitPCM {
+			Name "ucx_adat_out"
+			Direction Playback
+			Format S24_3LE
+			Channels 8
+			HWChannels 18
+			HWChannelPos0 UNKNOWN
+			HWChannelPos1 UNKNOWN
+			HWChannelPos2 UNKNOWN
+			HWChannelPos3 UNKNOWN
+			HWChannelPos4 UNKNOWN
+			HWChannelPos5 UNKNOWN
+			HWChannelPos6 UNKNOWN
+			HWChannelPos7 UNKNOWN
+			HWChannelPos8 UNKNOWN
+			HWChannelPos9 UNKNOWN
+			HWChannelPos10 UNKNOWN
+			HWChannelPos11 UNKNOWN
+			HWChannelPos12 UNKNOWN
+			HWChannelPos13 UNKNOWN
+			HWChannelPos14 UNKNOWN
+			HWChannelPos15 UNKNOWN
+			HWChannelPos16 UNKNOWN
+			HWChannelPos17 UNKNOWN
+		}
+	}
+	{
+		SplitPCM {
+			Name "ucx_mono_in"
+			Direction Capture
+			Format S24_3LE
+			Channels 1
+			HWChannels 18
+			HWChannelPos0 MONO
+			HWChannelPos1 MONO
+			HWChannelPos2 MONO
+			HWChannelPos3 MONO
+			HWChannelPos4 MONO
+			HWChannelPos5 MONO
+			HWChannelPos6 MONO
+			HWChannelPos7 MONO
+			HWChannelPos8 MONO
+			HWChannelPos9 MONO
+			HWChannelPos10 MONO
+			HWChannelPos11 MONO
+			HWChannelPos12 MONO
+			HWChannelPos13 MONO
+			HWChannelPos14 MONO
+			HWChannelPos15 MONO
+			HWChannelPos16 MONO
+			HWChannelPos17 MONO
+		}
+	}
+	{
+		SplitPCM {
+			Name "ucx_stereo_in"
+			Direction Capture
+			Format S24_3LE
+			Channels 2
+			HWChannels 18
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 FL
+			HWChannelPos3 FR
+			HWChannelPos4 FL
+			HWChannelPos5 FR
+			HWChannelPos6 FL
+			HWChannelPos7 FR
+			HWChannelPos8 FL
+			HWChannelPos9 FR
+			HWChannelPos10 FL
+			HWChannelPos11 FR
+			HWChannelPos12 FL
+			HWChannelPos13 FR
+			HWChannelPos14 FL
+			HWChannelPos15 FR
+			HWChannelPos16 FL
+			HWChannelPos17 FR
+		}
+	}
+	{
+		SplitPCM {
+			Name "ucx_adat_in"
+			Direction Capture
+			Format S24_3LE
+			Channels 8
+			HWChannels 18
+			HWChannelPos0 UNKNOWN
+			HWChannelPos1 UNKNOWN
+			HWChannelPos2 UNKNOWN
+			HWChannelPos3 UNKNOWN
+			HWChannelPos4 UNKNOWN
+			HWChannelPos5 UNKNOWN
+			HWChannelPos6 UNKNOWN
+			HWChannelPos7 UNKNOWN
+			HWChannelPos8 UNKNOWN
+			HWChannelPos9 UNKNOWN
+			HWChannelPos10 UNKNOWN
+			HWChannelPos11 UNKNOWN
+			HWChannelPos12 UNKNOWN
+			HWChannelPos13 UNKNOWN
+			HWChannelPos14 UNKNOWN
+			HWChannelPos15 UNKNOWN
+			HWChannelPos16 UNKNOWN
+			HWChannelPos17 UNKNOWN
+		}
+	}
+]
+
+# Analog outputs
+
+SectionDevice.Headphones {
+	Comment "Headphones"
+
+	Value {
+		PlackbackPriority 255
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ucx_stereo_out"
+		Direction Playback
+		HWChannels 18
+		Channels 2
+		Channel0 6
+		Channel1 7
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line 1" {
+	Comment "Line Output 1+2"
+
+	Value {
+		PlackbackPriority 192
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ucx_stereo_out"
+		Direction Playback
+		HWChannels 18
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line 2" {
+	Comment "Line Output 3+4"
+
+	Value {
+		PlackbackPriority 191
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ucx_stereo_out"
+		Direction Playback
+		HWChannels 18
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line 3" {
+	Comment "Line Output 5+6"
+
+	Value {
+		PlackbackPriority 190
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ucx_stereo_out"
+		Direction Playback
+		HWChannels 18
+		Channels 2
+		Channel0 4
+		Channel1 5
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+# Analog outputs in 4.0 surround configuration
+
+SectionDevice."Line 4" {
+	Comment "Line Output 1-4 (4.0 Surround)"
+
+	ConflictingDevice [
+		"Line 1"
+		"Line 2"
+	]
+
+	Value {
+		PlackbackPriority 160
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ucx_surround40_out"
+		Direction Playback
+		HWChannels 18
+		Channels 4
+		Channel0 0
+		Channel1 1
+		Channel2 2
+		Channel3 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+		ChannelPos2 RL
+		ChannelPos3 RR
+	}
+}
+
+# Analog outputs in 5.1 surround configuration
+
+SectionDevice."Line 5" {
+	Comment "Line Output 1-6 (5.1 Surround)"
+
+	Value {
+		PlackbackPriority 144
+	}
+
+	ConflictingDevice [
+		"Line 1"
+		"Line 2"
+		"Line 3"
+		"Line 4"
+	]
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ucx_surround51_out"
+		Direction Playback
+		HWChannels 18
+		Channels 6
+		Channel0 0
+		Channel1 1
+		Channel2 2
+		Channel3 3
+		Channel4 4
+		Channel5 5
+		ChannelPos0 FL
+		ChannelPos1 FR
+		ChannelPos2 RL
+		ChannelPos3 RR
+		ChannelPos4 FC
+		ChannelPos5 LFE
+	}
+}
+
+# Analog inputs
+
+SectionDevice."Mic 1" {
+	Comment "Line Input 1 (Microphone)"
+
+	Value {
+		CapturePriority 176
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ucx_mono_in"
+		Direction Capture
+		HWChannels 18
+		Channels 1
+		Channel0 0
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Mic 2" {
+	Comment "Line Input 2 (Microphone)"
+
+	Value {
+		CapturePriority 175
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ucx_mono_in"
+		Direction Capture
+		HWChannels 18
+		Channels 1
+		Channel0 1
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Line 6" {
+	Comment "Line Input 3 (Instrument)"
+
+	Value {
+		CapturePriority 174
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ucx_mono_in"
+		Direction Capture
+		HWChannels 18
+		Channels 1
+		Channel0 2
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Line 7" {
+	Comment "Line Input 4 (Instrument)"
+
+	Value {
+		CapturePriority 173
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ucx_mono_in"
+		Direction Capture
+		HWChannels 18
+		Channels 1
+		Channel0 3
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Line 8" {
+	Comment "Line Input 5+6"
+
+	Value {
+		CapturePriority 172
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ucx_stereo_in"
+		Direction Capture
+		HWChannels 18
+		Channels 2
+		Channel0 4
+		Channel1 5
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line 9" {
+	Comment "Line Input 7+8"
+
+	Value {
+		CapturePriority 171
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ucx_stereo_in"
+		Direction Capture
+		HWChannels 18
+		Channels 2
+		Channel0 6
+		Channel1 7
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+# Digital (consumer) outputs
+
+SectionDevice."SPDIF 1" {
+	Comment "S/PDIF Coax Output"
+
+	Value {
+		PlackbackPriority 112
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ucx_stereo_out"
+		Direction Playback
+		HWChannels 18
+		Channels 2
+		Channel0 8
+		Channel1 9
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."SPDIF 2" {
+	Comment "S/PDIF Optical Output"
+
+	ConflictingDevice [
+		"Direct 1"
+	]
+
+	Value {
+		PlackbackPriority 111
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ucx_stereo_out"
+		Direction Playback
+		HWChannels 18
+		Channels 2
+		Channel0 10
+		Channel1 11
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+# Digital (consumer) inputs
+
+SectionDevice."SPDIF 3" {
+	Comment "S/PDIF Coax Input"
+
+	Value {
+		CapturePriority 112
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ucx_stereo_in"
+		Direction Capture
+		HWChannels 18
+		Channels 2
+		Channel0 8
+		Channel1 9
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."SPDIF 4" {
+	Comment "S/PDIF Optical Input"
+
+	ConflictingDevice [
+		"Direct 2"
+	]
+
+	Value {
+		CapturePriority 112
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ucx_stereo_in"
+		Direction Capture
+		HWChannels 18
+		Channels 2
+		Channel0 10
+		Channel1 11
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+# Digital (professional) outputs
+
+SectionDevice."Direct 1" {
+	Comment "ADAT Optical Output"
+
+	Value {
+		PlackbackPriority 48
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ucx_adat_out"
+		Direction Playback
+		HWChannels 18
+		Channels 8
+		Channel0 10
+		Channel1 11
+		Channel2 12
+		Channel3 13
+		Channel4 14
+		Channel5 15
+		Channel6 16
+		Channel7 17
+		ChannelPos0 UNKNOWN
+		ChannelPos1 UNKNOWN
+		ChannelPos2 UNKNOWN
+		ChannelPos3 UNKNOWN
+		ChannelPos4 UNKNOWN
+		ChannelPos5 UNKNOWN
+		ChannelPos6 UNKNOWN
+		ChannelPos7 UNKNOWN
+	}
+}
+
+# Digital (professional) inputs
+
+SectionDevice."Direct 2" {
+	Comment "ADAT Optical Input"
+
+	Value {
+		CapturePriority 48
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ucx_adat_in"
+		Direction Capture
+		HWChannels 18
+		Channels 8
+		Channel0 10
+		Channel1 11
+		Channel2 12
+		Channel3 13
+		Channel4 14
+		Channel5 15
+		Channel6 16
+		Channel7 17
+		ChannelPos0 UNKNOWN
+		ChannelPos1 UNKNOWN
+		ChannelPos2 UNKNOWN
+		ChannelPos3 UNKNOWN
+		ChannelPos4 UNKNOWN
+		ChannelPos5 UNKNOWN
+		ChannelPos6 UNKNOWN
+		ChannelPos7 UNKNOWN
+	}
+}

--- a/ucm2/USB-Audio/RME/Fireface-UCX.conf
+++ b/ucm2/USB-Audio/RME/Fireface-UCX.conf
@@ -1,0 +1,35 @@
+Comment "Fireface UCX"
+
+# The Fireface UCX provides 18 playback and capture channels each:
+# - channels  0  to  7 are analog inputs and outputs
+# - channels  8 and  9 are S/PDIF via coax
+# - channels 10  to 17 are ADAT Optical Interface (8 channels)
+#                           or S/PDIF (output only, 10 and 11) via TOSLINK
+#
+# Physical connector layout:
+#  top to bottom, left to right, viewed from device front
+#
+# Front:
+# - 1 MIC / LINE: XLR / 1/4" TRS combo, balanced mono input, 48 V phantom power
+# - 2 MIC / LINE: XLR / 1/4" TRS combo, balanced mono input, 48 V phantom power
+# - 3 LINE / INSTR.: TRS 1/4", balanced mono input
+# - 4 LINE / INSTR.: TRS 1/4", balanced mono input
+# - Headphones symbol: TRS 1/4", unbalanced stereo output
+#
+# Back:
+# - LINE INPUTS (BALANCED) [5, 6; 7, 8]: TRS 1/4", balanced mono inputs
+# - LINE OUTPUTS (BALANCED) [1, 2; 3, 4; 5, 6]: TRS 1/4", balanced mono outputs
+# - S/PDIF IN: RCA, S/PDIF Coaxial Interface
+# - S/PDIF OUT: RCA, S/PDIF Coaxial Interface
+# - ADAT IN: TOSLINK, ADAT Optical Interface
+# - ADAT OUT: TOSLINK, ADAT Optical Interface or S/PDIF
+
+SectionUseCase."HiFi" {
+	Comment "Default"
+	File "/USB-Audio/RME/Fireface-UCX-HiFi.conf"
+}
+
+Define.DirectPlaybackChannels 18
+Define.DirectCaptureChannels 18
+
+Include.dhw.File "/common/direct.conf"

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -501,6 +501,15 @@ If.id4-0009 {
 	True.Define.ProfileName "Audient/Audient-iD4-0009"
 }
 
+If.fireface-ucx {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB0424:3fb9"
+	}
+	True.Define.ProfileName "RME/Fireface-UCX"
+}
+
 If.fireface-ucx-ii {
 	Condition {
 		Type String


### PR DESCRIPTION
Adds UCM for RME Fireface UCX (heavily based on RME Fireface UCX II config).
Device is assumed in CC mode.
#605 