### PR TITLE
ucm2: MediaTek: mt8391-evk: Add alsa-ucm support

### DIFF
--- a/ucm2/MediaTek/mt8391-evk/HiFi.conf
+++ b/ucm2/MediaTek/mt8391-evk/HiFi.conf
@@ -1,0 +1,150 @@
+SectionDevice."Speaker" {
+	Comment "Lineout speaker"
+
+	ConflictingDevice [
+		"Headphones"
+	]
+
+	EnableSequence [
+		cset "name='LOL Mux' Playback_L_DAC"
+	]
+
+	DisableSequence [
+		cset "name='LOL Mux' Open"
+	]
+
+	Value {
+		PlaybackPriority 300
+		PlaybackChannels 1
+		PlaybackPCM "hw:${CardId},${var:PlayDevN}"
+	}
+}
+
+SectionDevice."Headphones" {
+	Comment "Earphone speaker"
+
+	ConflictingDevice [
+		"Speaker"
+	]
+
+	EnableSequence [
+		cset "name='HP Mux' Audio Playback"
+	]
+
+	DisableSequence [
+		cset "name='HP Mux' Open"
+	]
+
+	Value {
+		PlaybackPriority 400
+		PlaybackChannels 2
+		PlaybackPCM "hw:${CardId},${var:PlayDevN}"
+		JackControl "Headphone Jack"
+	}
+}
+
+SectionDevice."Headset" {
+	Comment "Earphone microphone"
+
+	ConflictingDevice [
+		"Mic1"
+	]
+
+	EnableSequence [
+		cset "name='MISO0_MUX' UL1_CH1"
+		cset "name='ADC_L_Mux' Left Preamplifier"
+		cset "name='PGA_L_Mux' AIN1"
+	]
+
+	DisableSequence [
+		cset "name='ADC_L_Mux' Idle"
+		cset "name='PGA_L_Mux' None"
+	]
+
+	Value {
+		CapturePriority 500
+		CaptureChannels "${var:CapChanN}"
+		CapturePCM "hw:${CardId},${var:CapDevN}"
+		JackControl "Headset Mic Jack"
+	}
+}
+
+SectionDevice."Mic1" {
+	Comment "Analog microphone"
+
+	ConflictingDevice [
+		"Headset"
+	]
+
+	EnableSequence [
+		cset "name='MISO0_MUX' UL1_CH1"
+		cset "name='MISO1_MUX' UL1_CH2"
+		cset "name='ADC_L_Mux' Left Preamplifier"
+		cset "name='ADC_R_Mux' Right Preamplifier"
+		cset "name='PGA_L_Mux' AIN0"
+		cset "name='PGA_R_Mux' AIN2"
+	]
+
+	DisableSequence [
+		cset "name='ADC_L_Mux' Idle"
+		cset "name='ADC_R_Mux' Idle"
+		cset "name='PGA_L_Mux' None"
+		cset "name='PGA_R_Mux' None"
+	]
+
+	Value {
+		CapturePriority 400
+		CaptureChannels 2
+		CapturePCM "hw:${CardId},${var:CapDevN}"
+	}
+}
+
+SectionDevice."Mic2" {
+	Comment "Digital microphone"
+
+	Value {
+		CapturePriority 300
+		CaptureChannels 2
+		CapturePCM "hw:${CardId},2"
+	}
+}
+
+SectionDevice."Line1" {
+	Comment "PCM input"
+
+	Value {
+		CapturePriority 200
+		CaptureChannels 2
+		CapturePCM "hw:${CardId},20"
+	}
+}
+
+SectionDevice."Line2" {
+	Comment "PCM output"
+
+	Value {
+		PlaybackPriority 200
+		PlaybackChannels 2
+		PlaybackPCM "hw:${CardId},6"
+	}
+}
+
+SectionDevice."Line3" {
+	Comment "I2S input"
+
+	Value {
+		CapturePriority 100
+		CaptureChannels 2
+		CapturePCM "hw:${CardId},3"
+	}
+}
+
+SectionDevice."Line4" {
+	Comment "I2S output"
+
+	Value {
+		PlaybackPriority 100
+		PlaybackChannels 2
+		PlaybackPCM "hw:${CardId},1"
+	}
+}

--- a/ucm2/MediaTek/mt8391-evk/init.conf
+++ b/ucm2/MediaTek/mt8391-evk/init.conf
@@ -1,0 +1,25 @@
+Syntax 4
+
+SectionUseCase."HiFi" {
+	File "/MediaTek/mt8391-evk/HiFi.conf"
+	Comment "Play high quality music"
+}
+
+BootSequence [
+	cset "name='ADDA_DL_CH1 DL0_CH1' on"
+	cset "name='ADDA_DL_CH2 DL0_CH2' on"
+	cset "name='I2SOUT0_CH1 DL1_CH1' on"
+	cset "name='I2SOUT0_CH2 DL1_CH2' on"
+	cset "name='PCM_0_PB_CH1 DL2_CH1' on"
+	cset "name='PCM_0_PB_CH2 DL2_CH2' on"
+	cset "name='UL0_CH1 AP_DMIC_UL_CH1' on"
+	cset "name='UL0_CH2 AP_DMIC_UL_CH2' on"
+	cset "name='UL1_CH1 I2SIN0_CH1' on"
+	cset "name='UL1_CH2 I2SIN0_CH2' on"
+	cset "name='UL2_CH1 ADDA_UL_CH1' on"
+	cset "name='UL2_CH2 ADDA_UL_CH2' on"
+	cset "name='UL4_CH1 PCM_0_CAP_CH1' on"
+	cset "name='UL4_CH2 PCM_0_CAP_CH2' on"
+	cset "name='I2S_IN0_Mux' Dummy_Widget"
+	cset "name='I2S_OUT0_Mux' Dummy_Widget"
+]

--- a/ucm2/MediaTek/mt8391-evk/mt8391-evk.conf
+++ b/ucm2/MediaTek/mt8391-evk/mt8391-evk.conf
@@ -1,0 +1,9 @@
+Syntax 4
+
+Define {
+	PlayDevN "0"
+	CapDevN "4"
+	CapChanN "1"
+}
+
+Include.init.File "/MediaTek/mt8391-evk/init.conf"

--- a/ucm2/conf.d/mt8391-evk/mt8391-evk.conf
+++ b/ucm2/conf.d/mt8391-evk/mt8391-evk.conf
@@ -1,0 +1,1 @@
+../../MediaTek/mt8391-evk/mt8391-evk.conf


### PR DESCRIPTION
Add alsa-ucm support for the MediaTek mt8391-evk platform.