### PR TITLE
ucm2: Qualcomm: x1e80100: Add X1E80100-EVK configuration

### DIFF
--- a/ucm2/Qualcomm/x1e80100/X1E80100-EVK.conf
+++ b/ucm2/Qualcomm/x1e80100/X1E80100-EVK.conf
@@ -1,0 +1,19 @@
+Syntax 4
+
+SectionUseCase."HiFi" {
+	File "/Qualcomm/x1e80100/HiFi.conf"
+	Comment "HiFi quality Music."
+}
+
+BootSequence [
+	cset "name='HPHL Volume' 20"
+	cset "name='HPHR Volume' 20"
+	cset "name='ADC2 Volume' 10"
+]
+
+Include.card-init.File "/lib/card-init.conf"
+Include.ctl-remap.File "/lib/ctl-remap.conf"
+Include.wcd-init.File "/codecs/wcd938x/init.conf"
+Include.wsa-init.File "/codecs/wsa884x/four-speakers/init.conf"
+Include.wsam-init.File "/codecs/qcom-lpass/wsa-macro/four-speakers/init.conf"
+Include.rxm-init.File "/codecs/qcom-lpass/rx-macro/init.conf"

--- a/ucm2/conf.d/x1e80100/X1E80100-EVK.conf
+++ b/ucm2/conf.d/x1e80100/X1E80100-EVK.conf
@@ -1,0 +1,1 @@
+../../Qualcomm/x1e80100/X1E80100-EVK.conf


### PR DESCRIPTION
The X1E80100-EVK needs basically the same configuration as the X1E80100-CRD.
The dts upstream is already in progress.
https://lore.kernel.org/all/20250828-hamoa_initial-v8-3-c9d173072a5c@oss.qualcomm.com/
message id <20250828-hamoa_initial-v8-3-c9d173072a5c@oss.qualcomm.com>