### PR TITLE
UCM2: Intel: sof-hda-dsp: HiFi: IPC3 mono DMIC is exposed as stereo PCM

### DIFF
--- a/ucm2/Intel/sof-hda-dsp/HiFi.conf
+++ b/ucm2/Intel/sof-hda-dsp/HiFi.conf
@@ -40,8 +40,17 @@ If.dmic {
 						Regex "cfg-dmics:[1]"
 						String "${CardComponents}"
 					}
-					True {
-						CaptureChannels 1
+					True.If.ipc4 {
+						# Only IPC4 exposes Mono DMIC PCM
+						# IPC3 creates Stereo PCM.
+						Condition {
+							Type String
+							String1 "${var:SOFIPCVer}"
+							String2 "ipc4"
+						}
+						True {
+							CaptureChannels 1
+						}
 					}
 				}
 			}


### PR DESCRIPTION
With IPC3 the DMIC PCM is stereo even in case of a single (mono) DMIC connection.

Make the `CaptureChannels 1` conditional to IPC4 only.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2393552
Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2384324
Closes: https://github.com/thesofproject/linux/issues/5528
Fixes: 56cbdfd04339 ("UCM2: Intel: sof-hda-dsp: HiFi: Fix handling of mono DMICs")