### PR TITLE
Qualcomm: Kaanapali: Add Kaanapali MTP HiFi config

### DIFF
--- a/ucm2/Qualcomm/kaanapali/MTP/HiFi.conf
+++ b/ucm2/Qualcomm/kaanapali/MTP/HiFi.conf
@@ -1,0 +1,65 @@
+SectionVerb {
+	EnableSequence [
+		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia1' 1"
+		cset "name='WSA_CODEC_DMA_RX_0 Audio Mixer MultiMedia2' 1"
+		cset "name='MultiMedia3 Mixer TX_CODEC_DMA_TX_3' 1"
+		cset "name='MultiMedia4 Mixer VA_CODEC_DMA_TX_0' 1"
+	]
+
+	Include.wcde.File "/codecs/wcd939x/DefaultEnableSeq.conf"
+	Include.wsae.File "/codecs/wsa883x/DefaultEnableSeq.conf"
+
+	Value {
+		TQ "HiFi"
+	}
+}
+
+SectionDevice."Speaker" {
+	Comment "Speaker playback"
+
+	Include.wcdspk1e.File "/codecs/qcom-lpass/wsa-macro/SpeakerEnableSeq.conf"
+	Include.wcdspk1d.File "/codecs/qcom-lpass/wsa-macro/SpeakerDisableSeq.conf"
+	Include.wsaspke.File "/codecs/wsa883x/SpeakerEnableSeq.conf"
+	Include.wsaspkd.File "/codecs/wsa883x/SpeakerDisableSeq.conf"
+
+	Value {
+		PlaybackChannels 2
+		PlaybackPriority 100
+		PlaybackPCM "hw:${CardId},1"
+		PlaybackMixer "default:${CardId}"
+	}
+}
+
+SectionDevice."Headphones" {
+	Comment "Headphones playback"
+
+	Include.wcdhpe.File "/codecs/wcd939x/HeadphoneEnableSeq.conf"
+	Include.wcdhpd.File "/codecs/wcd939x/HeadphoneDisableSeq.conf"
+	Include.rxmhpe.File "/codecs/qcom-lpass/rx-macro/HeadphoneEnableSeq.conf"
+	Include.rxmhpd.File "/codecs/qcom-lpass/rx-macro/HeadphoneDisableSeq.conf"
+
+	Value {
+		PlaybackChannels 2
+		PlaybackPriority 200
+		PlaybackPCM "hw:${CardId},0"
+		PlaybackMixer "default:${CardId}"
+		PlaybackMixerElem "HP Digital"
+		JackControl "Headphone Jack"
+		JackHWMute "Speaker"
+	}
+}
+
+SectionDevice."Mic" {
+	Comment "Internal microphones"
+
+	Include.vadm0e.File "/codecs/qcom-lpass/va-macro/DMIC0EnableSeq.conf"
+	Include.vadm0d.File "/codecs/qcom-lpass/va-macro/DMIC0DisableSeq.conf"
+	Include.vadm1e.File "/codecs/qcom-lpass/va-macro/DMIC1EnableSeq.conf"
+	Include.vadm1d.File "/codecs/qcom-lpass/va-macro/DMIC1DisableSeq.conf"
+
+
+	Value {
+		CapturePriority 100
+		CapturePCM "hw:${CardId},3"
+	}
+}

--- a/ucm2/Qualcomm/kaanapali/MTP/Kaanapali-MTP.conf
+++ b/ucm2/Qualcomm/kaanapali/MTP/Kaanapali-MTP.conf
@@ -1,0 +1,17 @@
+Syntax 4
+
+SectionUseCase."HiFi" {
+	File "/Qualcomm/kaanapali/MTP/HiFi.conf"
+	Comment "HiFi quality Music."
+}
+
+BootSequence [
+	cset "name='SpkrLeft PA Volume' 12"
+	cset "name='SpkrRight PA Volume' 12"
+]
+
+Include.card-init.File "/lib/card-init.conf"
+Include.ctl-remap.File "/lib/ctl-remap.conf"
+Include.wcd-init.File "/codecs/wcd939x/init.conf"
+Include.wsa-init.File "/codecs/wsa883x/init.conf"
+Include.wsam-init.File "/codecs/qcom-lpass/wsa-macro/init.conf"

--- a/ucm2/conf.d/kaanapali/Kaanapali-MTP.conf
+++ b/ucm2/conf.d/kaanapali/Kaanapali-MTP.conf
@@ -1,0 +1,17 @@
+Syntax 4
+
+SectionUseCase."HiFi" {
+	File "/Qualcomm/kaanapali/MTP/HiFi.conf"
+	Comment "HiFi quality Music."
+}
+
+BootSequence [
+	cset "name='SpkrLeft PA Volume' 12"
+	cset "name='SpkrRight PA Volume' 12"
+]
+
+Include.card-init.File "/lib/card-init.conf"
+Include.ctl-remap.File "/lib/ctl-remap.conf"
+Include.wcd-init.File "/codecs/wcd939x/init.conf"
+Include.wsa-init.File "/codecs/wsa883x/init.conf"
+Include.wsam-init.File "/codecs/qcom-lpass/wsa-macro/init.conf"


### PR DESCRIPTION
Add UCM2 configs for the Qualcomm Kaanapali-MTP Board. Tested on-board Speakers playback, on-board Microphones.