### PR TITLE
ucm2 USB-Audio: Add support for ASUS Xonar U7

### DIFF
--- a/ucm2/USB-Audio/ASUS/Xonar-U7.conf
+++ b/ucm2/USB-Audio/ASUS/Xonar-U7.conf
@@ -1,0 +1,8 @@
+Syntax 4
+
+Comment "ASUS Xonar U7 USB Audio"
+
+SectionUseCase."HiFi" {
+	File "ASUS/Xonar-U7/HiFi.conf"
+	Comment "High quality audio"
+}

--- a/ucm2/USB-Audio/ASUS/Xonar-U7/HiFi.conf
+++ b/ucm2/USB-Audio/ASUS/Xonar-U7/HiFi.conf
@@ -1,0 +1,59 @@
+SectionVerb {
+	Value {
+		TQ "HiFi"
+		PlaybackMixerElem "PCM"
+		PlaybackVolume "PCM Playback Volume"
+		PlaybackMasterElem "PCM"
+	}
+
+}
+
+SectionDevice."Speaker" {
+	Comment "Stereo Output (Front Headphone / Rear Analog)"
+	
+	Value {
+		PlaybackPriority 300
+		PlaybackPCM "hw:${CardId},2"
+		PlaybackChannels 2
+	}
+}
+
+SectionDevice."Surround40" {
+	Comment "4.0 Surround Output"
+	
+	Value {
+		PlaybackPriority 200
+		PlaybackPCM "hw:${CardId},2"
+		PlaybackChannels 4
+	}
+}
+
+SectionDevice."Surround51" {
+	Comment "5.1 Surround Output"
+	
+	Value {
+		PlaybackPriority 200
+		PlaybackPCM "hw:${CardId},2"
+		PlaybackChannels 6
+	}
+}
+
+SectionDevice."Surround71" {
+	Comment "7.1 Surround Output"
+	
+	Value {
+		PlaybackPriority 200
+		PlaybackPCM "hw:${CardId},2"
+		PlaybackChannels 8
+	}
+}
+
+SectionDevice."IEC958" {
+	Comment "S/PDIF Digital Output"
+	
+	Value {
+		PlaybackPriority 100
+		PlaybackPCM "hw:${CardId},0"
+		PlaybackChannels 2
+	}
+}

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -22,6 +22,16 @@ If.linked {
 	True.Define.ProfileName "../common/linked"
 }
 
+If.asus-xonar-u7 {
+	Condition {
+		Type RegexMatch
+		String "${CardComponents}"
+		# 1043:8586 ASUS Xonar U7
+		Regex "USB1043:8586"
+	}
+	True.Define.ProfileName "ASUS/Xonar-U7"
+}
+
 If.realtek-alc1220-vb {
 
 	Condition {


### PR DESCRIPTION
Add UCM profile for ASUS Xonar U7 USB audio interface (1043:8586) to fix incorrect output mapping and enable hardware volume control.

Audio topology:
hw:1,0: S/PDIF PCM Output (rear panel)
hw:1,1: S/PDIF AC3 Passthrough (not exposed - compressed audio only)
hw:1,2: Analog Multi-Channel Output
 -2ch: Front Headphone Jack
 -4ch: Front + Rear outputs
 -6ch: Front + Rear + Center/LFE outputs
 -8ch: All outputs (Front + Rear + Center/LFE + Side)

Key changes:
- Direct hardware PCM mixer control via PlaybackMixerElem
  - Avoids double volume control (software + hardware), preserves full dynamic range and bit depth (better sound quality)
- All output modes exposed (stereo, 4.0, 5.1, 7.1, S/PDIF)
  - Surround output not tested due to lack of setup
- Fixes incorrect generic UCM mapping of analog output to S/PDIF device

Without this UCM, the generic USB-Audio profile incorrectly maps analog output to hw:1,0 (S/PDIF), resulting in no audio output when plugging in headphones.