### PR TITLE
ucm2: Add support for MT8196 Rauru Rev0 Chromebook with SOF

### DIFF
--- a/ucm2/MediaTek/mt8196-sof/init.conf
+++ b/ucm2/MediaTek/mt8196-sof/init.conf
@@ -1,0 +1,26 @@
+# mt8196 specific boot sequence
+
+BootSequence [
+	# Speaker
+	cset "name='I2SOUT4_CH1 DL_24CH_CH1' 1"
+	cset "name='I2SOUT4_CH2 DL_24CH_CH2' 1"
+
+	# Headphones
+	cset "name='I2SOUT6_CH1 DL1_CH1' 1"
+	cset "name='I2SOUT6_CH2 DL1_CH2' 1"
+
+	# Front Mic
+	cset "name='ADDA_UL_Mux' AP_DMIC"
+	cset "name='UL0_CH1 ADDA_UL_CH1' 1"
+	cset "name='UL0_CH2 ADDA_UL_CH2' 1"
+
+	# Mic
+	cset "name='UL1_CH1 I2SIN6_CH1' 1"
+	cset "name='UL1_CH2 I2SIN6_CH2' 1"
+
+	# Rear Mic
+	cset "name='ADDA_CH34_UL_Mux' AP_DMIC"
+	cset "name='UL2_CH1 ADDA_UL_CH3' 1"
+	cset "name='UL2_CH2 ADDA_UL_CH4' 1"
+]
+

--- a/ucm2/MediaTek/mt8196-sof/nau8825-nau8318/HiFi.conf
+++ b/ucm2/MediaTek/mt8196-sof/nau8825-nau8318/HiFi.conf
@@ -1,0 +1,68 @@
+SectionVerb {
+	EnableSequence [
+		disdevall ""
+	]
+}
+
+SectionDevice."Speaker" {
+	Comment "Speaker"
+
+	Value {
+		PlaybackPCM "hw:${CardId},0"
+		PlaybackPriority 100
+	}
+}
+
+SectionDevice."Headphones" {
+	Comment "Headphones"
+
+	EnableSequence [
+		cset "name='Headphone Jack Switch' 1"
+	]
+
+	DisableSequence [
+		cset "name='Headphone Jack Switch' 0"
+	]
+
+	Value {
+		PlaybackPCM "hw:${CardId},1"
+		JackControl "Headphone Jack"
+		PlaybackPriority 200
+	}
+}
+
+SectionDevice."Mic1" {
+	Comment "Front Microphone"
+
+	Value {
+		CapturePCM "hw:${CardId},2"
+		CapturePriority 200
+	}
+}
+
+SectionDevice."Mic2" {
+	Comment "Rear Microphone"
+
+	Value {
+		CapturePCM "hw:${CardId},4"
+		CapturePriority 100
+	}
+}
+
+SectionDevice."Mic3" {
+	Comment "Headset Microphone"
+
+	EnableSequence [
+		cset "name='Headset Mic Switch' 1"
+	]
+
+	DisableSequence [
+		cset "name='Headset Mic Switch' 0"
+	]
+
+	Value {
+		CapturePCM "hw:${CardId},3"
+		JackControl "Headset Mic Jack"
+		CapturePriority 300
+	}
+}

--- a/ucm2/MediaTek/mt8196-sof/nau8825-nau8318/sof-mt8196-nau8825-nau8318.conf
+++ b/ucm2/MediaTek/mt8196-sof/nau8825-nau8318/sof-mt8196-nau8825-nau8318.conf
@@ -1,0 +1,11 @@
+Comment "MT8196 NAU8825 NAU8318 sound card"
+Syntax 4
+
+SectionUseCase."HiFi" {
+	File "/MediaTek/mt8196-sof/nau8825-nau8318/HiFi.conf"
+	Comment "Default"
+}
+
+Include.card-init.File "/lib/card-init.conf"
+Include.ctl-remap.File "/lib/ctl-remap.conf"
+Include.init.File "/MediaTek/mt8196-sof/init.conf"

--- a/ucm2/conf.d/sof-mt8196-nau8/sof-mt8196-nau8825.conf
+++ b/ucm2/conf.d/sof-mt8196-nau8/sof-mt8196-nau8825.conf
@@ -1,0 +1,1 @@
+../../MediaTek/mt8196-sof/nau8825-nau8318/sof-mt8196-nau8825-nau8318.conf


### PR DESCRIPTION
Add support for the Google Rauru Rev0 Chromebook, powered by MediaTek Kompanio Ultra (MT8196). This machine uses NAU8825 as headphone codec and NAU8318 as speaker codec.