### PR TITLE
ucm2: Add support for Steinberg UR22mkII

### DIFF
--- a/ucm2/USB-Audio/Steinberg/UR22mkII-HiFi.conf
+++ b/ucm2/USB-Audio/Steinberg/UR22mkII-HiFi.conf
@@ -1,0 +1,55 @@
+Include.pcm_split.File "/common/pcm/split.conf"
+
+Macro [
+	{
+		SplitPCM {
+			Name "steinberg_ur22mkii_mono_in"
+			Direction Capture
+			Channels 1
+			HWChannels 2
+			HWChannelPos0 MONO
+			HWChannelPos1 MONO
+		}
+	}
+]
+
+SectionDevice."Line 1" {
+	Comment "Stereo Output"
+
+	Value {
+		PlaybackPriority 200
+		PlaybackPCM "hw:${CardId}"
+	}
+}
+
+SectionDevice."Input 1" {
+	Comment "Input 1"
+
+	Value {
+		CapturePriority 600
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "steinberg_ur22mkii_mono_in"
+		Direction Capture
+		HWChannels 2
+		Channels 1
+		Channel0 0
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Input 2" {
+	Comment "Input 2"
+
+	Value {
+		CapturePriority 500
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "steinberg_ur22mkii_mono_in"
+		Direction Capture
+		HWChannels 2
+		Channels 1
+		Channel0 1
+		ChannelPos0 MONO
+	}
+}

--- a/ucm2/USB-Audio/Steinberg/UR22mkII.conf
+++ b/ucm2/USB-Audio/Steinberg/UR22mkII.conf
@@ -1,0 +1,11 @@
+Comment "Steinberg UR22mkII USB-Audio"
+
+SectionUseCase."HiFi" {
+	Comment "HiFi"
+	File "/USB-Audio/Steinberg/UR22mkII-HiFi.conf"
+}
+
+Define.DirectPlaybackChannels 2
+Define.DirectCaptureChannels 2
+
+Include.dhw.File "/common/direct.conf"

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -140,6 +140,15 @@ If.steinberg-ur22c {
 	True.Define.ProfileName "Steinberg/UR22C"
 }
 
+If.steinberg-ur22mkii {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB0499:170f"
+	}
+	True.Define.ProfileName "Steinberg/UR22mkII"
+}
+
 If.steinberg-ur24c {
 	Condition {
 		Type String


### PR DESCRIPTION
This device is basically an earlier model of the UR22C that already has a configuration. The main functional difference is that the UR22mkII only has 2 hardware channels for the inputs. I have also changed the names/comments in the config to mostly match the text on the device (Input 1/Input 2).

This configuration was tested with a Steinberg UR22mkII with firmware version 1.04.

---

**Disclaimer:** I don't know a lot about ALSA/UCM. I just stumbled on this repository today while looking up how to properly address my audio interface inputs as 2 mono inputs in Pipewire. Please let me know if you need any changes or if there are others steps I need to follow.

I did test my changes on my machines and they work as intended there - The 2 inputs from the UR22 show up as 2 mono inputs now. Just like with the UR22C, this should match the usual usage pattern of most users.