### PR TITLE
ucm2: Qualcomm: x1e80100: T14s: add USB DisplayPort playback

### DIFF
--- a/ucm2/Qualcomm/x1e80100/T14s-HiFi.conf
+++ b/ucm2/Qualcomm/x1e80100/T14s-HiFi.conf
@@ -3,6 +3,9 @@
 
 SectionVerb {
 	EnableSequence [
+		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia1' 0"
+		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia1' 0"
+		cset "name='DISPLAY_PORT_RX_2 Audio Mixer MultiMedia1' 0"
 		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia1' 1"
 		cset "name='WSA_CODEC_DMA_RX_0 Audio Mixer MultiMedia2' 1"
 		cset "name='MultiMedia3 Mixer TX_CODEC_DMA_TX_3' 1"
@@ -36,6 +39,12 @@ SectionDevice."Speaker" {
 SectionDevice."Headphones" {
 	Comment "Headphones playback"
 
+	ConflictingDevice [
+		"HDMI0"
+		"HDMI1"
+		"HDMI2"
+	]
+
 	Include.wcdhpe.File "/codecs/wcd938x/HeadphoneEnableSeq.conf"
 	Include.wcdhpd.File "/codecs/wcd938x/HeadphoneDisableSeq.conf"
 	Include.rxmhpe.File "/codecs/qcom-lpass/rx-macro/HeadphoneEnableSeq.conf"
@@ -43,6 +52,9 @@ SectionDevice."Headphones" {
 
 	EnableSequence [
 		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia1' 1"
+		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia1' 0"
+		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia1' 0"
+		cset "name='DISPLAY_PORT_RX_2 Audio Mixer MultiMedia1' 0"
 	]
 
 	DisableSequence [
@@ -85,5 +97,86 @@ SectionDevice."Mic" {
 	Value {
 		CapturePriority 100
 		CapturePCM "hw:${CardId},3"
+	}
+}
+
+SectionDevice."HDMI0" {
+	Comment "USB/DisplayPort 0 playback"
+
+	ConflictingDevice [
+		"Headphones"
+		"HDMI1"
+		"HDMI2"
+	]
+
+	EnableSequence [
+		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia1' 0"
+		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia1' 1"
+		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia1' 0"
+		cset "name='DISPLAY_PORT_RX_2 Audio Mixer MultiMedia1' 0"
+	]
+
+	DisableSequence [
+		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia1' 0"
+	]
+
+	Value {
+		PlaybackPriority 200
+		PlaybackPCM "hw:${CardId},0"
+		JackControl "DP0 Jack"
+	}
+}
+
+SectionDevice."HDMI1" {
+	Comment "USB/DisplayPort 1 playback"
+
+	ConflictingDevice [
+		"Headphones"
+		"HDMI0"
+		"HDMI2"
+	]
+
+	EnableSequence [
+		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia1' 0"
+		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia1' 0"
+		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia1' 1"
+		cset "name='DISPLAY_PORT_RX_2 Audio Mixer MultiMedia1' 0"
+	]
+
+	DisableSequence [
+		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia1' 0"
+	]
+
+	Value {
+		PlaybackPriority 200
+		PlaybackPCM "hw:${CardId},0"
+		JackControl "DP1 Jack"
+	}
+}
+
+SectionDevice."HDMI2" {
+	Comment "HDMI playback"
+
+	ConflictingDevice [
+		"Headphones"
+		"HDMI0"
+		"HDMI1"
+	]
+
+	EnableSequence [
+		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia1' 0"
+		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia1' 0"
+		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia1' 0"
+		cset "name='DISPLAY_PORT_RX_2 Audio Mixer MultiMedia1' 1"
+	]
+
+	DisableSequence [
+		cset "name='DISPLAY_PORT_RX_2 Audio Mixer MultiMedia1' 0"
+	]
+
+	Value {
+		PlaybackPriority 200
+		PlaybackPCM "hw:${CardId},0"
+		JackControl "DP2 Jack"
 	}
 }


### PR DESCRIPTION
Add two DisplayPort (over USB) and one HDMI playback devices, conflicting with the headset, because they use the same MultiMedia1 frontend.

Signed-off-by: Krzysztof Kozlowski <krzysztof.kozlowski@linaro.org>

---

Linux kernel patch adding support for these:
https://lore.kernel.org/linux-arm-msm/honsqyec45rg4yrh3rwjlqlhcqyatbbsvnhamhjdin3tgaggzc@5yrxw5mwhkni/T/#u