### PR TITLE
ucm2: sof: hdmi: Add 5.1 and 7.1 variants of HDMI devices when using IPC4

### DIFF
--- a/ucm2/Intel/sof-hda-dsp/sof-hda-dsp.conf
+++ b/ucm2/Intel/sof-hda-dsp/sof-hda-dsp.conf
@@ -41,7 +41,24 @@ If.devdmic {
 
 SectionUseCase."HiFi" {
 	File "/Intel/sof-hda-dsp/HiFi.conf"
-	Comment "Play HiFi quality Music"
+	If.multichannel {
+		Condition {
+			Type String
+			Empty "${var:Iec61937Pcms1}"
+		}
+		True.Comment "Play HiFi quality Music"
+		False {
+			Variant."HiFi" {
+				Comment "Play HiFi quality Music"
+			}
+			Variant."HiFi 5+1" {
+				Comment "Surround 5.1"
+			}
+			Variant."HiFi 7+1" {
+				Comment "Surround 7.1"
+			}
+		}
+	}
 }
 
 Include.hda-init.File "/HDA/init.conf"

--- a/ucm2/codecs/hda/hdmi.conf
+++ b/ucm2/codecs/hda/hdmi.conf
@@ -39,6 +39,13 @@ DefineMacro.HDMI {
 				PlaybackPCM "hw:${CardId},${var:__Device}"
 				JackControl "HDMI/DP${var:__Suffix} Jack"
 			}
+
+			Variant."HiFi 5+1".Value {
+				PlaybackChannels 6
+			}
+			Variant."HiFi 7+1".Value {
+				PlaybackChannels 8
+			}
 		}
 	}
 }

--- a/ucm2/sof-soundwire/sof-soundwire.conf
+++ b/ucm2/sof-soundwire/sof-soundwire.conf
@@ -1,14 +1,5 @@
 Syntax 7
 
-SectionUseCase."HiFi" {
-	File "/sof-soundwire/HiFi.conf"
-	Comment "Play HiFi quality Music"
-}
-
-Include.led.File "/common/ctl/led.conf"
-Include.card-init.File "/lib/card-init.conf"
-Include.ctl-remap.File "/lib/ctl-remap.conf"
-
 Define {
 	SpeakerCodec1 ""
 	SpeakerChannels1 "2"
@@ -19,6 +10,32 @@ Define {
 	Iec61937Pcms1 ""
 	MultiCodec1 ""
 }
+
+SectionUseCase."HiFi" {
+	File "/sof-soundwire/HiFi.conf"
+	If.multichannel {
+		Condition {
+			Type String
+			Empty "${var:Iec61937Pcms1}"
+		}
+		True.Comment "Play HiFi quality Music"
+		False {
+			Variant."HiFi" {
+				Comment "Play HiFi quality Music"
+			}
+			Variant."HiFi 5+1" {
+				Comment "Surround 5.1"
+			}
+			Variant."HiFi 7+1" {
+				Comment "Surround 7.1"
+			}
+		}
+	}
+}
+
+Include.led.File "/common/ctl/led.conf"
+Include.card-init.File "/lib/card-init.conf"
+Include.ctl-remap.File "/lib/ctl-remap.conf"
 
 DefineRegex {
 	SpeakerCodec {


### PR DESCRIPTION
Systems using IPC4 can support up to 8 channels of audio (and passthrough) via HDMI.

In UCM the default PlaybackChannels is set to 2, which prevents users from selecting multichannel configurations.

When probing the card, Pipewire will drop configurations that are not supported either by the PCM device or based on ELD information.
This means that if the equipment supports only stereo then the 5.1 and 7.1 variants should not be visible, if the equipment is 5.1 capable, then only the 7.1 variant is removed.

The kernel will refine the PCM parameters based on the ELD information as wall when https://lore.kernel.org/linux-sound/20251029073600.13624-1-peter.ujfalusi@linux.intel.com/ is applied.

@perexg, @wtay, @ford-prefect, is this something which can help PW and user space to handle the HDMI a bit better with SOF?