### PR TITLE
ucm2: Add setting LED Mode in SetLED macro

### DIFF
--- a/ucm2/codecs/cs42l45-dmic/init.conf
+++ b/ucm2/codecs/cs42l45-dmic/init.conf
@@ -5,5 +5,5 @@ BootSequence [
 ]
 
 Macro [
-	{ SetLED { LED="mic" Action="attach" CtlId="cs42l45 FU 113 Mute Switch" } }
+	{ SetLED { LED="mic" Action="attach" CtlId="cs42l45 FU 113 Mute Switch" Mode="follow-route"} }
 ]

--- a/ucm2/common/ctl/led.conf
+++ b/ucm2/common/ctl/led.conf
@@ -30,6 +30,7 @@
 #   LED    - LED selection - "speaker" or "mic"
 #   Action - action for given control - "attach" or "detach"
 #   CtlId  - control identifier (as for amixer, e.g. "Capture Switch" or "name='CaptureSwitch',index=1")
+#   Mode   - (optional) LED mode - "on", "off", "follow-mute" or "follow-route"
 #
 
 DefineMacro.SetLED {
@@ -46,6 +47,15 @@ DefineMacro.SetLED {
 		}
 	}
 	If.1 {
+		Condition {
+			Type String
+			Empty "${var:-__Mode}"
+		}
+		False.FixedBootSequence [
+			sysw "-/class/sound/ctl-led/${var:__LED}/mode:${var:__Mode}"
+		]
+	}
+	If.2 {
 		Condition { Type AlwaysTrue }
 		True.FixedBootSequence [
 			sysw "-/class/sound/ctl-led/${var:__LED}/card${CardNumber}/${var:__Action}:${var:__CtlId}"


### PR DESCRIPTION
Add 'Mode' argument to SetLED macro in order to allow setting a different LED mode. This will allow mute switches with inverted values to control the LEDs with 'follow-route' option instead of default 'follow-mute'.

Update all calls to SetLED with appropriate Mode argument.