### PR TITLE
ucm2: IO-Boards: Toradex: aquila: add support

### DIFF
--- a/ucm2/IO-Boards/Toradex/aquila/dev-HiFi.conf
+++ b/ucm2/IO-Boards/Toradex/aquila/dev-HiFi.conf
@@ -1,0 +1,39 @@
+# Use case configuration for Toradex Aquila Development Carrier Board
+# This is a carrier board for the Aquila family, where any Aquila SoM (with
+# different SoCs as AM69, iMX95...) can be connected to it.
+
+SectionDevice."Headphones" {
+	Comment "Headphones"
+
+	EnableSequence [
+		cset "name='Headphone Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Headphone Switch' off"
+	]
+
+	Value {
+		PlaybackPCM "hw:${CardId}"
+		PlaybackVolume "Headphone Volume"
+		PlaybackSwitch "Headphone Switch"
+	}
+}
+
+SectionDevice."Mic" {
+	Comment "Microphone"
+
+	EnableSequence [
+		cset "name='Capture Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Capture Switch' off"
+	]
+
+	Value {
+		CapturePCM "hw:${CardId}"
+		CaptureVolume "Capture Volume"
+		CaptureSwitch "Capture Switch"
+	}
+}

--- a/ucm2/IO-Boards/Toradex/aquila/dev.conf
+++ b/ucm2/IO-Boards/Toradex/aquila/dev.conf
@@ -1,0 +1,17 @@
+# Use case configuration for Toradex Aquila Development Carrier Board
+# This is a carrier board for the Aquila family, where any Aquila SoM (with
+# different SoCs as AM69, iMX95...) can be connected to it.
+
+Syntax 4
+
+SectionUseCase."HiFi" {
+	File "/IO-Boards/Toradex/aquila/dev-HiFi.conf"
+	Comment "Default"
+}
+
+BootSequence [
+	cset "name='Headphone Volume' 50%"
+	cset "name='Left Capture Inverting Mux' 'IN1L'"
+	cset "name='Right Capture Inverting Mux' 'IN1R'"
+	cset "name='Capture Volume' 31"
+]

--- a/ucm2/conf.d/simple-card/aquila-wm8904.conf
+++ b/ucm2/conf.d/simple-card/aquila-wm8904.conf
@@ -1,0 +1,1 @@
+../../IO-Boards/Toradex/aquila/dev.conf


### PR DESCRIPTION
Add support for Toradex Aquila Development board, using the WM8904 audio codec.

This is a carrier board for the Toradex Aquila family, where any Toradex Aquila SoM can be connected to it, therefore this is being added to the IO-Boards instead of a specific hardware vendor.