### PR TITLE
HDA: route speaker volume to Post Mixer Analog

### DIFF
--- a/ucm2/HDA/HiFi-analog.conf
+++ b/ucm2/HDA/HiFi-analog.conf
@@ -117,8 +117,14 @@ If.spk {
 			}
 		}
 
-		Define.spk_mixer "Speaker"
-		Define.spk_volume "Speaker Playback Volume"
+		Value {
+			PlaybackPriority 100
+			PlaybackPCM "hw:${CardId}"
+			PlaybackMixerElem "Speaker"
+			PlaybackMasterElem "Speaker"
+			PlaybackVolume "Speaker Playback Volume"
+			PlaybackSwitch "Speaker Playback Switch"
+		}
 
 		If.legion {
 			Condition {
@@ -131,20 +137,12 @@ If.spk {
 					Type ControlExists
 					Control "name='Post Mixer Analog Playback Volume'"
 				}
-				True.Define {
-					spk_mixer "Post Mixer Analog"
-					spk_volume "Post Mixer Analog Playback Volume"
+				True.Value {
+					PlaybackMixerElem "Post Mixer Analog"
+					PlaybackMasterElem "Post Mixer Analog"
+					PlaybackVolume "Post Mixer Analog Playback Volume"
 				}
 			}
-		}
-
-		Value {
-			PlaybackPriority 100
-			PlaybackPCM "hw:${CardId}"
-			PlaybackMixerElem "${var:spk_mixer}"
-			PlaybackMasterElem "${var:spk_mixer}"
-			PlaybackVolume "${var:spk_volume}"
-			PlaybackSwitch "Speaker Playback Switch"
 		}
 	}
 }


### PR DESCRIPTION
On certain laptops (e.g., Lenovo Legion Pro 7 16IAX10H), the live speaker gain is exposed through the Post Mixer Analog controls. The default UCM entries point at Speaker/Master, so software volume never touches the woofer amps. Routing the Speaker device to the Post Mixer Analog mixer and volume elements restores proper volume control without affecting other paths