### PR TITLE
USB-Audio: Add jack controls for HP Thunderbolt Dock G2

### DIFF
--- a/ucm2/USB-Audio/HP/Thunderbolt-Dock-Audio-Headset-HiFi.conf
+++ b/ucm2/USB-Audio/HP/Thunderbolt-Dock-Audio-Headset-HiFi.conf
@@ -1,0 +1,43 @@
+SectionDevice."Headphones" {
+	Comment "Headphones"
+
+	Value {
+		PlaybackPriority 100
+		PlaybackPCM "hw:${CardId}"
+		JackControl "Headsets Playback Jack"
+
+		If.Headphone_ctl {
+			Condition {
+				Type ControlExists
+				Control "name='Headsets Playback Switch'"
+			}
+			True {
+				PlaybackMixerElem "Headsets"
+				PlaybackVolume "Headsets Playback Volume"
+				PlaybackSwitch "Headsets Playback Switch"
+			}
+		}
+	}
+}
+
+SectionDevice."Headset" {
+	Comment "Headset Microphone"
+
+	Value {
+		CapturePriority 100
+		CapturePCM "hw:${CardId}"
+		JackControl "Headset Capture Jack"
+
+		If.Mic_ctl {
+			Condition {
+				Type ControlExists
+				Control "name='Headset Capture Switch'"
+			}
+			True {
+				CaptureMixerElem "Headset"
+				CaptureVolume "Headset Capture Volume"
+				CaptureSwitch "Headset Capture Switch"
+			}
+		}
+	}
+}

--- a/ucm2/USB-Audio/HP/Thunderbolt-Dock-Audio-Headset.conf
+++ b/ucm2/USB-Audio/HP/Thunderbolt-Dock-Audio-Headset.conf
@@ -1,0 +1,6 @@
+Comment "HP Thunderbolt Dock G2 headset"
+
+SectionUseCase."HiFi" {
+	Comment "Default"
+	File "/USB-Audio/HP/Thunderbolt-Dock-Audio-Headset-HiFi.conf"
+}

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -323,6 +323,15 @@ If.dell-desktop-rear {
 	True.Define.ProfileName "Dell/Desktop-Rear"
 }
 
+If.hp-tb-dock {
+	Condition {
+		Type RegexMatch
+		String "${CardComponents}"
+		Regex "USB03f0:0269"
+	}
+	True.Define.ProfileName "HP/Thunderbolt-Dock-Audio-Headset"
+}
+
 If.mbox3 {
 	Condition {
 		Type String


### PR DESCRIPTION
Similar to the Dell WD15/WD19, this allows for jack detection (headphones/headset) on the HP Thunderbolt Dock G2.

Link: https://lore.kernel.org/linux-sound/20251126003805.2705503-1-tasos@tasossah.com/T/