### PR TITLE
Add Audient iD14 MK2 support

### DIFF
--- a/ucm2/USB-Audio/Audient/Audient-iD14-0008.conf
+++ b/ucm2/USB-Audio/Audient/Audient-iD14-0008.conf
@@ -1,0 +1,11 @@
+Comment "Audient iD14 MK2 USB-Audio"
+
+SectionUseCase."HiFi" {
+	Comment "Default"
+	File "/USB-Audio/Audient/Audient-iD14-HiFi-0008.conf"
+}
+
+Define.DirectPlaybackChannels 6
+Define.DirectCaptureChannels 12
+
+Include.dhw.File "/common/direct.conf"

--- a/ucm2/USB-Audio/Audient/Audient-iD14-HiFi-0008.conf
+++ b/ucm2/USB-Audio/Audient/Audient-iD14-HiFi-0008.conf
@@ -1,0 +1,112 @@
+Include.pcm_split.File "/common/pcm/split.conf"
+
+Macro [
+	{
+		SplitPCM {
+			Name "id14_mono_in"
+			Direction Capture
+			Format S32_LE
+			Channels 1
+			HWChannels 12
+			HWChannelPos0 MONO
+			HWChannelPos1 MONO
+			HWChannelPos2 MONO
+			HWChannelPos3 MONO
+			HWChannelPos4 MONO
+			HWChannelPos5 MONO
+			HWChannelPos6 MONO
+			HWChannelPos7 MONO
+			HWChannelPos8 MONO
+			HWChannelPos9 MONO
+			HWChannelPos10 MONO
+			HWChannelPos11 MONO
+		}
+	}
+	{
+		SplitPCM {
+			Name "id14_stereo_out"
+			Direction Playback
+			Format S32_LE
+			Channels 2
+			HWChannels 6
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 FL
+			HWChannelPos3 FR
+			HWChannelPos4 FL
+			HWChannelPos5 FR
+		}
+	}
+]
+
+SectionDevice."Headphones" {
+	Comment "Headphones"
+
+	Value {
+		PlaybackPriority 200
+		PlaybackChannels 2
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "id14_stereo_out"
+		Direction Playback
+		HWChannels 6
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line1" {
+	Comment "Monitor Output 1-2"
+
+	Value {
+		PlaybackPriority 100
+		PlaybackChannels 2
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "id14_stereo_out"
+		Direction Playback
+		HWChannels 6
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Mic1" {
+	Comment "Mic/Line Input 1"
+
+	Value {
+		CapturePriority 200
+		CaptureChannels 1
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "id14_mono_in"
+		Direction Capture
+		HWChannels 12
+		Channels 1
+		Channel0 0
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Mic2" {
+	Comment "Mic/Line Input 2"
+
+	Value {
+		CapturePriority 100
+		CaptureChannels 1
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "id14_mono_in"
+		Direction Capture
+		HWChannels 12
+		Channels 1
+		Channel0 1
+		ChannelPos0 MONO
+	}
+}

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -521,6 +521,15 @@ If.id4-0009 {
 	True.Define.ProfileName "Audient/Audient-iD4-0009"
 }
 
+If.id14-0008 {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB2708:0008"
+	}
+	True.Define.ProfileName "Audient/Audient-iD14-0008"
+}
+
 If.fireface-ucx {
 	Condition {
 		Type String


### PR DESCRIPTION
  Add UCM2 configuration for the Audient iD14 MK2 USB audio interface.

  Device: Audient iD14 MK2
  USB ID: 2708:0008

  This is a minimal configuration exposing only the main analog I/O:
  - Microphone/line inputs (2 mono channels)
  - Headphone and monitor outputs

  Full 12-channel capture (ADAT, S/PDIF, loopback) is not exposed.

  Playback devices:
  - Headphones (priority 200)
  - Line1/Monitor 1-2 (priority 100)

  Capture devices:
  - Mic1/Input 1 (priority 200)
  - Mic2/Input 2 (priority 100)

  Tested on NixOS with PipeWire.
