### PR TITLE
ucm2: sof-soundwire: fix a case MultiCodec1 string is in HeadsetCodec1 string

### DIFF
--- a/ucm2/sof-soundwire/sof-soundwire.conf
+++ b/ucm2/sof-soundwire/sof-soundwire.conf
@@ -100,6 +100,16 @@ If.multi_headset {
 	True {
 		Define.HeadsetCodec1 ""
 	}
+	False.If.multi_hs {
+		Condition {
+			Type RegexMatch
+			Regex "${var:MultiCodec1}"
+			String "(${var:HeadsetCodec1}(-sdca)?)"
+		}
+		True {
+			Define.HeadsetCodec1 ""
+		}
+	}
 }
 
 If.spk_init {


### PR DESCRIPTION

ucm2: sof-soundwire: fix a case MultiCodec1 string is in HeadsetCodec1 string

The component string is
Components    : 'HDA:80862822,80860101,00100000  cfg-amp:1 iec61937-pcm:7,6,5 hs:rt713-sdca mic:rt713 spk:rt1320'
Therefore, HeadsetCodec1 string is 'rt713-sdca' and MultiCodec1 string is 'rt713'.
The Regex and String should be swapped and check again.