### PR TITLE
[for alsa-lib 1.2.15] USB-Audio: add support for conf.d configurations

### DIFF
--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -1,8 +1,16 @@
 Syntax 8
 
+#
+# Optional configuration can be stored to USB-Audio/conf.d/{VENDOR}-{DEVICE}.conf files
+#
+
 Define.ProfileName ""
 Define.MixerRemap ""
 Define.SplitPCMPeriodTime 10000		# 10ms
+DefineRegex.USBID {
+	Regex "USB([0-9a-f]{4}):([0-9a-f]{4})"
+	String "${CardComponents}"
+}
 
 If.env1 {
 	Condition {
@@ -11,6 +19,10 @@ If.env1 {
 	}
 	False.Define.SplitPCMPeriodTime "${env:UCM_USB_PERIOD_TIME}"
 }
+
+#
+# device specific configuration block
+#
 
 If.linked {
 	Condition {
@@ -614,6 +626,15 @@ If.beacn-studio {
 		Regex "USB33ae:[04]003"
 	}
 	True.Define.ProfileName "Beacn/Beacn-Studio"
+}
+
+#
+# end of device specific configuration block
+#
+
+If.opt.Append.Include.opt {
+	File "/USB-Audio/conf.d/${var:USBID1}-${var:USBID2}.conf"
+	Optional true
 }
 
 If.mixremap {


### PR DESCRIPTION
It may be useful to add new or override specific hardware configurations until they are merged to the main USB-Audio.conf file.

BugLink: https://github.com/alsa-project/alsa-ucm-conf/issues/609