### PR TITLE
ucm2: sof-soundwire: Simplify cs42l45 configs

### DIFF
--- a/ucm2/codecs/cs42l45-dmic/init.conf
+++ b/ucm2/codecs/cs42l45-dmic/init.conf
@@ -1,9 +1,22 @@
 # cs42l45 specific control settings
 
+LibraryConfig.remap.Config {
+	ctl.default.map {
+		"name='cs42l45 Microphone Capture Switch'" {
+			"name='cs42l45 FU 113 Channel Switch'".vindex.0 0
+			"name='cs42l45 FU 113 Channel Switch'".vindex.1 1
+		}
+		"name='cs42l45 Microphone Capture Volume'" {
+			"name='cs42l45 FU 113 Channel Volume'".vindex.0 0
+			"name='cs42l45 FU 113 Channel Volume'".vindex.1 1
+		}
+	}
+}
+
 BootSequence [
-	cset "name='cs42l45 FU 113 Mute Switch' 0"
+	cset "name='cs42l45 FU 113 Channel Switch' 0"
 ]
 
 Macro [
-	{ SetLED { LED="mic" Action="attach" CtlId="cs42l45 FU 113 Mute Switch" Mode="follow-route"} }
+	{ SetLED { LED="mic" Action="attach" CtlId="cs42l45 FU 113 Channel Switch"} }
 ]

--- a/ucm2/codecs/cs42l45/init.conf
+++ b/ucm2/codecs/cs42l45/init.conf
@@ -1,0 +1,24 @@
+# cs42l45 specific control settings
+
+LibraryConfig.remap.Config {
+	ctl.default.map {
+		"name='cs42l45 Jack Microphone Capture Switch'" {
+			"name='cs42l45 FU 36 Channel Switch'".vindex.0 0
+			"name='cs42l45 FU 36 Channel Switch'".vindex.1 1
+		}
+		"name='cs42l45 Jack Microphone Capture Volume'" {
+			"name='cs42l45 FU 36 Channel Volume'".vindex.0 0
+			"name='cs42l45 FU 36 Channel Volume'".vindex.1 1
+		}
+	}
+	ctl.default.map {
+		"name='cs42l45 Headphone Playback Switch'" {
+			"name='cs42l45 FU 41 Channel Switch'".vindex.0 0
+			"name='cs42l45 FU 41 Channel Switch'".vindex.1 1
+		}
+		"name='cs42l45 Headphone Playback Volume'" {
+			"name='cs42l45 FU 41 Channel Volume'".vindex.0 0
+			"name='cs42l45 FU 41 Channel Volume'".vindex.1 1
+		}
+	}
+}

--- a/ucm2/sof-soundwire/cs42l45-dmic.conf
+++ b/ucm2/sof-soundwire/cs42l45-dmic.conf
@@ -7,18 +7,14 @@ SectionDevice."Mic" {
 		"Headset"
 	]
 
-	EnableSequence [
-		cset "name='cs42l45 FU 113 Mute Switch' 0"
-	]
-
 	DisableSequence [
-		cset "name='cs42l45 FU 113 Mute Switch' 1"
+		cset "name='cs42l45 FU 113 Channel Switch' 0"
 	]
 
 	Value {
 		CapturePriority 100
 		CapturePCM "hw:${CardId},4"
 		CaptureMixer "default:${CardId}"
-		CaptureVolume "cs42l45 FU 113 Channel Volume"
+		CaptureMixerElem "cs42l45 Microphone"
 	}
 }

--- a/ucm2/sof-soundwire/cs42l45.conf
+++ b/ucm2/sof-soundwire/cs42l45.conf
@@ -3,19 +3,11 @@
 SectionDevice."Headphones" {
 	Comment "Headphones"
 
-	EnableSequence [
-		cset "name='cs42l45 FU 41 Mute Switch' 0"
-	]
-
-	DisableSequence [
-		cset "name='cs42l45 FU 41 Mute Switch' 1"
-	]
-
 	Value {
 		PlaybackPriority 200
 		PlaybackPCM "hw:${CardId},0"
 		PlaybackMixer "default:${CardId}"
-		PlaybackVolume "cs42l45 FU 41 Channel Volume"
+		PlaybackMixerElem "cs42l45 Headphone"
 		JackControl "cs42l45 OT 43 Headphone Jack"
 	}
 }
@@ -23,19 +15,15 @@ SectionDevice."Headphones" {
 SectionDevice."Headset" {
 	Comment "Jack Microphone"
 
-	EnableSequence [
-		cset "name='cs42l45 FU 36 Mute Switch' 0"
-	]
-
 	DisableSequence [
-		cset "name='cs42l45 FU 36 Mute Switch' 1"
+		cset "name='cs42l45 FU 36 Channel Switch' 0"
 	]
 
 	Value {
 		CapturePriority 200
 		CapturePCM "hw:${CardId},1"
 		CaptureMixer "default:${CardId}"
-		CaptureVolume "cs42l45 FU 36 Channel Volume"
+		CaptureMixerElem "cs42l45 Jack Microphone"
 		JackControl "cs42l45 IT 31 Microphone Jack"
 	}
 }

--- a/ucm2/sof-soundwire/sof-soundwire.conf
+++ b/ucm2/sof-soundwire/sof-soundwire.conf
@@ -114,7 +114,7 @@ If.spk_init {
 If.hs_init {
 	Condition {
 		Type RegexMatch
-		Regex "(cs42l43|rt5682|rt700|rt711|rt713(-sdca)?)"
+		Regex "(cs42l43|cs42l45|rt5682|rt700|rt711|rt713(-sdca)?)"
 		String "${var:HeadsetCodec1}"
 	}
 	True.Include.hs_init.File "/codecs/${var:HeadsetCodec1}/init.conf"


### PR DESCRIPTION
Continued from https://github.com/alsa-project/alsa-ucm-conf/pull/644

Simplify cs42l45 configs following machine driver changes [1] which bring normal switches instead of mute switches.

[1] https://lore.kernel.org/all/20251127163426.2500633-2-ckeepax@opensource.cirrus.com/