### PR TITLE
ucm2: USB-Audio: Add Rodecaster Pro II

### DIFF
--- a/ucm2/USB-Audio/RODE/RODECaster-Pro-II-Multitrack-Capture.conf
+++ b/ucm2/USB-Audio/RODE/RODECaster-Pro-II-Multitrack-Capture.conf
@@ -1,0 +1,223 @@
+Include.pcm_split.File "/common/pcm/split.conf"
+
+Macro.playback.SplitPCM {
+	Name "rodecaster_pro_ii_stereo_in"
+	Direction Capture
+	Channels 2
+	HWChannels 16
+	Device 1
+
+	HWChannelPos0 FL	# Main Mix Left
+	HWChannelPos1 FR	# Main Mix Right
+
+	HWChannelPos2 MONO	# Combo 1
+	HWChannelPos3 MONO	# Combo 2
+	HWChannelPos4 MONO	# Combo 3
+	HWChannelPos5 MONO	# Combo 4
+
+	HWChannelPos6 FL	# Bluetooth Left
+	HWChannelPos7 FR	# Bluetooth Right
+
+	HWChannelPos8 FL	# Smart Pads Left
+	HWChannelPos9 FR	# Smart Pads Right
+
+	HWChannelPos10 FL	# System Left
+	HWChannelPos11 FR	# System Right
+
+	HWChannelPos12 FL	# Chat Left
+	HWChannelPos13 FR	# Chat Right
+
+	HWChannelPos14 FL	# USB2 Left
+	HWChannelPos15 FR	# USB2 Right
+}
+
+SectionDevice."Mic" {
+	Comment "Microphone"
+
+	Value {
+		CapturePriority 100
+		CapturePCM "hw:${CardId},0"
+	}
+}
+
+SectionDevice."Line:main" {
+	Comment "Main"
+
+	Value {
+		CapturePriority 110
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "rodecaster_pro_ii_stereo_in"
+		Direction Capture
+		Device 1
+		HWChannels 16
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line:combo_1" {
+	Comment "Combo 1"
+
+	Value {
+		CapturePriority 120
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "rodecaster_pro_ii_stereo_in"
+		Direction Capture
+		Device 1
+		HWChannels 16
+		Channels 1
+		Channel0 2
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Line:combo_2" {
+	Comment "Combo 2"
+
+	Value {
+		CapturePriority 130
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "rodecaster_pro_ii_stereo_in"
+		Direction Capture
+		Device 1
+		HWChannels 16
+		Channels 1
+		Channel0 3
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Line:combo_3" {
+	Comment "Combo 3"
+
+	Value {
+		CapturePriority 140
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "rodecaster_pro_ii_stereo_in"
+		Direction Capture
+		Device 1
+		HWChannels 16
+		Channels 1
+		Channel0 4
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Line:combo_4" {
+	Comment "Combo 4"
+
+	Value {
+		CapturePriority 150
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "rodecaster_pro_ii_stereo_in"
+		Direction Capture
+		Device 1
+		HWChannels 16
+		Channels 1
+		Channel0 5
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Line:bluetooth" {
+	Comment "Bluetooth"
+
+	Value {
+		CapturePriority 160
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "rodecaster_pro_ii_stereo_in"
+		Direction Capture
+		Device 1
+		HWChannels 16
+		Channels 2
+		Channel0 6
+		Channel1 7
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line:usb2" {
+	Comment "USB 2"
+
+	Value {
+		CapturePriority 170
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "rodecaster_pro_ii_stereo_in"
+		Direction Capture
+		Device 1
+		HWChannels 16
+		Channels 2
+		Channel0 14
+		Channel1 15
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line:smart_pads" {
+	Comment "SMART Pads"
+
+	Value {
+		CapturePriority 180
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "rodecaster_pro_ii_stereo_in"
+		Direction Capture
+		Device 1
+		HWChannels 16
+		Channels 2
+		Channel0 8
+		Channel1 9
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line:system" {
+	Comment "System"
+
+	Value {
+		CapturePriority 190
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "rodecaster_pro_ii_stereo_in"
+		Direction Capture
+		Device 1
+		HWChannels 16
+		Channels 2
+		Channel0 10
+		Channel1 11
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line:chat" {
+	Comment "Chat"
+
+	Value {
+		CapturePriority 200
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "rodecaster_pro_ii_stereo_in"
+		Direction Capture
+		Device 1
+		HWChannels 16
+		Channels 2
+		Channel0 12
+		Channel1 13
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}

--- a/ucm2/USB-Audio/RODE/RODECaster-Pro-II-Multitrack-Playback.conf
+++ b/ucm2/USB-Audio/RODE/RODECaster-Pro-II-Multitrack-Playback.conf
@@ -1,0 +1,128 @@
+Include.pcm_split.File "/common/pcm/split.conf"
+
+Macro.playback.SplitPCM {
+	Name "rodecaster_pro_ii_stereo_out"
+	Direction Playback
+	Channels 2
+	HWChannels 10
+	Device 1
+
+	HWChannelPos0 FL	# System Left
+	HwChannelPos1 FR	# System Right
+
+	HWChannelPos2 FL	# Game Left
+	HWChannelPos3 FR	# Game Right
+
+	HWChannelPos4 FL	# Music Left
+	HWChannelPos5 FR	# Music Right
+
+	HWChannelPos6 FL	# Virtual A Left
+	HWChannelPos7 FR	# Virtual A Right
+
+	HWChannelPos8 FL	# Virtual B Left
+	HWChannelPos9 FR	# Virtual B Right
+}
+
+SectionDevice."Speaker" {
+	Comment "System"
+
+	Value {
+		PlaybackPriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "rodecaster_pro_ii_stereo_out"
+		Direction Playback
+		Device 1
+		HWChannels 10
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line:chat" {
+	Comment "Chat"
+
+	Value {
+		PlaybackPCM "hw:${CardId},0"
+		PlaybackPriority 110
+	}
+}
+
+SectionDevice."Line:game" {
+	Comment "Game"
+
+	Value {
+		PlaybackPriority 120
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "rodecaster_pro_ii_stereo_out"
+		Direction Playback
+		Device 1
+		HWChannels 10
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line:music" {
+	Comment "Music"
+
+	Value {
+		PlaybackPriority 130
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "rodecaster_pro_ii_stereo_out"
+		Direction Playback
+		Device 1
+		HWChannels 10
+		Channels 2
+		Channel0 4
+		Channel1 5
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line:virtual_a" {
+	Comment "Virtual A"
+
+	Value {
+		PlaybackPriority 140
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "rodecaster_pro_ii_stereo_out"
+		Direction Playback
+		Device 1
+		HWChannels 10
+		Channels 2
+		Channel0 6
+		Channel1 7
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line:virtual_b" {
+	Comment "Virtual B"
+
+	Value {
+		PlaybackPriority 150
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "rodecaster_pro_ii_stereo_out"
+		Direction Playback
+		Device 1
+		HWChannels 10
+		Channels 2
+		Channel0 8
+		Channel1 9
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}

--- a/ucm2/USB-Audio/RODE/RODECaster-Pro-II.conf
+++ b/ucm2/USB-Audio/RODE/RODECaster-Pro-II.conf
@@ -1,0 +1,156 @@
+# The RODECaster Pro II has two USB ports, each with its own PID.
+# USB1 has additionally the special capability to send multiple additonal tracks (multitrack mode).
+# The multitrack functionallity can be configured for output and input individually.
+# This soundcard also provides two devices on USB1. Device 0 is always the Mic/Chat Track. Device 1 is the
+# optional multitrack device.
+
+Comment "RODECaster Pro II USB"
+If.usb1 {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB19f7:0037"
+	}
+	True {
+		# Multitrack is disabled for Input and Output
+		SectionUseCase."HiFi" {
+			Comment "RODECaster Pro II"
+			Config {
+				SectionDevice."Speaker" {
+					Comment "System"
+					Value {
+						PlaybackPCM "hw:${CardId},1"
+						PlaybackPriority 100
+					}
+				}
+				SectionDevice."Line:chat" {
+					Comment "Chat"
+					Value {
+						PlaybackPCM "hw:${CardId},0"
+						PlaybackPriority 110
+					}
+				}
+				SectionDevice."Mic" {
+					Comment "Microphone"
+					Value {
+						CapturePCM "hw:${CardId},0"
+						CapturePriority 100
+					}
+				}
+				SectionDevice."Line:main" {
+					Comment "Main"
+					Value {
+						CapturePCM "hw:${CardId},1"
+						CapturePriority 110
+					}
+				}
+			}
+		}
+	}
+}
+If.usb1_multitrack {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB19f7:0072"
+	}
+	True {
+		# Multitrack is enabled for Input and Output
+		SectionUseCase."HiFi" {
+			Comment "RODECaster Pro II"
+			Config {
+				Include.playback.File "/USB-Audio/RODE/RODECaster-Pro-II-Multitrack-Playback.conf"
+				Include.capture.File "/USB-Audio/RODE/RODECaster-Pro-II-Multitrack-Capture.conf"
+			}
+		}
+	}
+}
+If.usb1_multitrack_playback {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB19f7:0078"
+	}
+	True {
+		# Multitrack is only for Input enabled
+		SectionUseCase."HiFi" {
+			Comment "RODECaster Pro II"
+			Config {
+				Include.playback.File "/USB-Audio/RODE/RODECaster-Pro-II-Multitrack-Playback.conf"
+				SectionDevice."Mic" {
+					Comment "Microphone"
+					Value {
+						CapturePCM "hw:${CardId},0"
+						CapturePriority 100
+					}
+				}
+				SectionDevice."Line:main" {
+					Comment "Main"
+					Value {
+						CapturePCM "hw:${CardId},1"
+						CapturePriority 110
+					}
+				}
+			}
+		}
+	}
+}
+If.usb1_multitrack_capture {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB19f7:0030"
+	}
+	True {
+		# Multitrack is only for Output enabled
+		SectionUseCase."HiFi" {
+			Comment "RODECaster Pro II"
+			Config {
+				Include.capture.File "/USB-Audio/RODE/RODECaster-Pro-II-Multitrack-Capture.conf"
+				SectionDevice."Speaker" {
+					Comment "System"
+					Value {
+						PlaybackPCM "hw:${CardId},1"
+						PlaybackPriority 100
+					}
+				}
+				SectionDevice."Line:chat" {
+					Comment "Chat"
+					Value {
+						PlaybackPCM "hw:${CardId},0"
+						PlaybackPriority 110
+					}
+				}
+			}
+		}
+	}
+}
+
+If.usb2 {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB19f7:0026"
+	}
+	True {
+		SectionUseCase."HiFi" {
+			Comment "RODECaster Pro II"
+			Config {
+				SectionDevice."Speaker" {
+					Comment "Secondary"
+
+					Value {
+						PlaybackPCM "hw:${CardId},0"
+					}
+				}
+				SectionDevice."Mic" {
+					Comment "Secondary"
+
+					Value {
+						CapturePCM "hw:${CardId},0"
+					}
+				}
+			}
+		}
+	}
+}

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -148,6 +148,13 @@ Macro.sony-dualsense-ps5.RegexMatch	"Id='054c:0((ce6)|(df2))' Profile='Sony/Dual
 # and generations from the same series
 Macro.boss-katana.StringMatch		"Id='0582:01d8' Profile='BOSS/Katana'"
 
+Macro.rode-rodecaster-pro-2.RegexMatch {
+	# RODECaster Pro II USB1: 19f7:0037, 19f7:0072, 19f7:0078, 19f7:0030
+	# RODECaster Pro II USB2: 19f7:0026
+	Id "19f7:00(37|72|78|30|26)"
+	Profile "RODE/RODECaster-Pro-II"
+}
+
 Macro.roland-quadcapture.StringMatch	"Id='0582:012f' Profile='Roland/Quad-Capture'"
 Macro.roland-bridgecast.StringMatch	"Id='0582:02b7' Profile='Roland/BridgeCast'"
 


### PR DESCRIPTION
This PR adds support for the RODECaster Pro II Split PCM configuration.

The Rodecaster reports as two audio devices, device 0 is always the mic/chat track and device 1 can be configure by the user to either be a multitrack device or a simple stereo input/output device.
Using the USB PID its possible to detect the current channel configuration (similar to the GoXLR).