### PR TITLE
ucm2: codecs: rt722: add condition to SetLED for mic

### DIFF
--- a/ucm2/codecs/rt722/init.conf
+++ b/ucm2/codecs/rt722/init.conf
@@ -10,4 +10,12 @@ BootSequence [
 	cset "name='rt722 FU0F Capture Volume' 63"
 ]
 
-Macro [{ SetLED { LED="mic" Action="attach" CtlId="rt722 FU1E Capture Switch" } }]
+If.mic_init_rt722 {
+	Condition {
+		Type String
+		Needle "rt722"
+		Haystack "${var:MicCodec1}"
+	}
+	True.Macro [{ SetLED { LED="mic" Action="attach" CtlId="rt722 FU1E Capture Switch" } }]
+}
+


### PR DESCRIPTION
Some SKUs don't have the internal mic, so the patch adds the condition to check whether the SKU has the internal mic or not.