### PR TITLE
sof-soundwire: third fix for multi-codec

### DIFF
--- a/ucm2/sof-soundwire/sof-soundwire.conf
+++ b/ucm2/sof-soundwire/sof-soundwire.conf
@@ -72,8 +72,8 @@ If.multi_init {
 If.multi_speaker {
 	Condition {
 		Type RegexMatch
-		Regex "(${var:MultiCodec1}(-sdca)?)"
-		String "${var:SpeakerCodec1}"
+		Regex "=(${var:MultiCodec1}(-sdca)?)=" # guard with "=" to avoid empty string matching
+		String "=${var:SpeakerCodec1}="
 	}
 	True {
 		Define.SpeakerCodec1 ""
@@ -83,8 +83,8 @@ If.multi_speaker {
 If.multi_mic {
 	Condition {
 		Type RegexMatch
-		Regex "(${var:MultiCodec1}(-sdca)?)"
-		String "${var:MicCodec1}"
+		Regex "=(${var:MultiCodec1}(-sdca)?)=" # guard with "=" to avoid empty string matching
+		String "=${var:MicCodec1}="
 	}
 	True {
 		Define.MicCodec1 ""
@@ -94,8 +94,8 @@ If.multi_mic {
 If.multi_headset {
 	Condition {
 		Type RegexMatch
-		Regex "(${var:MultiCodec1}(-sdca)?)"
-		String "${var:HeadsetCodec1}"
+		Regex "=(${var:MultiCodec1}(-sdca)?)=" # guard with "=" to avoid empty string matching
+		String "=${var:HeadsetCodec1}="
 	}
 	True {
 		Define.HeadsetCodec1 ""


### PR DESCRIPTION
Ensure MultiCodec-based actions are only done when MultiCodec1 is not empty, otherwise Speaker/Mic/HeadsetCodec1 vars can be cleared without reason and prevent other devices from being recognized.