### PR TITLE
ucm2: USB-Audio: Add Antelope Audio Zen Go support

### DIFF
--- a/ucm2/USB-Audio/AntelopeAudio/ZenGo-HiFi.conf
+++ b/ucm2/USB-Audio/AntelopeAudio/ZenGo-HiFi.conf
@@ -1,0 +1,195 @@
+Include.pcm_split.File "/common/pcm/split.conf"
+
+Macro [
+	{
+		SplitPCM {
+			Name "zengo_stereo_out"
+			Direction Playback
+			Channels 2
+			HWChannels 16
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 FL
+			HWChannelPos3 FR
+			HWChannelPos4 FL
+			HWChannelPos5 FR
+			HWChannelPos6 FL
+			HWChannelPos7 FR
+			HWChannelPos8 FL
+			HWChannelPos9 FR
+			HWChannelPos10 FL
+			HWChannelPos11 FR
+			HWChannelPos12 FL
+			HWChannelPos13 FR
+			HWChannelPos14 FL
+			HWChannelPos15 FR
+		}
+	}
+	{
+		SplitPCM {
+			Name "zengo_stereo_in"
+			Direction Capture
+			Channels 2
+			HWChannels 16
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 FL
+			HWChannelPos3 FR
+			HWChannelPos4 FL
+			HWChannelPos5 FR
+			HWChannelPos6 FL
+			HWChannelPos7 FR
+			HWChannelPos8 FL
+			HWChannelPos9 FR
+			HWChannelPos10 FL
+			HWChannelPos11 FR
+			HWChannelPos12 FL
+			HWChannelPos13 FR
+			HWChannelPos14 FL
+			HWChannelPos15 FR
+		}
+	}
+]
+
+SectionDevice."Line1" {
+	Comment "Playback 1-2"
+	Value {
+		PlaybackPriority 200
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "zengo_stereo_out"
+		Direction Playback
+		HWChannels 16
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line2" {
+	Comment "Playback 3-4"
+
+	Value {
+		PlaybackPriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "zengo_stereo_out"
+		Direction Playback
+		HWChannels 16
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line3" {
+	Comment "Playback 5-6"
+
+	Value {
+		PlaybackPriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "zengo_stereo_out"
+		Direction Playback
+		HWChannels 16
+		Channels 2
+		Channel0 4
+		Channel1 5
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line4" {
+	Comment "Playback 7-8"
+
+	Value {
+		PlaybackPriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "zengo_stereo_out"
+		Direction Playback
+		HWChannels 16
+		Channels 2
+		Channel0 6
+		Channel1 7
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line5" {
+	Comment "Recording 1-2"
+
+	Value {
+		CapturePriority 200
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "zengo_stereo_in"
+		Direction Capture
+		HWChannels 16
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line6" {
+	Comment "Recording 3-4"
+
+	Value {
+		CapturePriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "zengo_stereo_in"
+		Direction Capture
+		HWChannels 16
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line7" {
+	Comment "Recording 5-6"
+
+	Value {
+		CapturePriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "zengo_stereo_in"
+		Direction Capture
+		HWChannels 16
+		Channels 2
+		Channel0 4
+		Channel1 5
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line8" {
+	Comment "Recording 7-8"
+
+	Value {
+		CapturePriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "zengo_stereo_in"
+		Direction Capture
+		HWChannels 16
+		Channels 2
+		Channel0 6
+		Channel1 7
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}

--- a/ucm2/USB-Audio/AntelopeAudio/ZenGo.conf
+++ b/ucm2/USB-Audio/AntelopeAudio/ZenGo.conf
@@ -1,0 +1,13 @@
+Syntax 3
+
+Comment "Antelope Audio Zen Go"
+
+SectionUseCase."HiFi" {
+	Comment "Analog Stereo Outputs + Inputs"
+	File "/USB-Audio/AntelopeAudio/ZenGo-HiFi.conf"
+}
+
+Define.DirectPlaybackChannels 8
+Define.DirectCaptureChannels 8
+
+Include.dhw.File "/common/directm.conf"

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -628,6 +628,15 @@ If.beacn-studio {
 	True.Define.ProfileName "Beacn/Beacn-Studio"
 }
 
+If.antelope-audio-zengosc {
+	Condition {
+		Type RegexMatch
+		String "${CardComponents}"
+		Regex "USB23e5:a015"
+	}
+	True.Define.ProfileName "AntelopeAudio/ZenGo"
+}
+
 #
 # end of device specific configuration block
 #

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -271,6 +271,15 @@ Macro.ssl2.RegexMatch			"Id='31e9:000[1289]' Profile='SolidStateLabs/SSL2'"
 Macro.beacn-mic.StringMatch		"Id='33ae:0001' Profile='Beacn/Beacn-Mic'"
 Macro.beacn-studio.RegexMatch		"Id='33ae:[04]003' Profile='Beacn/Beacn-Studio'"
 
+If.antelope-audio-zengosc {
+	Condition {
+		Type RegexMatch
+		String "${CardComponents}"
+		Regex "USB23e5:a015"
+	}
+	True.Define.ProfileName "AntelopeAudio/ZenGo"
+}
+
 #
 # end of device specific configuration block
 #


### PR DESCRIPTION
Add support for Antelope Audio Zen Go SC


[alsa-info.txt](https://github.com/user-attachments/files/24074814/alsa-info.txt)
