### PR TITLE
USB-Audio: Add Focusrite Vocaster interfaces

### DIFF
--- a/ucm2/USB-Audio/Focusrite/Vocaster-One-HiFi.conf
+++ b/ucm2/USB-Audio/Focusrite/Vocaster-One-HiFi.conf
@@ -1,0 +1,192 @@
+Include.pcm_split.File "/common/pcm/split.conf"
+
+Macro [
+	{
+		SplitPCM {
+			Name "vocaster_one_stereo_out"
+			Direction Playback
+			Channels 2
+			HWChannels 4
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 FL
+			HWChannelPos3 FR
+		}
+	}
+	{
+		SplitPCM {
+			Name "vocaster_one_mono_in"
+			Direction Capture
+			Channels 1
+			HWChannels 10
+			HWChannelPos0 MONO
+			HWChannelPos1 MONO
+			HWChannelPos2 MONO
+			HWChannelPos3 MONO
+			HWChannelPos4 MONO
+			HWChannelPos5 MONO
+			HWChannelPos6 MONO
+			HWChannelPos7 MONO
+			HWChannelPos8 MONO
+			HWChannelPos9 MONO
+		}
+	}
+	{
+		SplitPCM {
+			Name "vocaster_one_stereo_in"
+			Direction Capture
+			Channels 2
+			HWChannels 10
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 FL
+			HWChannelPos3 FR
+			HWChannelPos4 FL
+			HWChannelPos5 FR
+			HWChannelPos6 FL
+			HWChannelPos7 FR
+			HWChannelPos8 FL
+			HWChannelPos9 FR
+		}
+	}
+]
+
+SectionDevice."USB 1" {
+	Comment "Video Call"
+
+	Value {
+		PlaybackPriority 200
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "vocaster_one_stereo_out"
+		Direction Playback
+		HWChannels 4
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."USB 2" {
+	Comment "Playback"
+
+	Value {
+		PlaybackPriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "vocaster_one_stereo_out"
+		Direction Playback
+		HWChannels 4
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."USB 3" {
+	Comment "Video Call"
+
+	Value {
+		CapturePriority 200
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "vocaster_one_stereo_in"
+		Direction Capture
+		HWChannels 10
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."USB 4" {
+	Comment "Show Mix"
+
+	Value {
+		CapturePriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "vocaster_one_stereo_in"
+		Direction Capture
+		HWChannels 10
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."USB 5" {
+	Comment "Host Mic"
+
+	Value {
+		CapturePriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "vocaster_one_mono_in"
+		Direction Capture
+		HWChannels 10
+		Channels 1
+		Channel0 4
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."USB 6" {
+	Comment "Aux"
+
+	Value {
+		CapturePriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "vocaster_one_mono_in"
+		Direction Capture
+		HWChannels 10
+		Channels 1
+		Channel0 5
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."USB 7" {
+	Comment "Loopback 1"
+
+	Value {
+		CapturePriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "vocaster_one_stereo_in"
+		Direction Capture
+		HWChannels 10
+		Channels 2
+		Channel0 6
+		Channel1 7
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."USB 8" {
+	Comment "Loopback 2"
+
+	Value {
+		CapturePriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "vocaster_one_stereo_in"
+		Direction Capture
+		HWChannels 10
+		Channels 2
+		Channel0 8
+		Channel1 9
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}

--- a/ucm2/USB-Audio/Focusrite/Vocaster-One.conf
+++ b/ucm2/USB-Audio/Focusrite/Vocaster-One.conf
@@ -1,0 +1,13 @@
+Define {
+	DirectPlaybackChannels 4
+	DirectCaptureChannels 10
+}
+
+Comment "Focusrite Vocaster One"
+
+SectionUseCase."HiFi" {
+	Comment "Default"
+	File "/USB-Audio/Focusrite/Vocaster-One-HiFi.conf"
+}
+
+Include.dhw.File "/common/direct.conf"

--- a/ucm2/USB-Audio/Focusrite/Vocaster-Two-HiFi.conf
+++ b/ucm2/USB-Audio/Focusrite/Vocaster-Two-HiFi.conf
@@ -1,0 +1,254 @@
+Include.pcm_split.File "/common/pcm/split.conf"
+
+Macro [
+	{
+		SplitPCM {
+			Name "vocaster_two_stereo_out"
+			Direction Playback
+			Channels 2
+			HWChannels 4
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 FL
+			HWChannelPos3 FR
+		}
+	}
+	{
+		SplitPCM {
+			Name "vocaster_two_mono_in"
+			Direction Capture
+			Channels 1
+			HWChannels 14
+			HWChannelPos0 MONO
+			HWChannelPos1 MONO
+			HWChannelPos2 MONO
+			HWChannelPos3 MONO
+			HWChannelPos4 MONO
+			HWChannelPos5 MONO
+			HWChannelPos6 MONO
+			HWChannelPos7 MONO
+			HWChannelPos8 MONO
+			HWChannelPos9 MONO
+			HWChannelPos10 MONO
+			HWChannelPos11 MONO
+			HWChannelPos12 MONO
+			HWChannelPos13 MONO
+		}
+	}
+	{
+		SplitPCM {
+			Name "vocaster_two_stereo_in"
+			Direction Capture
+			Channels 2
+			HWChannels 14
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 FL
+			HWChannelPos3 FR
+			HWChannelPos4 FL
+			HWChannelPos5 FR
+			HWChannelPos6 FL
+			HWChannelPos7 FR
+			HWChannelPos8 FL
+			HWChannelPos9 FR
+			HWChannelPos10 FL
+			HWChannelPos11 FR
+			HWChannelPos12 FL
+			HWChannelPos13 FR
+		}
+	}
+]
+
+SectionDevice."USB 1" {
+	Comment "Video Call"
+
+	Value {
+		PlaybackPriority 200
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "vocaster_two_stereo_out"
+		Direction Playback
+		HWChannels 4
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."USB 2" {
+	Comment "Playback"
+
+	Value {
+		PlaybackPriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "vocaster_two_stereo_out"
+		Direction Playback
+		HWChannels 4
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."USB 3" {
+	Comment "Video Call"
+
+	Value {
+		CapturePriority 200
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "vocaster_two_stereo_in"
+		Direction Capture
+		HWChannels 14
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."USB 4" {
+	Comment "Show Mix"
+
+	Value {
+		CapturePriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "vocaster_two_stereo_in"
+		Direction Capture
+		HWChannels 14
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."USB 5" {
+	Comment "Host Mic"
+
+	Value {
+		CapturePriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "vocaster_two_mono_in"
+		Direction Capture
+		HWChannels 14
+		Channels 1
+		Channel0 4
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."USB 6" {
+	Comment "Guest Mic"
+
+	Value {
+		CapturePriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "vocaster_two_mono_in"
+		Direction Capture
+		HWChannels 14
+		Channels 1
+		Channel0 5
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."USB 7" {
+	Comment "Mic In 1-2"
+
+	Value {
+		CapturePriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "vocaster_two_stereo_in"
+		Direction Capture
+		HWChannels 14
+		Channels 2
+		Channel0 4
+		Channel1 5
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."USB 8" {
+	Comment "Aux"
+
+	Value {
+		CapturePriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "vocaster_two_stereo_in"
+		Direction Capture
+		HWChannels 14
+		Channels 2
+		Channel0 6
+		Channel1 7
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."USB 9" {
+	Comment "Bluetooth"
+
+	Value {
+		CapturePriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "vocaster_two_stereo_in"
+		Direction Capture
+		HWChannels 14
+		Channels 2
+		Channel0 8
+		Channel1 9
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."USB 10" {
+	Comment "Loopback 1"
+
+	Value {
+		CapturePriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "vocaster_two_stereo_in"
+		Direction Capture
+		HWChannels 14
+		Channels 2
+		Channel0 10
+		Channel1 11
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."USB 11" {
+	Comment "Loopback 2"
+
+	Value {
+		CapturePriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "vocaster_two_stereo_in"
+		Direction Capture
+		HWChannels 14
+		Channels 2
+		Channel0 12
+		Channel1 13
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}

--- a/ucm2/USB-Audio/Focusrite/Vocaster-Two.conf
+++ b/ucm2/USB-Audio/Focusrite/Vocaster-Two.conf
@@ -1,0 +1,13 @@
+Define {
+	DirectPlaybackChannels 4
+	DirectCaptureChannels 14
+}
+
+Comment "Focusrite Vocaster Two"
+
+SectionUseCase."HiFi" {
+	Comment "Default"
+	File "/USB-Audio/Focusrite/Vocaster-Two-HiFi.conf"
+}
+
+Include.dhw.File "/common/direct.conf"

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -396,6 +396,28 @@ If.focusrite-scarlett-18i20 {
 	True.Define.ProfileName "Focusrite/Scarlett-18i20"
 }
 
+If.focusrite-vocaster-one {
+	Condition {
+		Type RegexMatch
+		String "${CardComponents}"
+		Regex "USB1235:8216"
+	}
+	True.Define {
+		ProfileName "Focusrite/Vocaster-One"
+	}
+}
+
+If.focusrite-vocaster-two {
+	Condition {
+		Type RegexMatch
+		String "${CardComponents}"
+		Regex "USB1235:8217"
+	}
+	True.Define {
+		ProfileName "Focusrite/Vocaster-Two"
+	}
+}
+
 If.behringer-umc202hd {
 	Condition {
 		Type String


### PR DESCRIPTION
Add split configs for the Focusrite Vocaster One and Two interfaces.