### PR TITLE
ucm2: Qualcomm: Add Lenovo Yoga Air 14s support

### DIFF
--- a/ucm2/Qualcomm/x1e80100/x1e80100.conf
+++ b/ucm2/Qualcomm/x1e80100/x1e80100.conf
@@ -15,7 +15,7 @@ If.LENOVOSlim7x {
 	Condition {
 		Type RegexMatch
 		String "${var:DMI_info}"
-		Regex "LENOVO.*Yoga Slim 7.*"
+		Regex "LENOVO.*(Yoga Slim 7|YOGA Air 14s).*"
 	}
 	True.Include.7x.File "/Qualcomm/x1e80100/LENOVO-Slim-7x.conf"
 }


### PR DESCRIPTION
Lenovo Yoga Air 14s laptop is basically a Slim 7 for China, and they share the same audio configuration.