### PR TITLE
ucm2: Qualcomm: add Asus vivobook 16 support

### DIFF
--- a/ucm2/Qualcomm/x1e80100/x1e80100.conf
+++ b/ucm2/Qualcomm/x1e80100/x1e80100.conf
@@ -6,7 +6,7 @@ If.LENOVOT14s {
 	Condition {
 		Type RegexMatch
 		String "${var:DMI_info}"
-		Regex "LENOVO.*(Think(Pad T14s Gen 6.*|Book 16 G7 QOY)|Ideapad.*5.*)|(HP.*Omnibook X.*)|ASUSTeK COMPUTER.*ASUS (Zenbook A14|Vivobook S 15)|(Microsoft Corporation.*Surface.*Microsoft Surface Laptop, 7th Edition)"
+		Regex "LENOVO.*(Think(Pad T14s Gen 6.*|Book 16 G7 QOY)|Ideapad.*5.*)|(HP.*Omnibook X.*)|ASUSTeK COMPUTER.*ASUS (Zenbook A14|Vivobook S 15|Vivobook 16)|(Microsoft Corporation.*Surface.*Microsoft Surface Laptop, 7th Edition)"
 	}
 	True.Include.t14s.File "/Qualcomm/x1e80100/LENOVO-T14s.conf"
 }


### PR DESCRIPTION
Add support for Asus Vivobook 16 (F1607QA) with Snapdragon X1 SoC. This device topology is nearly identical to Lenovo Thinkpad T14s or Asus Vivobook S15.