### PR TITLE
Add support for the Behringer ULM200D wireless microphones.

### DIFF
--- a/ucm2/USB-Audio/Behringer/ULM200D-HiFi.conf
+++ b/ucm2/USB-Audio/Behringer/ULM200D-HiFi.conf
@@ -1,0 +1,27 @@
+Include.pcm_split.File "/common/pcm/split.conf"
+
+SectionDevice."Mic1" {
+	Comment "Mic 1"
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ulm200d_mono_in"
+		Direction Capture
+		HWChannels 2
+		Channels 1
+		Channel0 0
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Mic2" {
+	Comment "Mic 2"
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "ulm200d_mono_in"
+		Direction Capture
+		HWChannels 2
+		Channels 1
+		Channel0 1
+		ChannelPos0 MONO
+	}
+}

--- a/ucm2/USB-Audio/Behringer/ULM200D.conf
+++ b/ucm2/USB-Audio/Behringer/ULM200D.conf
@@ -1,0 +1,8 @@
+Comment "Behringer ULM200D"
+
+SectionUseCase."HiFi" {
+	Comment "Default"
+	File "/USB-Audio/Behringer/ULM200D-HiFi.conf"
+}
+
+Macro.0.DirectUseCase { Id="Direct" PlaybackChannels=0 CaptureChannels=2 }

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -397,6 +397,18 @@ If.focusrite-scarlett-18i20 {
 	True.Define.ProfileName "Focusrite/Scarlett-18i20"
 }
 
+If.behringer-ulm200d {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB1397:00f1"
+	}
+	True.Define {
+		ProfileName "Behringer/ULM200D"
+		MixerRemap yes
+	}
+}
+
 If.behringer-umc202hd {
 	Condition {
 		Type String


### PR DESCRIPTION
This is a USB receiver for two wireless microphones. Each microphone appears on a different channel. By default these would be detected as left and right.

Just a disclaimer, I don't know what I am doing here. I used the UMC202HD as a reference and changed the values where it seemed reasonable. This device also has no output so I deleted everything that seemed output related. Seems to work.