### PR TITLE
ucm2: da7213: Add ADC switch in HeadphoneMic2 sequences

### DIFF
--- a/ucm2/codecs/da7213/HeadphoneMic2DisableSeq.conf
+++ b/ucm2/codecs/da7213/HeadphoneMic2DisableSeq.conf
@@ -3,6 +3,7 @@ DisableSequence [
 	cset "name='Mixin Left Mic 2 Switch' off"
 	cset "name='Mixin Right Mic 2 Switch' off"
 	cset "name='Mixin PGA Switch' off"
+	cset "name='ADC Switch' off"
 	cset "name='Headphone Switch' off"
 	cset "name='Mixout Left DAC Left Switch' off"
 	cset "name='Mixout Right DAC Right Switch' off"

--- a/ucm2/codecs/da7213/HeadphoneMic2EnableSeq.conf
+++ b/ucm2/codecs/da7213/HeadphoneMic2EnableSeq.conf
@@ -5,6 +5,7 @@ EnableSequence [
 	cset "name='Mixin Left Mic 2 Switch' on"
 	cset "name='Mixin Right Mic 2 Switch' on"
 	cset "name='Mixin PGA Switch' on"
+	cset "name='ADC Switch' on"
 	cset "name='DAI Left Source MUX' ADC Left"
 	cset "name='DAI Right Source MUX' ADC Right"
 	cset "name='Headphone Volume' 85"


### PR DESCRIPTION
Enable and disable the ADC switch in HeadphoneMic2EnableSeq.conf and HeadphoneMic2DisableSeq.conf to ensure headset microphone audio works properly on Talos EVK with DA7213 codec.

Without this change, the headset mic path remains muted and capture does not function.

Fixes: 5ccdd19 ("Qualcomm: qcs615: Add TALOS EVK HiFi config")