### PR TITLE
ucm2: Add config for Tascam US-2x2HR

### DIFF
--- a/ucm2/USB-Audio/TASCAM/US2x2HR-HiFi.conf
+++ b/ucm2/USB-Audio/TASCAM/US2x2HR-HiFi.conf
@@ -1,0 +1,54 @@
+Include.pcm_split.File "/common/pcm/split.conf"
+
+Macro [
+	{
+		SplitPCM {
+			Name "us2x2hr_mono_in"
+			Direction Capture
+			Channels 1
+			HWChannels 2
+			HWChannelPos0 MONO
+			HWChannelPos1 MONO
+		}
+	}
+]
+
+SectionDevice."Line1" {
+	Comment "Line Out / Phones"
+	Value {
+		PlaybackPriority 200
+		PlaybackPCM "hw:${CardId}"
+	}
+}
+
+SectionDevice."Mic1" {
+	Comment "IN1"
+
+	Value {
+		CapturePriority 200
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "us2x2hr_mono_in"
+		Direction Capture
+		HWChannels 2
+		Channels 1
+		Channel0 0
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Mic2" {
+	Comment "IN2"
+
+	Value {
+		CapturePriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "us2x2hr_mono_in"
+		Direction Capture
+		HWChannels 2
+		Channels 1
+		Channel0 1
+		ChannelPos0 MONO
+	}
+}

--- a/ucm2/USB-Audio/TASCAM/US2x2HR.conf
+++ b/ucm2/USB-Audio/TASCAM/US2x2HR.conf
@@ -1,0 +1,10 @@
+Comment "TASCAM US-2x2HR"
+
+SectionUseCase."HiFi" {
+	Comment "Default"
+	File "/USB-Audio/TASCAM/US2x2HR-HiFi.conf"
+}
+
+Include.dhw.File "/common/directm.conf"
+
+Macro.0.DirectUseCase { Id="Direct" PlaybackChannels=2 CaptureChannels=2 }

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -270,6 +270,15 @@ If.tascam-m12 {
 	True.Define.ProfileName "TASCAM/Model12"
 }
 
+If.tascam-us2x2hr {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB0644:8070"
+	}
+	True.Define.ProfileName "TASCAM/US2x2HR"
+}
+
 If.motu-m246 {
 	Condition {
 		Type RegexMatch


### PR DESCRIPTION
USB ID 0644:8070 TEAC Corp. US-2x2HR

Line1/Mic1/Mic2 comments mostly match the device labels:
2 mono inputs, labeled IN1 and IN2
1 stereo output, shared with physical Line OUT L/R jacks and a Phone jack

[alsa-info.txt](https://github.com/user-attachments/files/24826345/alsa-info.txt)
