### PR TITLE
USB-Audio: correct typo in Universal Audio Volt 2 config

### DIFF
--- a/ucm2/USB-Audio/UniversalAudio/Volt2.conf
+++ b/ucm2/USB-Audio/UniversalAudio/Volt2.conf
@@ -1,4 +1,4 @@
-omment "Universal Audio Volt 2"
+Comment "Universal Audio Volt 2"
 
 SectionUseCase."HiFi" {
 	Comment "Default"


### PR DESCRIPTION
Updating the package in nixpkgs (https://github.com/NixOS/nixpkgs/pull/483379), I noticed a typo in the Universal Audio Volt 2 configuration.