### PR TITLE
USB-Audio: Motu: M6-HiFi.conf - m6 has only 4 outputs, not 6

### DIFF
--- a/ucm2/USB-Audio/MOTU/M6-HiFi.conf
+++ b/ucm2/USB-Audio/MOTU/M6-HiFi.conf
@@ -69,7 +69,7 @@ SectionDevice."Line2" {
 	Macro.pcm_split.SplitPCMDevice {
 		Name "m6_stereo_out"
 		Direction Playback
-		HWChannels 6
+		HWChannels 4
 		Channels 2
 		Channel0 2
 		Channel1 3


### PR DESCRIPTION
hi, here is the fix for https://github.com/alsa-project/alsa-ucm-conf/issues/700

motu m6 has 6 input and 4 outputs. https://motu.com/products/m-series/m6 'The M6 is a 6-in/4-out USB-C audio interface...'

in config it is listed as 6 outputs and that throws ALSA UCM error.

adjusting configuration on working system makes error go away. 