### PR TITLE
USB-Audio: MOTU M6 - fix playback channels

### DIFF
--- a/ucm2/USB-Audio/MOTU/M6-HiFi.conf
+++ b/ucm2/USB-Audio/MOTU/M6-HiFi.conf
@@ -69,7 +69,7 @@ SectionDevice."Line2" {
 	Macro.pcm_split.SplitPCMDevice {
 		Name "m6_stereo_out"
 		Direction Playback
-		HWChannels 6
+		HWChannels 4
 		Channels 2
 		Channel0 2
 		Channel1 3


### PR DESCRIPTION
There is only one incorrect instance of playback HWChannels. Fix it.

Closes: #700