### PR TITLE
Qualcomm: qcs615: Remove JackControl from TALOS EVK HiFi config

### DIFF
--- a/ucm2/Qualcomm/qcs615/HiFi.conf
+++ b/ucm2/Qualcomm/qcs615/HiFi.conf
@@ -20,7 +20,6 @@ SectionDevice."Headphones" {
 		PlaybackPCM "hw:${CardId},0"
 		PlaybackMixer "default:${CardId}"
 		PlaybackMixerElem "HP Digital"
-		JackControl "Headphone Jack"
 	}
 }
 
@@ -33,7 +32,6 @@ SectionDevice."Headset" {
 	Value {
 		CapturePriority 100
 		CapturePCM "hw:${CardId},1"
-		JackControl "Mic Jack"
 		JackHWMute "Mic"
 	}
 }


### PR DESCRIPTION
The EVK board does not support headset or jack detection. Keeping JackControl entries prevents PipeWire (wpctl) from exposing sinks and sources correctly.

Remove JackControl from Headphones and Headset devices so PipeWire can enumerate playback and capture nodes normally.