### PR TITLE
ucm2: sof-soundwire: Add support for Cirrus Logic CS47L47

### DIFF
--- a/ucm2/codecs/cs47l47-dmic/init.conf
+++ b/ucm2/codecs/cs47l47-dmic/init.conf
@@ -1,0 +1,22 @@
+# cs47l47 specific control settings
+
+LibraryConfig.remap.Config {
+	ctl.default.map {
+		"name='cs47l47 Microphone Capture Switch'" {
+			"name='cs47l47 FU 113 Channel Switch'".vindex.0 0
+			"name='cs47l47 FU 113 Channel Switch'".vindex.1 1
+		}
+		"name='cs47l47 Microphone Capture Volume'" {
+			"name='cs47l47 FU 113 Channel Volume'".vindex.0 0
+			"name='cs47l47 FU 113 Channel Volume'".vindex.1 1
+		}
+	}
+}
+
+BootSequence [
+	cset "name='cs47l47 FU 113 Channel Switch' 0"
+]
+
+Macro [
+	{ SetLED { LED="mic" Action="attach" CtlId="cs47l47 FU 113 Channel Switch"} }
+]

--- a/ucm2/codecs/cs47l47/init.conf
+++ b/ucm2/codecs/cs47l47/init.conf
@@ -1,0 +1,24 @@
+# cs47l47 specific control settings
+
+LibraryConfig.remap.Config {
+	ctl.default.map {
+		"name='cs47l47 Jack Microphone Capture Switch'" {
+			"name='cs47l47 FU 36 Channel Switch'".vindex.0 0
+			"name='cs47l47 FU 36 Channel Switch'".vindex.1 1
+		}
+		"name='cs47l47 Jack Microphone Capture Volume'" {
+			"name='cs47l47 FU 36 Channel Volume'".vindex.0 0
+			"name='cs47l47 FU 36 Channel Volume'".vindex.1 1
+		}
+	}
+	ctl.default.map {
+		"name='cs47l47 Headphone Playback Switch'" {
+			"name='cs47l47 FU 41 Channel Switch'".vindex.0 0
+			"name='cs47l47 FU 41 Channel Switch'".vindex.1 1
+		}
+		"name='cs47l47 Headphone Playback Volume'" {
+			"name='cs47l47 FU 41 Channel Volume'".vindex.0 0
+			"name='cs47l47 FU 41 Channel Volume'".vindex.1 1
+		}
+	}
+}

--- a/ucm2/sof-soundwire/cs47l47-dmic.conf
+++ b/ucm2/sof-soundwire/cs47l47-dmic.conf
@@ -1,0 +1,16 @@
+# Use case Configuration for sof-soundwire card
+
+SectionDevice."Mic" {
+	Comment "Microphones"
+
+	ConflictingDevice [
+		"Headset"
+	]
+
+	Value {
+		CapturePriority 100
+		CapturePCM "hw:${CardId},4"
+		CaptureMixer "default:${CardId}"
+		CaptureMixerElem "cs47l47 Microphone"
+	}
+}

--- a/ucm2/sof-soundwire/cs47l47.conf
+++ b/ucm2/sof-soundwire/cs47l47.conf
@@ -1,0 +1,25 @@
+# Use case Configuration for sof-soundwire card
+
+SectionDevice."Headphones" {
+	Comment "Headphones"
+
+	Value {
+		PlaybackPriority 200
+		PlaybackPCM "hw:${CardId},0"
+		PlaybackMixer "default:${CardId}"
+		PlaybackMixerElem "cs47l47 Headphone"
+		JackControl "cs47l47 OT 43 Headphone Jack"
+	}
+}
+
+SectionDevice."Headset" {
+	Comment "Jack Microphone"
+
+	Value {
+		CapturePriority 200
+		CapturePCM "hw:${CardId},1"
+		CaptureMixer "default:${CardId}"
+		CaptureMixerElem "cs47l47 Jack Microphone"
+		JackControl "cs47l47 IT 31 Microphone Jack"
+	}
+}

--- a/ucm2/sof-soundwire/sof-soundwire.conf
+++ b/ucm2/sof-soundwire/sof-soundwire.conf
@@ -117,7 +117,7 @@ If.spk_init {
 If.hs_init {
 	Condition {
 		Type RegexMatch
-		Regex "(cs42l43|cs42l45|rt5682|rt700|rt711|rt713(-sdca)?)"
+		Regex "(cs42l43|cs42l45|cs47l47|rt5682|rt700|rt711|rt713(-sdca)?)"
 		String "${var:HeadsetCodec1}"
 	}
 	True.Include.hs_init.File "/codecs/${var:HeadsetCodec1}/init.conf"
@@ -126,7 +126,7 @@ If.hs_init {
 If.mic_init {
 	Condition {
 		Type RegexMatch
-		Regex "(cs42l43-dmic|cs42l45-dmic|rt712-dmic|rt713-dmic|rt715(-sdca)?)"
+		Regex "(cs42l43-dmic|cs42l45-dmic|cs47l47-dmic|rt712-dmic|rt713-dmic|rt715(-sdca)?)"
 		String "${var:MicCodec1}"
 	}
 	True.Include.mic_init.File "/codecs/${var:MicCodec1}/init.conf"


### PR DESCRIPTION
Add the sof-soundwire and codec files for the CS47L47.

This is a SDCA codec with headphone/headset and digital mic. The configuration is based on the CS42L45 files.