### PR TITLE
ucm2: rt1320: Add Use case Configuration for rt1320 with DMIC

### DIFF
--- a/ucm2/sof-soundwire/rt1320-dmic.conf
+++ b/ucm2/sof-soundwire/rt1320-dmic.conf
@@ -1,0 +1,21 @@
+# Use case Configuration for RT1320 SoundWire DMIC (microphone function)
+
+SectionDevice."Mic" {
+	Comment	"SoundWire Microphone"
+
+	EnableSequence [
+		cset "name='rt1320-1 FU Capture Switch' on,on"
+	]
+
+	DisableSequence [
+		cset "name='rt1320-1 FU Capture Switch' off,off"
+	]
+
+	Value {
+		CapturePriority 100
+		CapturePCM "hw:${CardId},4"
+		CaptureSwitch "rt1320-1 FU Capture Switch"
+		CaptureVolume "rt1320-1 FU Capture Volume"
+		CaptureMixerElem "rt1320-1 FU"
+	}
+}


### PR DESCRIPTION
My surface pro 11 for business uses the rt1320 with a microphone. I have patches for the kernel to enable the configuration in: https://github.com/AndreGilerson/linux-surface