### PR TITLE
UCM2: Qualcomm: sc8280xp: add Huawei MateBook E Go support

### DIFF
--- a/ucm2/Qualcomm/sc8280xp/HUAWEI-MateBook-E-Go.conf
+++ b/ucm2/Qualcomm/sc8280xp/HUAWEI-MateBook-E-Go.conf
@@ -1,0 +1,21 @@
+Syntax 4
+
+SectionUseCase."HiFi" {
+	File "/Qualcomm/sc8280xp/HiFi.conf"
+	Comment "HiFi quality Music."
+}
+
+BootSequence [
+	cset "name='SpkrLeft PA Volume' 12"
+	cset "name='SpkrRight PA Volume' 12"
+	cset "name='HPHL Volume' 2"
+	cset "name='HPHR Volume' 2"
+	cset "name='ADC2 Volume' 10"
+]
+
+Include.card-init.File "/lib/card-init.conf"
+Include.ctl-remap.File "/lib/ctl-remap.conf"
+Include.wcd-init.File "/codecs/wcd938x/init.conf"
+Include.wsa-init.File "/codecs/wsa883x/init.conf"
+Include.wsam-init.File "/codecs/qcom-lpass/wsa-macro/init.conf"
+Include.rxm-init.File "/codecs/qcom-lpass/rx-macro/init.conf"

--- a/ucm2/Qualcomm/sc8280xp/sc8280xp.conf
+++ b/ucm2/Qualcomm/sc8280xp/sc8280xp.conf
@@ -7,5 +7,23 @@ If.LENOVOX13s {
 		Regex "LENOVO.*ThinkPad X13s.*"
 	}
 	True.Include.x13s.File "/Qualcomm/sc8280xp/LENOVO-X13s.conf"
-	False.Error "SC8280XP - ${sys:devices/virtual/dmi/id/board_vendor}-${sys:devices/virtual/dmi/id/product_family} model not supported"
+}
+
+If.HUAWEIMateBookEGo {
+	Condition {
+		Type RegexMatch
+		String "${sys:devices/virtual/dmi/id/board_vendor}-${sys:devices/virtual/dmi/id/product_family}"
+		Regex "HUAWEI.*MateBook E.*"
+	}
+	True.Include.huawei.File "/Qualcomm/sc8280xp/HUAWEI-MateBook-E-Go.conf"
+	False {
+		If.unsupported {
+			Condition {
+				Type RegexMatch
+				String "${sys:devices/virtual/dmi/id/board_vendor}"
+				Regex "LENOVO"
+			}
+			False.Error "SC8280XP - ${sys:devices/virtual/dmi/id/board_vendor}-${sys:devices/virtual/dmi/id/product_family} model not supported"
+		}
+	}
 }


### PR DESCRIPTION
## Summary

Add UCM configuration for the Huawei MateBook E Go (GK-W7X), an sc8280xp-based tablet with the same audio codec hardware as the Lenovo ThinkPad X13s (WCD938x + WSA8835 via SoundWire).

- Add `HUAWEI-MateBook-E-Go.conf` device configuration
- Update `sc8280xp.conf` to match HUAWEI DMI alongside existing LENOVO match
- Error message only emitted when no known vendor matches

## Hardware details

| Field | Value |
|-------|-------|
| Device | Huawei MateBook E Go (GK-W7X) |
| SoC | Snapdragon 8cx Gen 3 (sc8280xp) |
| Audio codec | WCD938x (headphones) + WSA8835 v2 (speakers) |
| Audio bus | SoundWire |
| `board_vendor` | `HUAWEI` |
| `product_family` | `MateBook E` |

## Test plan

- Tested on Huawei MateBook E Go with kernel 6.18.8 + Arch Linux
- Speaker playback, headphone playback, internal mic, headset mic all functional
- `wpctl status` shows correct device names (Speaker, Headphones, Internal microphones, Headset)