### PR TITLE
sof-hda-dsp: add workaround for speaker LED on MSI laptops

### DIFF
--- a/ucm2/Intel/sof-hda-dsp/sof-hda-dsp.conf
+++ b/ucm2/Intel/sof-hda-dsp/sof-hda-dsp.conf
@@ -46,13 +46,13 @@ SectionUseCase."HiFi" {
 
 Include.hda-init.File "/HDA/init.conf"
 
-If.DellMuteLed {
+If.PlatformMuteLed {
 	Condition {
-		Type String
-		Haystack "$${sys:class/leds/platform::mute/device}"
-		Needle "dell-laptop"
+		Type RegexMatch
+		Regex "(dell-laptop|msi-ec)"
+		String "$${sys:class/leds/platform::mute/device}"
 	}
-	True.Macro [{ SetLED { LED="speaker" Action="detach" CtlId="Master Playback Switch" } }]
+	True.Macro [{ SetLED { LED="speaker" Action="attach" CtlId="Master Playback Switch" } }]
 }
 
 If.dmic {


### PR DESCRIPTION
Make speaker LED work out of the box once LEDs are made discoverable via msi-ec module