### PR TITLE
sof-soundwire: rt1320: add playback control switch

### DIFF
--- a/ucm2/codecs/rt1320/init.conf
+++ b/ucm2/codecs/rt1320/init.conf
@@ -1,0 +1,67 @@
+# RT1320 amp specific switch control settings
+
+DefineMacro.rt1320spkled.If.0 {
+	Condition {
+		Type RegexMatch
+		Regex "${var:__ForAmps}"
+		String "${var:SpeakerAmps}"
+	}
+	True.Macro [
+		{ SetLED { LED="speaker" Action="attach" CtlId="rt1320-${var:__Amp} OT23 L Switch" } }
+		{ SetLED { LED="speaker" Action="attach" CtlId="rt1320-${var:__Amp} OT23 R Switch" } }
+	]
+}
+
+If.spk_init_rt1320 {
+	Condition {
+		Type String
+		Needle "rt1320"
+		Haystack "${var:MultiSpeakerShadow}"
+	}
+	True {
+		Macro.num1.rt1320spkled { ForAmps "[12]" Amp 1 }
+		Macro.num2.rt1320spkled { ForAmps "2" Amp 2 }
+	}
+}
+
+Define.SpeakerMixerElem "rt1320-1 OT23"
+
+If.oneAmp {
+	Condition {
+		Type RegexMatch
+		Regex "1"
+		String "${var:SpeakerAmps}"
+	}
+	True {
+		Define.SpeakerMixerElem "rt1320 OT23"
+		LibraryConfig.remap.Config {
+			ctl.default.map {
+				"name='rt1320 OT23 Playback Switch'" {
+					"name='rt1320-1 OT23 L Switch'".vindex.0 0
+					"name='rt1320-1 OT23 R Switch'".vindex.1 0
+				}
+			}
+		}
+	}
+}
+
+If.twoAmps {
+	Condition {
+		Type RegexMatch
+		Regex "2"
+		String "${var:SpeakerAmps}"
+	}
+	True {
+		Define.SpeakerMixerElem "rt1320 OT23"
+		LibraryConfig.remap.Config {
+			ctl.default.map {
+				"name='rt1320 OT23 Playback Switch'" {
+					"name='rt1320-1 OT23 L Switch'".vindex.0 0
+					"name='rt1320-1 OT23 R Switch'".vindex.0 0
+					"name='rt1320-2 OT23 L Switch'".vindex.1 0
+					"name='rt1320-2 OT23 R Switch'".vindex.1 0
+				}
+			}
+		}
+	}
+}

--- a/ucm2/codecs/rt1320/init.conf
+++ b/ucm2/codecs/rt1320/init.conf
@@ -65,3 +65,53 @@ If.twoAmps {
 		}
 	}
 }
+
+# RT1320 DMIC specific switch control settings
+
+Define.MicMixerElem "rt1320-1 FU"
+
+DefineMacro.rt1320micled.If.0 {
+	Condition {
+		Type RegexMatch
+		Regex "${var:__ForMics}"
+		String "${var:Mics}"
+	}
+	True.Macro [{ SetLED { LED="mic" Action="attach" CtlId="rt1320-${var:__Mic} FU Capture Switch" } }]
+}
+
+If.mic_init_rt1320 {
+	Condition {
+		Type String
+		Needle "rt1320"
+		Haystack "${var:MultiMicShadow}"
+	}
+	True {
+		Macro.num1.rt1320micled { ForMics "[12]" Mic 1 }
+		Macro.num2.rt1320micled { ForMics "2" Mic 2 }
+
+		If.twoMics {
+			Condition {
+				Type RegexMatch
+				Regex "2"
+				String "${var:Mics}"
+			}
+			True {
+				Define.MicMixerElem "rt1320 FU"
+				LibraryConfig.remap.Config {
+					ctl.default.map {
+						"name='rt1320 FU Capture Switch'" {
+							"name='rt1320-1 FU Capture Switch'".vindex.0 0
+							"name='rt1320-1 FU Capture Switch'".vindex.1 1
+							"name='rt1320-1 FU Capture Switch'".vindex.2 2
+							"name='rt1320-1 FU Capture Switch'".vindex.3 3
+							"name='rt1320-2 FU Capture Switch'".vindex.4 0
+							"name='rt1320-2 FU Capture Switch'".vindex.5 1
+							"name='rt1320-2 FU Capture Switch'".vindex.6 2
+							"name='rt1320-2 FU Capture Switch'".vindex.7 3
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/ucm2/sof-soundwire/rt1320.conf
+++ b/ucm2/sof-soundwire/rt1320.conf
@@ -41,7 +41,10 @@ SectionDevice."Speaker" {
 	]
 
 	Value {
-	      PlaybackPriority 100
-	      PlaybackPCM "hw:${CardId},2"
+		PlaybackPriority 100
+		PlaybackPCM "hw:${CardId},2"
+		PlaybackMixer "default:${CardId}"
+		PlaybackMixerElem "${var:SpeakerMixerElem}"
+		PlaybackSwitch "${var:SpeakerMixerElem} Playback Switch"
 	}
 }

--- a/ucm2/sof-soundwire/rt1320.conf
+++ b/ucm2/sof-soundwire/rt1320.conf
@@ -48,3 +48,44 @@ SectionDevice."Speaker" {
 		PlaybackSwitch "${var:SpeakerMixerElem} Playback Switch"
 	}
 }
+
+# Use case Configuration for RT1320 SoundWire DMIC (microphone function)
+
+DefineMacro.rt1320dmic.If.0 {
+	Condition {
+		Type RegexMatch
+		Regex "${var:__ForMics}"
+		String "${var:Mics}"
+	}
+	True {
+		EnableSequence [
+			cset "name='rt1320-${var:__Mic} FU Capture Switch' 1"
+		]
+		DisableSequence [
+			cset "name='rt1320-${var:__Mic} FU Capture Switch' 0"
+		]
+	}
+}
+
+If.codecmic {
+	Condition {
+		Type String
+		Needle "rt1320"
+		Haystack "${var:MultiMicShadow}"
+	}
+	True {
+		SectionDevice."Mic" {
+			Comment	"Microphones"
+
+			Macro.num1.rt1320dmic { ForMics "[12]" Mic 1 }
+			Macro.num2.rt1320dmic { ForMics "2" Mic 2 }
+
+			Value {
+				CapturePriority 100
+				CapturePCM "hw:${CardId},4"
+				CaptureMixerElem "${var:MicMixerElem}"
+				CaptureSwitch "${var:MicMixerElem} Capture Switch"
+			}
+		}
+	}
+}

--- a/ucm2/sof-soundwire/sof-soundwire.conf
+++ b/ucm2/sof-soundwire/sof-soundwire.conf
@@ -50,7 +50,7 @@ DefineRegex {
 		String "${CardComponents}"
 	}
 	MultiCodec {
-		Regex "(rt712|rt713|rt721|rt722)"
+		Regex "(rt712|rt713|rt721|rt722|rt1320)"
 		String "${var:SpeakerCodec1} ${var:HeadsetCodec1} ${var:MicCodec1}"
 	}
 }

--- a/ucm2/sof-soundwire/sof-soundwire.conf
+++ b/ucm2/sof-soundwire/sof-soundwire.conf
@@ -117,7 +117,7 @@ If.spk_init {
 If.hs_init {
 	Condition {
 		Type RegexMatch
-		Regex "(cs42l43|cs42l45|cs47l47|rt5682|rt700|rt711|rt713(-sdca)?)"
+		Regex "(cs42l43|cs42l45|cs47l47|rt5682|rt700|rt711|rt713(-sdca)?|rt722)"
 		String "${var:HeadsetCodec1}"
 	}
 	True.Include.hs_init.File "/codecs/${var:HeadsetCodec1}/init.conf"

--- a/ucm2/sof-soundwire/sof-soundwire.conf
+++ b/ucm2/sof-soundwire/sof-soundwire.conf
@@ -141,6 +141,18 @@ If.mic_init_rt715 {
 	True.Macro [{ SetLED { LED="mic" Action="detach" CtlId="PGA5.0 5 Master Capture Switch" } }]
 }
 
+If.mic_init_rt1320 {
+	Condition {
+		Type String
+		Needle "rt1320"
+		Haystack "${var:MicCodec1}"
+	}
+	True {
+		Define.MicCodec1 "rt1320-dmic"
+		Include.mic_init.File "/codecs/${var:MicCodec1}/init.conf"
+	}
+}
+
 If.pga_init_pga2 {
 	Condition {
 		Type ControlExists


### PR DESCRIPTION
This patch defines 'rt1320 OT23' as PlaybackMixerElem and a remapped one 'rt1320 OT23 Playback Switch' when using one or two amps.

And also attach rt1320 OT23 controls to speaker LED.