### PR TITLE
Roland BridgeCast X - add USB1 support, changed channel count from 16 to 14 and changed Labels to more closely match Rolands Software.

### DIFF
--- a/ucm2/USB-Audio/Roland/BridgeCastXV2-Hifi.conf
+++ b/ucm2/USB-Audio/Roland/BridgeCastXV2-Hifi.conf
@@ -6,7 +6,7 @@ Macro [
 			Name "bc_stereo_out"
 			Direction Playback
 			Channels 2
-			HWChannels 16
+			HWChannels 14
 			HWChannelPos0 FL
 			HWChannelPos1 FR
 			HWChannelPos2 FL
@@ -23,8 +23,6 @@ Macro [
 			HWChannelPos11 FR
 			HWChannelPos12 FL
 			HWChannelPos13 FR
-			HWChannelPos14 FL
-			HWChannelPos15 FR
 		}
 	}
 	{
@@ -44,7 +42,7 @@ Macro [
 ]
 
 SectionDevice."Line1" {
-	Comment "Chat L/R"
+	Comment "Chat"
 
 	Value {
 		PlaybackPriority 100
@@ -53,7 +51,7 @@ SectionDevice."Line1" {
 	Macro.pcm_split.SplitPCMDevice {
 		Name "bc_stereo_out"
 		Direction Playback
-		HWChannels 16
+		HWChannels 14
 		Channels 2
 		Channel0 0
 		Channel1 1
@@ -63,7 +61,7 @@ SectionDevice."Line1" {
 }
 
 SectionDevice."Line2" {
-	Comment "Game L/R"
+	Comment "Game"
 
 	Value {
 		PlaybackPriority 200
@@ -72,7 +70,7 @@ SectionDevice."Line2" {
 	Macro.pcm_split.SplitPCMDevice {
 		Name "bc_stereo_out"
 		Direction Playback
-		HWChannels 16
+		HWChannels 14
 		Channels 2
 		Channel0 2
 		Channel1 3
@@ -82,7 +80,7 @@ SectionDevice."Line2" {
 }
 
 SectionDevice."Line3" {
-	Comment "Music L/R"
+	Comment "Music"
 
 	Value {
 		PlaybackPriority 300
@@ -91,7 +89,7 @@ SectionDevice."Line3" {
 	Macro.pcm_split.SplitPCMDevice {
 		Name "bc_stereo_out"
 		Direction Playback
-		HWChannels 16
+		HWChannels 14
 		Channels 2
 		Channel0 12
 		Channel1 13
@@ -101,7 +99,7 @@ SectionDevice."Line3" {
 }
 
 SectionDevice."Line4" {
-	Comment "System L/R"
+	Comment "System"
 
 	Value {
 		PlaybackPriority 400
@@ -110,7 +108,7 @@ SectionDevice."Line4" {
 	Macro.pcm_split.SplitPCMDevice {
 		Name "bc_stereo_out"
 		Direction Playback
-		HWChannels 16
+		HWChannels 14
 		Channels 2
 		Channel0 10
 		Channel1 11
@@ -120,7 +118,7 @@ SectionDevice."Line4" {
 }
 
 SectionDevice."Line5" {
-	Comment "StreamMix"
+	Comment "Stream Mix"
 
 	Value {
 		CapturePriority 300
@@ -156,7 +154,7 @@ SectionDevice."Line6" {
 }
 
 SectionDevice."Line7" {
-	Comment "SFX"
+	Comment "Sub Mix"
 
 	Value {
 		CapturePriority 100

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -164,7 +164,13 @@ Macro.roland-bridgecast.StringMatch	"Id='0582:02b7' Profile='Roland/BridgeCast'"
 # 0582:030d Bridge Cast One
 Macro.roland-bridgecastv2.RegexMatch	"Id='0582:03((1e)|(0d))' Profile='Roland/BridgeCastV2'"
 
-Macro.roland-bridgecastx.StringMatch	"Id='0582:0321' Profile='Roland/BridgeCastXV2'"
+Macro.roland-bridgecastx.RegexMatch	{
+	# Roland BridgeCaster X V2 USB1: 0582:0320
+	# Roland BridgeCaster X V2 USB2: 0582:0321
+	Id "0582:03((20)|(21))"
+	Profile "Roland/BridgeCastXV2"
+}
+
 Macro.tascam-m12.StringMatch		"Id='0644:805f' Profile='TASCAM/Model12'"
 
 If.motu-m246 {

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -165,7 +165,13 @@ Macro.roland-bridgecast.StringMatch	"Id='0582:02b7' Profile='Roland/BridgeCast'"
 # 0582:030d Bridge Cast One
 Macro.roland-bridgecastv2.RegexMatch	"Id='0582:03((1e)|(0d))' Profile='Roland/BridgeCastV2'"
 
-Macro.roland-bridgecastx.StringMatch	"Id='0582:0321' Profile='Roland/BridgeCastXV2'"
+Macro.roland-bridgecastx.RegexMatch	{
+	# Roland BridgeCaster X V2 USB1: 0582:0320
+	# Roland BridgeCaster X V2 USB2: 0582:0321
+	Id "0582:03((20)|(21))"
+	Profile "Roland/BridgeCastXV2"
+}
+
 Macro.tascam-m12.StringMatch		"Id='0644:805f' Profile='TASCAM/Model12'"
 Macro.tascam-us2xhr.StringMatch		"Id='0644:8070' Profile='TASCAM/US2x2HR'"
 Macro.maudio-fast-track-ultra.StringMatch "Id='0763:2080' Profile='M-Audio/Fast-Track-Ultra' Remap='yes'"


### PR DESCRIPTION
Most importantly this PR adds support for the USB1 port on the device via Regex (i used the RODECaster Pro II entry as an formatting example).
It also changes the comments of the different Audio Devices to more closely match the Roland labels, i also changed the channel count from 16 to 14. My device only shows 14 channels i can't seem to enable 16 channels regardless of settings.
It could be related to virtual surround sound or USB ports but i did not get this working. Maybe a second config is needed to accommodate the apparently different channel counts?


System Specs:
```
Operating System: CachyOS Linux
KDE Plasma Version: 6.6.2
KDE Frameworks Version: 6.24.0
Qt Version: 6.10.2
Kernel Version: 6.19.7-1-cachyos (64-bit)
Graphics Platform: Wayland
Processors: 16 × AMD Ryzen 7 5700X3D 8-Core Processor
Memory: 64 GiB of RAM (62.7 GiB usable)
Graphics Processor: AMD Radeon RX 9070 XT
```

Roland BridgeCast X:
Firmware V3.0 - SEP 2025
Connected via USB-1

cat /proc/asound/card0/stream0 gave the Following Output:

```
Roland BRIDGE CAST X-I V2 at usb-0000:09:00.1-2, high speed : USB Audio

Playback:
  Status: Running
    Interface = 1
    Altset = 1
    Packet Size = 392
    Momentary freq = 48000 Hz (0x6.0000)
  Interface 1
    Altset 1
    Format: S32_LE
    Channels: 14
    Endpoint: 0x0d (13 OUT) (ASYNC)
    Rates: 48000
    Data packet interval: 125 us
    Bits: 24
    Channel map: FL FR FC LFE RL RR FLC FRC RC SL SR TC -- --
    Sync Endpoint: 0x8e (14 IN)
    Sync EP Interface: 2
    Sync EP Altset: 1
    Implicit Feedback Mode: Yes

Capture:
  Status: Stop
  Interface 2
    Altset 1
    Format: S32_LE
    Channels: 6
    Endpoint: 0x8e (14 IN) (ASYNC)
    Rates: 48000
    Data packet interval: 125 us
    Bits: 24
    Channel map: FL FR FC LFE RL RR
    Sync Endpoint: 0x0d (13 OUT)
    Sync EP Interface: 1
    Sync EP Altset: 1
    Implicit Feedback Mode: Yes
```