### PR TITLE
ucm2: Qualcomm: Create missing symlink for Radxa Dragon Q6A

### DIFF
--- a/ucm2/conf.d/qcs6490/RadxaComputerCo.Ltd.-RadxaDragonQ6A-1.0.conf
+++ b/ucm2/conf.d/qcs6490/RadxaComputerCo.Ltd.-RadxaDragonQ6A-1.0.conf
@@ -1,0 +1,1 @@
+QCS6490-Radxa-Dragon-Q6A.conf


### PR DESCRIPTION
The long card name set by the Linux kernel is based on the DMI information for the vendor name, product name and board revision. Create a symlink so that the configuration is correctly picked up by ALSA if DMI is enabled in the kernel.