### PR TITLE
ucm2: sof-soundwire: cs42l43: support UAJ-less configuration

### DIFF
--- a/ucm2/sof-soundwire/cs42l43-dmic.conf
+++ b/ucm2/sof-soundwire/cs42l43-dmic.conf
@@ -3,9 +3,18 @@
 SectionDevice."Mic" {
 	Comment "Microphones"
 
-	ConflictingDevice [
-		"Headset"
-	]
+	If.hs_present {
+		Condition {
+			Type RegexMatch
+			Regex "cs42l43"
+			String "${var:HeadsetCodec1}"
+		}
+		True {
+			ConflictingDevice [
+				"Headset"
+			]
+		}
+	}
 
 	DisableSequence [
 		cset "name='cs42l43 DP1TX1 Input' 'None'"

--- a/ucm2/sof-soundwire/cs42l43-spk.conf
+++ b/ucm2/sof-soundwire/cs42l43-spk.conf
@@ -3,9 +3,18 @@
 SectionDevice."Speaker" {
 	Comment "Speaker"
 
-	ConflictingDevice [
-		"Headphones"
-	]
+	If.hs_present {
+		Condition {
+			Type RegexMatch
+			Regex "cs42l43"
+			String "${var:HeadsetCodec1}"
+		}
+		True {
+			ConflictingDevice [
+				"Headphones"
+			]
+		}
+	}
 
 	EnableSequence [
 		cset "name='cs42l43 Speaker L Input 1' 'DP6RX1'"


### PR DESCRIPTION
In some cases cs42l43/cs42l43b devices can be set up without UAJ. In this case, guard the ConflictingDevices behind a check for a cs42l43's headset's presence so the UCM can still load even if the headset is missing.