### PR TITLE
ucm2: Focusrite Scarlett 18i20 Gen 1 — fix USB ID

### DIFF
--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -229,11 +229,11 @@ Macro.goxlr.RegexMatch			"Id='1220:8fe[04]' Profile='GoXLR/GoXLR'"
 # 8219 2i2 4th Gen
 Macro.focusrite-scarlett-2i.RegexMatch	"Id='1235:8(0(0[6a]|1c)|2(0[025]|1[0189]))' Profile='Focusrite/Scarlett-2i'"
 
-# 800C 1st Gen
+# 800c 1st Gen
 # 8201 2nd Gen
 # 8215 3rd Gen
 # 821d 4th Gen
-Macro.focusrite-scarlett-18i20.RegexMatch "Id='1235:8(00C|2(01|1(5|d)))' Profile='Focusrite/Scarlett-18i20'"
+Macro.focusrite-scarlett-18i20.RegexMatch "Id='1235:8(00c|2(01|1(5|d)))' Profile='Focusrite/Scarlett-18i20'"
 
 Macro.focusrite-vocaster-one.RegexMatch	"Id='1235:8216' Profile='Focusrite/Vocaster-One'"
 Macro.focusrite-vocaster-two.RegexMatch	"Id='1235:8217' Profile='Focusrite/Vocaster-Two'"


### PR DESCRIPTION
## Summary

The device matching regex for the Focusrite Scarlett 18i20 series in `USB-Audio.conf` uses an uppercase `C` in the Gen 1 product ID (`800C`), but kernel reports USB component IDs in lowercase (`800c`). The regex is case-sensitive, so the Gen 1 device never matches and the UCM profile fails to load entirely.

This is the remaining piece of the Gen 1 UCM breakage reported in #588 — the ADAT channel count issue was addressed by #731 (commit 17b48b1), but the device never reaches the profile at all due to this earlier match failure.

*Note, Claude-Code was heavily depended on for the troubleshooting, local bug fix, and testing.*

---

## Details

In `ucm2/USB-Audio/USB-Audio.conf`, the Scarlett 18i20 matching block uses:

```
Regex "USB1235:8(00C|2(01|1(5|d)))"
```

The kernel reports the Gen 1 component string as `USB1235:800c` (lowercase). Because the regex is case-sensitive and only matches `800C`, the `ProfileName` variable is never set and the loader hits the fallback error:

```
True.Error "UCM is not supported for this USB device (${CardLongName} @ ${CardComponents})"
```

This causes WirePlumber to report the device as `[ALSA UCM error]` and refuse to load any profile for it.

The other IDs in the same regex — `8201`, `8215`, `821d` — are already lowercase and match correctly. Only the Gen 1 `800C` is inconsistent.

---

## Fix

```diff
--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -1 +1 @@
-		Regex "USB1235:8(00C|2(01|1(5|d)))"
+		Regex "USB1235:8(00c|2(01|1(5|d)))"
```

Same single-character change applies to `ucm2/conf.d/USB-Audio/USB-Audio.conf`.

---

## Testing

Tested on Focusrite Scarlett 18i20 Gen 1 (`USB1235:800c`) with:
- Kernel: 6.19.10-zen1-1-zen (Arch Linux)
- PipeWire / WirePlumber
- `alsa-ucm-conf` 1.2.15.3

With both this fix and the ADAT channel count fix from #731 applied, the device loads without UCM errors and all output ports enumerate correctly.

Without this fix, the ADAT channel count fix in #731 has no effect for Gen 1 users — the profile match fails before the HiFi configuration is ever reached.

---

## Related

- Fixes #588 — Focusrite Scarlett 18i20 Gen 1: UCM configuration fails to load
- Related to #559 — ALSA UCM error for Scarlett 18i20 Gen 2 (ADAT channel count addressed by #731)
