### PR TITLE
sof-soundwire: rt711-sdca: fix silent headphones and headset mic

### DIFF
--- a/ucm2/sof-soundwire/rt711-sdca.conf
+++ b/ucm2/sof-soundwire/rt711-sdca.conf
@@ -23,10 +23,12 @@ SectionDevice."Headset" {
 	Comment "Headset Microphone"
 
 	EnableSequence [
+		cset "name='Headset Mic Switch' on"
 		cset "name='rt711 FU0F Capture Switch' 1"
 	]
 
 	DisableSequence [
+		cset "name='Headset Mic Switch' off"
 		cset "name='rt711 FU0F Capture Switch' 0"
 	]
 

--- a/ucm2/sof-soundwire/rt711-sdca.conf
+++ b/ucm2/sof-soundwire/rt711-sdca.conf
@@ -5,6 +5,7 @@ SectionDevice."Headphones" {
 
 	EnableSequence [
 		cset "name='Headphone Switch' on"
+		cset "name='PGA30.0 30 Playback Volume' 32,32"
 	]
 
 	DisableSequence [


### PR DESCRIPTION
Two related UCM fixes for rt711-sdca on sof-soundwire platforms.

**Fix 1: Headphones produce no audio**

PGA30.0 30 Playback Volume (the SOF pipeline 30 gain stage for PCM device 0)
defaults to 0 at boot, which the dBscale treats as a hardware mute. The DAPM
chain is active and audio flows on the SoundWire bus, but the pipeline passes
silence into the codec. Added to Headphones EnableSequence with value 32,32 (0 dB).

**Fix 2: Headset microphone produces no audio**

Headset Mic Switch is a DAPM gate controlling the codec mic input path. UCM never
enabled it, so the capture path was powered down regardless of the FU0F Capture
Switch state. Added on/off to Headset Enable/DisableSequence, matching the existing
pattern for Headphone Switch.

Both bugs affect any sof-soundwire platform using rt711-sdca.
Tested on Dell Precision 5480 (Intel Raptor Lake-P, sof-audio-pci-intel-tgl,
rt711-sdca on SoundWire master-0-2).