### PR TITLE
USB-Audio: Add RODECaster Duo

### DIFF
--- a/ucm2/USB-Audio/RODE/RODECaster-Duo-Multitrack-Capture-Dynamic.conf
+++ b/ucm2/USB-Audio/RODE/RODECaster-Duo-Multitrack-Capture-Dynamic.conf
@@ -1,0 +1,239 @@
+Include.pcm_split.File "/common/pcm/split.conf"
+
+Macro.playback.SplitPCM {
+	Name "rodecaster_duo_dynamic_stereo_in"
+	Direction Capture
+	Channels 2
+	HWChannels 20
+	Device 1
+
+	HWChannelPos0 FL	# Main Mix Left
+	HWChannelPos1 FR	# Main Mix Right
+
+	HWChannelPos2 FL	# Fader 1 Left
+	HWChannelPos3 FR	# Fader 1 Right
+
+	HWChannelPos4 FL	# Fader 2 Left
+	HWChannelPos5 FR	# Fader 2 Right
+
+	HWChannelPos6 FL	# Fader 3 Left
+	HWChannelPos7 FR	# Fader 3 Right
+
+	HWChannelPos8 FL	# Fader 4 Left
+	HWChannelPos9 FR	# Fader 4 Right
+
+	HWChannelPos10 FL	# Virtual Fader 1 Left
+	HWChannelPos11 FR	# Virtual Fader 1 Right
+
+	HWChannelPos12 FL	# Virtual Fader 2 Left
+	HWChannelPos13 FR	# Virtual Fader 2 Right
+
+	HWChannelPos14 FL	# Virtual Fader 3 Left
+	HWChannelPos15 FR	# Virtual Fader 3 Right
+
+	HWChannelPos16 FL	# Virtual Fader 4 Left
+	HWChannelPos17 FR	# Virtual Fader 4 Right
+
+	HWChannelPos18 FL	# Virtual Fader 5 Left
+	HWChannelPos19 FR	# Virtual Fader 5 Right
+}
+
+SectionDevice."Mic" {
+	Comment "Microphone"
+
+	Value {
+		CapturePriority 100
+		CapturePCM "hw:${CardId},0"
+	}
+}
+
+SectionDevice."Line:main" {
+	Comment "Main"
+
+	Value {
+		CapturePriority 110
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "rodecaster_duo_dynamic_stereo_in"
+		Direction Capture
+		Device 1
+		HWChannels 20
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+
+SectionDevice."Line:fader_1" {
+	Comment "Fader 1"
+
+	Value {
+		CapturePriority 120
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "rodecaster_duo_dynamic_stereo_in"
+		Direction Capture
+		Device 1
+		HWChannels 20
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line:fader_2" {
+	Comment "Fader 2"
+
+	Value {
+		CapturePriority 130
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "rodecaster_duo_dynamic_stereo_in"
+		Direction Capture
+		Device 1
+		HWChannels 20
+		Channels 2
+		Channel0 4
+		Channel1 5
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line:fader_3" {
+	Comment "Fader 3"
+
+	Value {
+		CapturePriority 140
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "rodecaster_duo_dynamic_stereo_in"
+		Direction Capture
+		Device 1
+		HWChannels 20
+		Channels 2
+		Channel0 6
+		Channel1 7
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line:fader_4" {
+	Comment "Fader 4"
+
+	Value {
+		CapturePriority 150
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "rodecaster_duo_dynamic_stereo_in"
+		Direction Capture
+		Device 1
+		HWChannels 20
+		Channels 2
+		Channel0 8
+		Channel1 9
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line:fader_virtual_1" {
+	Comment "Virtual Fader 1"
+
+	Value {
+		CapturePriority 160
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "rodecaster_duo_dynamic_stereo_in"
+		Direction Capture
+		Device 1
+		HWChannels 20
+		Channels 2
+		Channel0 10
+		Channel1 11
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line:fader_virtual_2" {
+	Comment "Virtual Fader 2"
+
+	Value {
+		CapturePriority 170
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "rodecaster_duo_dynamic_stereo_in"
+		Direction Capture
+		Device 1
+		HWChannels 20
+		Channels 2
+		Channel0 12
+		Channel1 13
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line:fader_virtual_3" {
+	Comment "Virtual Fader 3"
+
+	Value {
+		CapturePriority 180
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "rodecaster_duo_dynamic_stereo_in"
+		Direction Capture
+		Device 1
+		HWChannels 20
+		Channels 2
+		Channel0 14
+		Channel1 15
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line:fader_virtual_4" {
+	Comment "Virtual Fader 4"
+
+	Value {
+		CapturePriority 190
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "rodecaster_duo_dynamic_stereo_in"
+		Direction Capture
+		Device 1
+		HWChannels 20
+		Channels 2
+		Channel0 16
+		Channel1 17
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line:fader_virtual_5" {
+	Comment "Virtual Fader 5"
+
+	Value {
+		CapturePriority 200
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "rodecaster_duo_dynamic_stereo_in"
+		Direction Capture
+		Device 1
+		HWChannels 20
+		Channels 2
+		Channel0 18
+		Channel1 19
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}

--- a/ucm2/USB-Audio/RODE/RODECaster-Duo-Multitrack-Capture.conf
+++ b/ucm2/USB-Audio/RODE/RODECaster-Duo-Multitrack-Capture.conf
@@ -1,0 +1,224 @@
+Include.pcm_split.File "/common/pcm/split.conf"
+
+Macro.playback.SplitPCM {
+	Name "rodecaster_duo_stereo_in"
+	Direction Capture
+	Channels 2
+	HWChannels 16
+	Device 1
+
+	HWChannelPos0 FL	# Main Mix Left
+	HWChannelPos1 FR	# Main Mix Right
+
+	HWChannelPos2 MONO	# Combo 1
+	HWChannelPos3 MONO	# Combo 2
+	HWChannelPos4 MONO	# Combo 3
+	HWChannelPos5 MONO	# Combo 4
+
+	HWChannelPos6 FL	# Bluetooth Left
+	HWChannelPos7 FR	# Bluetooth Right
+
+	HWChannelPos8 FL	# Smart Pads Left
+	HWChannelPos9 FR	# Smart Pads Right
+
+	HWChannelPos10 FL	# System Left
+	HWChannelPos11 FR	# System Right
+
+	HWChannelPos12 FL	# Chat Left
+	HWChannelPos13 FR	# Chat Right
+
+	HWChannelPos14 FL	# USB2 Left
+	HWChannelPos15 FR	# USB2 Right
+}
+
+SectionDevice."Mic" {
+	Comment "Microphone"
+
+	Value {
+		CapturePriority 100
+		CapturePCM "hw:${CardId},0"
+	}
+}
+
+SectionDevice."Line:main" {
+	Comment "Main"
+
+	Value {
+		CapturePriority 110
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "rodecaster_duo_stereo_in"
+		Direction Capture
+		Device 1
+		HWChannels 16
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+
+SectionDevice."Line:combo_1" {
+	Comment "Combo 1"
+
+	Value {
+		CapturePriority 120
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "rodecaster_duo_stereo_in"
+		Direction Capture
+		Device 1
+		HWChannels 16
+		Channels 1
+		Channel0 2
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Line:combo_2" {
+	Comment "Combo 2"
+
+	Value {
+		CapturePriority 130
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "rodecaster_duo_stereo_in"
+		Direction Capture
+		Device 1
+		HWChannels 16
+		Channels 1
+		Channel0 3
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Line:combo_3" {
+	Comment "Combo 3"
+
+	Value {
+		CapturePriority 140
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "rodecaster_duo_stereo_in"
+		Direction Capture
+		Device 1
+		HWChannels 16
+		Channels 1
+		Channel0 4
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Line:combo_4" {
+	Comment "Combo 4"
+
+	Value {
+		CapturePriority 150
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "rodecaster_duo_stereo_in"
+		Direction Capture
+		Device 1
+		HWChannels 16
+		Channels 1
+		Channel0 5
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Line:bluetooth" {
+	Comment "Bluetooth"
+
+	Value {
+		CapturePriority 160
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "rodecaster_duo_stereo_in"
+		Direction Capture
+		Device 1
+		HWChannels 16
+		Channels 2
+		Channel0 6
+		Channel1 7
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line:usb2" {
+	Comment "USB 2"
+
+	Value {
+		CapturePriority 170
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "rodecaster_duo_stereo_in"
+		Direction Capture
+		Device 1
+		HWChannels 16
+		Channels 2
+		Channel0 14
+		Channel1 15
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line:smart_pads" {
+	Comment "SMART Pads"
+
+	Value {
+		CapturePriority 180
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "rodecaster_duo_stereo_in"
+		Direction Capture
+		Device 1
+		HWChannels 16
+		Channels 2
+		Channel0 8
+		Channel1 9
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line:system" {
+	Comment "System"
+
+	Value {
+		CapturePriority 190
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "rodecaster_duo_stereo_in"
+		Direction Capture
+		Device 1
+		HWChannels 16
+		Channels 2
+		Channel0 10
+		Channel1 11
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line:chat" {
+	Comment "Chat"
+
+	Value {
+		CapturePriority 200
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "rodecaster_duo_stereo_in"
+		Direction Capture
+		Device 1
+		HWChannels 16
+		Channels 2
+		Channel0 12
+		Channel1 13
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}

--- a/ucm2/USB-Audio/RODE/RODECaster-Duo-Multitrack-Playback.conf
+++ b/ucm2/USB-Audio/RODE/RODECaster-Duo-Multitrack-Playback.conf
@@ -1,0 +1,129 @@
+Include.pcm_split.File "/common/pcm/split.conf"
+
+Macro.playback.SplitPCM {
+	Name "rodecaster_duo_stereo_out"
+	Direction Playback
+	Channels 2
+	HWChannels 10
+	Device 1
+
+	HWChannelPos0 FL	# System Left
+	HwChannelPos1 FR	# System Right
+
+	HWChannelPos2 FL	# Game Left
+	HWChannelPos3 FR	# Game Right
+
+	HWChannelPos4 FL	# Music Left
+	HWChannelPos5 FR	# Music Right
+
+	HWChannelPos6 FL	# Virtual A Left
+	HWChannelPos7 FR	# Virtual A Right
+
+	HWChannelPos8 FL	# Virtual B Left
+	HWChannelPos9 FR	# Virtual B Right
+}
+
+SectionDevice."Speaker" {
+	Comment "System"
+
+	Value {
+		PlaybackPriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "rodecaster_duo_stereo_out"
+		Direction Playback
+		Device 1
+		HWChannels 10
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+
+SectionDevice."Line:chat" {
+	Comment "Chat"
+
+	Value {
+		PlaybackPCM "hw:${CardId},0"
+		PlaybackPriority 110
+	}
+}
+
+SectionDevice."Line:game" {
+	Comment "Game"
+
+	Value {
+		PlaybackPriority 120
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "rodecaster_duo_stereo_out"
+		Direction Playback
+		Device 1
+		HWChannels 10
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line:music" {
+	Comment "Music"
+
+	Value {
+		PlaybackPriority 130
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "rodecaster_duo_stereo_out"
+		Direction Playback
+		Device 1
+		HWChannels 10
+		Channels 2
+		Channel0 4
+		Channel1 5
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line:virtual_a" {
+	Comment "Virtual A"
+
+	Value {
+		PlaybackPriority 140
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "rodecaster_duo_stereo_out"
+		Direction Playback
+		Device 1
+		HWChannels 10
+		Channels 2
+		Channel0 6
+		Channel1 7
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line:virtual_b" {
+	Comment "Virtual B"
+
+	Value {
+		PlaybackPriority 150
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "rodecaster_duo_stereo_out"
+		Direction Playback
+		Device 1
+		HWChannels 10
+		Channels 2
+		Channel0 8
+		Channel1 9
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}

--- a/ucm2/USB-Audio/RODE/RODECaster-Duo.conf
+++ b/ucm2/USB-Audio/RODE/RODECaster-Duo.conf
@@ -1,0 +1,204 @@
+# The RODECaster Duo has two USB ports, each with its own PID.
+# USB1 has additionally the special capability to send multiple additional tracks (multitrack mode).
+# The multitrack functionality can be configured for output and input individually.
+# This sound card also provides two devices on USB1. Device 0 is always the Mic/Chat Track. Device 1 is the
+# optional multitrack device.
+
+Comment "RODECaster Duo USB"
+If.usb1 {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB19f7:0038"
+	}
+	True {
+		# Multitrack is disabled for Input and Output
+		SectionUseCase."HiFi" {
+			Comment "RODECaster Duo"
+			Config {
+				SectionDevice."Speaker" {
+					Comment "System"
+					Value {
+						PlaybackPCM "hw:${CardId},1"
+						PlaybackPriority 100
+					}
+				}
+				SectionDevice."Line:chat" {
+					Comment "Chat"
+					Value {
+						PlaybackPCM "hw:${CardId},0"
+						PlaybackPriority 110
+					}
+				}
+				SectionDevice."Mic" {
+					Comment "Microphone"
+					Value {
+						CapturePCM "hw:${CardId},0"
+						CapturePriority 100
+					}
+				}
+				SectionDevice."Line:main" {
+					Comment "Main"
+					Value {
+						CapturePCM "hw:${CardId},1"
+						CapturePriority 110
+					}
+				}
+			}
+		}
+	}
+}
+
+If.usb1_multitrack {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB19f7:0073"
+	}
+	True {
+		# Multitrack is enabled for Input and Output
+		SectionUseCase."HiFi" {
+			Comment "RODECaster Duo"
+			Config {
+				Include.playback.File "/USB-Audio/RODE/RODECaster-Duo-Multitrack-Playback.conf"
+				Include.capture.File "/USB-Audio/RODE/RODECaster-Duo-Multitrack-Capture.conf"
+			}
+		}
+	}
+}
+If.usb1_multitrack_dynamic {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB19f7:0095"
+	}
+	True {
+		# Multitrack is enabled for Input and Output with dynamic channel assignment (firmware 1.7.3)
+		SectionUseCase."HiFi" {
+			Comment "RODECaster Duo"
+			Config {
+				Include.playback.File "/USB-Audio/RODE/RODECaster-Duo-Multitrack-Playback.conf"
+				Include.capture.File "/USB-Audio/RODE/RODECaster-Duo-Multitrack-Capture-Dynamic.conf"
+			}
+		}
+	}
+}
+If.usb1_multitrack_playback {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB19f7:0079"
+	}
+	True {
+		# Multitrack is only for Input enabled
+		SectionUseCase."HiFi" {
+			Comment "RODECaster Duo"
+			Config {
+				Include.playback.File "/USB-Audio/RODE/RODECaster-Duo-Multitrack-Playback.conf"
+				SectionDevice."Mic" {
+					Comment "Microphone"
+					Value {
+						CapturePCM "hw:${CardId},0"
+						CapturePriority 100
+					}
+				}
+				SectionDevice."Line:main" {
+					Comment "Main"
+					Value {
+						CapturePCM "hw:${CardId},1"
+						CapturePriority 110
+					}
+				}
+			}
+		}
+	}
+}
+If.usb1_multitrack_capture {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB19f7:0031"
+	}
+	True {
+		# Multitrack is only for Output enabled
+		SectionUseCase."HiFi" {
+			Comment "RODECaster Duo"
+			Config {
+				Include.capture.File "/USB-Audio/RODE/RODECaster-Duo-Multitrack-Capture.conf"
+				SectionDevice."Speaker" {
+					Comment "System"
+					Value {
+						PlaybackPCM "hw:${CardId},1"
+						PlaybackPriority 100
+					}
+				}
+				SectionDevice."Line:chat" {
+					Comment "Chat"
+					Value {
+						PlaybackPCM "hw:${CardId},0"
+						PlaybackPriority 110
+					}
+				}
+			}
+		}
+	}
+}
+If.usb1_multitrack_capture_dynamic {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB19f7:0093"
+	}
+	True {
+		# Multitrack is only for Output enabled (firmware 1.7.3)
+		SectionUseCase."HiFi" {
+			Comment "RODECaster Duo"
+			Config {
+				Include.capture.File "/USB-Audio/RODE/RODECaster-Duo-Multitrack-Capture-Dynamic.conf"
+				SectionDevice."Speaker" {
+					Comment "System"
+					Value {
+						PlaybackPCM "hw:${CardId},1"
+						PlaybackPriority 100
+					}
+				}
+				SectionDevice."Line:chat" {
+					Comment "Chat"
+					Value {
+						PlaybackPCM "hw:${CardId},0"
+						PlaybackPriority 110
+					}
+				}
+			}
+		}
+	}
+}
+
+If.usb2 {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB19f7:0027"
+	}
+	True {
+		SectionUseCase."HiFi" {
+			Comment "RODECaster Duo"
+			Config {
+				SectionDevice."Speaker" {
+					Comment "Secondary"
+
+					Value {
+						PlaybackPCM "hw:${CardId},0"
+					}
+				}
+				SectionDevice."Mic" {
+					Comment "Secondary"
+
+					Value {
+						CapturePCM "hw:${CardId},0"
+					}
+				}
+			}
+		}
+	}
+}

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -150,6 +150,13 @@ Macro.sony-dualsense-ps5.RegexMatch	"Id='054c:0((ce6)|(df2))' Profile='Sony/Dual
 # and generations from the same series
 Macro.boss-katana.StringMatch		"Id='0582:01d8' Profile='BOSS/Katana'"
 
+Macro.rode-rodecaster-duo.RegexMatch {
+	# RODECaster Duo USB1: 19f7:0038, 19f7:0073, 19f7:0079, 19f7:0031, 19f7:0093, 19f7:0095
+	# RODECaster Duo USB2: 19f7:0027
+	Id "19f7:00(38|73|79|31|27|93|95)"
+	Profile "RODE/RODECaster-Duo"
+}
+
 Macro.rode-rodecaster-pro-2.RegexMatch {
 	# RODECaster Pro II USB1: 19f7:0037, 19f7:0072, 19f7:0078, 19f7:0030, 19f7:0092, 19f7:0094
 	# RODECaster Pro II USB2: 19f7:0026


### PR DESCRIPTION
The RODECaster Duo is very similar to the RODECaster Pro II, other than the physical/virtual faders from the USB side of things.