### PR TITLE
ucm2: sof-soundwire: support dual-codec cs42l43-spk + cs35l56 speakers

### DIFF
--- a/ucm2/sof-soundwire/cs35l56.conf
+++ b/ucm2/sof-soundwire/cs35l56.conf
@@ -3,6 +3,30 @@
 SectionDevice."Speaker" {
 	Comment "Speaker"
 
+	EnableSequence [
+		cset "name='Speaker Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Speaker Switch' off"
+	]
+
+	If.cs42l43_spk_routing {
+		Condition {
+			Type RegexMatch
+			Regex "spk:cs42l43-spk"
+			String "${CardComponents}"
+		}
+		True.EnableSequence [
+			cset "name='cs42l43 Speaker L Input 1' 'DP6RX1'"
+			cset "name='cs42l43 Speaker R Input 1' 'DP6RX2'"
+		]
+		True.DisableSequence [
+			cset "name='cs42l43 Speaker L Input 1' 'None'"
+			cset "name='cs42l43 Speaker R Input 1' 'None'"
+		]
+	}
+
 	Value {
 		PlaybackPriority 100
 		PlaybackPCM "hw:${CardId},2"

--- a/ucm2/sof-soundwire/cs42l43-spk.conf
+++ b/ucm2/sof-soundwire/cs42l43-spk.conf
@@ -15,6 +15,7 @@ SectionDevice."Speaker" {
 	}
 
 	EnableSequence [
+		cset "name='Speaker Switch' on"
 		cset "name='cs42l43 Speaker L Input 1' 'DP6RX1'"
 		cset "name='cs42l43 Speaker R Input 1' 'DP6RX2'"
 	]
@@ -22,6 +23,7 @@ SectionDevice."Speaker" {
 	DisableSequence [
 		cset "name='cs42l43 Speaker L Input 1' 'None'"
 		cset "name='cs42l43 Speaker R Input 1' 'None'"
+		cset "name='Speaker Switch' off"
 	]
 
 
@@ -36,6 +38,18 @@ SectionDevice."Speaker" {
 		}
 		False.Value {
 			PlaybackMixerElem "cs42l43 Speaker Digital"
+		}
+	}
+
+	If.cs35l56_mute {
+		Condition {
+			Type RegexMatch
+			Regex "spk:cs35l56( |$)"
+			String "${CardComponents}"
+		}
+		True.Value {
+			PlaybackMixer "default:${CardId}"
+			PlaybackMixerElem "cs35l56 Speaker"
 		}
 	}
 

--- a/ucm2/sof-soundwire/sof-soundwire.conf
+++ b/ucm2/sof-soundwire/sof-soundwire.conf
@@ -108,10 +108,39 @@ If.multi_headset {
 If.spk_init {
 	Condition {
 		Type RegexMatch
-		Regex "(rt1318(-1)?|cs35l56(-bridge)?)"
-		String "${var:SpeakerCodec1}"
+		Regex "spk:cs35l56( |$)"
+		String "${CardComponents}"
 	}
-	True.Include.spk_init.File "/codecs/${var:SpeakerCodec1}/init.conf"
+	True {
+		If.dual_spk {
+			Condition {
+				Type RegexMatch
+				Regex "spk:cs42l43-spk"
+				String "${CardComponents}"
+			}
+			True {
+				Define.SpeakerAmps "${eval:($SpeakerAmps1-1)}"
+				Include.cs35l56_init.File "/codecs/cs35l56/init.conf"
+				LibraryConfig.remap.Config.ctl.default.map {
+					"name='cs35l56 Speaker Playback Switch'" {
+						"name='cs42l43 Speaker Digital Switch'" {
+							vindex."${eval:($SpeakerAmps1-1)}" 0
+							vindex."${eval:$SpeakerAmps1}" 1
+						}
+					}
+				}
+			}
+			False.Include.spk_init.File "/codecs/cs35l56/init.conf"
+		}
+	}
+	False.If.other_spk_init {
+		Condition {
+			Type RegexMatch
+			Regex "(rt1318(-1)?|cs35l56(-bridge)?)"
+			String "${var:SpeakerCodec1}"
+		}
+		True.Include.other_spk_init.File "/codecs/${var:SpeakerCodec1}/init.conf"
+	}
 }
 
 If.hs_init {


### PR DESCRIPTION
Some machines have both cs42l43 and cs35l56 speaker amps on SoundWire. Only the first spk: tag in CardComponents was handled, leaving the second codec without init, control remap, or mute LED.

Detect cs35l56 directly in CardComponents instead of SpeakerCodec1, and when cs42l43-spk is also present, initialise both codecs and extend the mute LED remap to cover all amp channels.

Toggle Speaker Switch in both device confs and set up cross-codec routing and mute tracking as needed.