### PR TITLE
ucm2: add Arduino VENTUNO support

### DIFF
--- a/ucm2/Qualcomm/qcs8300/arduino-monza/HiFi.conf
+++ b/ucm2/Qualcomm/qcs8300/arduino-monza/HiFi.conf
@@ -1,0 +1,137 @@
+# Use case configuration for Arduino Monza
+# Author: Srinivas Kandagatla <srinivas.Kandagatla@oss.qualcomm.com>
+
+SectionVerb {
+	EnableSequence [
+		cset "name='LPI_MI2S_RX_0 Audio Mixer MultiMedia1' 1"
+		cset "name='LPI_MI2S_RX_4 Audio Mixer MultiMedia2' 1"
+		cset "name='MultiMedia4 Mixer LPI_MI2S_TX_0' 1"
+	]
+	Include.e.File "/codecs/max98090/EnableSeq.conf"
+	Value {
+		TQ "HiFi"
+	}
+}
+
+SectionDevice."Line1" {
+	Comment "Analog Line Output"
+
+	Value {
+		PlaybackPCM "hw:${CardId},0"
+		PlaybackMixer "default:${CardId}"
+	}
+
+	ConflictingDevice [
+		"Headphones"
+		"Earpiece"
+	]
+
+	EnableSequence [
+		cset "name='Receiver Left Switch' on"
+		cset "name='Receiver Right Switch' on"
+		cset "name='Receiver Switch' on"
+		cset "name='Left Receiver Mixer Left DAC Switch' 1"
+		cset "name='Right Receiver Mixer Right DAC Switch' 1"
+		cset "name='LINMOD Mux' 1"
+		cset "name='Receiver Left Mixer Volume' 2"
+		cset "name='Receiver Right Mixer Volume' 2"
+		cset "name='Speaker Switch' off"
+	]
+
+	DisableSequence [
+		cset "name='Receiver Left Switch' off"
+		cset "name='Receiver Right Switch' off"
+		cset "name='Receiver Switch' off"
+	]
+}
+
+SectionDevice."Headphones" {
+	Comment "Headphone Output"
+
+	Value {
+		PlaybackPCM "hw:${CardId},0"
+		PlaybackMixer "default:${CardId}"
+	}
+
+	ConflictingDevice [
+		"Line1"
+		"Earpiece"
+	]
+
+	EnableSequence [
+		cset "name='Headphone Left Switch' on"
+		cset "name='Headphone Right Switch' on"
+		cset "name='Headphone Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Headphone Left Switch' off"
+		cset "name='Headphone Right Switch' off"
+		cset "name='Headphone Switch' off"
+	]
+}
+
+SectionDevice."Earpiece" {
+	Comment "Earpiece playback"
+
+	Value {
+		PlaybackPCM "hw:${CardId},0"
+		PlaybackMixer "default:${CardId}"
+	}
+
+	ConflictingDevice [
+		"Line1"
+		"Headphones"
+	]
+
+	EnableSequence [
+		cset "name='Speaker Left Switch' on"
+		cset "name='Speaker Right Switch' on"
+		cset "name='Speaker Switch' on"
+		cset "name='Receiver Switch' off"
+	]
+
+	DisableSequence [
+		cset "name='Speaker Left Switch' off"
+		cset "name='Speaker Right Switch' off"
+		cset "name='Speaker Switch' off"
+	]
+
+}
+SectionDevice."HDMI" {
+	Comment "HDMI playback"
+
+	Value {
+		PlaybackChannels 2
+		PlaybackPCM "hw:${CardId},1"
+		PlaybackMixer "default:${CardId}"
+	}
+}
+
+SectionDevice."Headset" {
+	Comment "Headset microphone"
+
+	EnableSequence [
+		cset "name='MIC1 Mux' IN12"
+		cset "name='DMIC Mux' 0"
+		cset "name='Headset Mic Switch' on"
+		cset "name='Headset Mic12 Switch' on"
+		cset "name='Record Path DC Blocking' on"
+		cset "name='Left ADC Mixer MIC2 Switch' on"
+		cset "name='Right ADC Mixer MIC2 Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Headset Mic Switch' off"
+		cset "name='DMIC Mux' 1"
+		cset "name='Record Path DC Blocking' off"
+		cset "name='Headset Mic12 Switch' off"
+		cset "name='Left ADC Mixer MIC2 Switch' off"
+		cset "name='Right ADC Mixer MIC2 Switch' off"
+	]
+
+	Value {
+		CapturePriority 200
+		CapturePCM "hw:${CardId},3"
+	}
+}

--- a/ucm2/Qualcomm/qcs8300/arduino-monza/arduino-monza.conf
+++ b/ucm2/Qualcomm/qcs8300/arduino-monza/arduino-monza.conf
@@ -1,0 +1,11 @@
+Syntax 4
+
+SectionUseCase."HiFi" {
+	File "/Qualcomm/qcs8300/arduino-monza/HiFi.conf"
+	Comment "HiFi quality Music"
+}
+
+BootSequence [
+	cset "name='Headphone Volume' 30"
+	cset "name='MIC1 Volume' 20"
+]

--- a/ucm2/conf.d/qcs8300/arduino-monza.conf
+++ b/ucm2/conf.d/qcs8300/arduino-monza.conf
@@ -1,0 +1,1 @@
+../../Qualcomm/qcs8300/arduino-monza/arduino-monza.conf


### PR DESCRIPTION
Arduino VENTUNO has 1xHDMI, 1xDP, Headset(Mic and speakers), LineOut and EarOut connectors.

Add support for everything except DP, as it is not fully enabled yet.