### PR TITLE
ucm2: rt722: add speaker mute LED and PlaybackSwitch for FU06

### DIFF
--- a/ucm2/codecs/rt722/init.conf
+++ b/ucm2/codecs/rt722/init.conf
@@ -10,6 +10,15 @@ BootSequence [
 	cset "name='rt722 FU0F Capture Volume' 63"
 ]
 
+If.spk_init_rt722 {
+	Condition {
+		Type String
+		Needle "rt722"
+		Haystack "${var:SpeakerCodec1}"
+	}
+	True.Macro [{ SetLED { LED="speaker" Action="attach" CtlId="rt722 FU06 Playback Switch" } }]
+}
+
 If.mic_init_rt722 {
 	Condition {
 		Type String

--- a/ucm2/sof-soundwire/rt722.conf
+++ b/ucm2/sof-soundwire/rt722.conf
@@ -51,6 +51,7 @@ If.codecspk {
 				PlaybackPriority 100
 				PlaybackPCM "hw:${CardId},2"
 				PlaybackMixerElem "rt722 FU06"
+				PlaybackSwitch "rt722 FU06 Playback Switch"
 				PlaybackVolume "rt722 FU06 Playback Volume"
 			}
 		}


### PR DESCRIPTION
Attach rt722 FU06 Playback Switch to the speaker mute LED via SetLED in init.conf, and declare PlaybackSwitch in the Speaker device so PipeWire can toggle hardware mute.

Link: https://lore.kernel.org/linux-sound/20260423101338.1040131-1-aaron.ma@canonical.com/