### PR TITLE
ucm2: Qualcomm: x1e80100: T14s-HiFi: switch DP outputs to dedicated MultiMedia5/6/7 streams

### DIFF
--- a/ucm2/Qualcomm/x1e80100/T14s-HiFi.conf
+++ b/ucm2/Qualcomm/x1e80100/T14s-HiFi.conf
@@ -123,7 +123,6 @@ SectionDevice."HDMI0" {
 	Value {
 		PlaybackPriority 200
 		PlaybackPCM "hw:${CardId},4"
-		JackControl "DP0 Jack"
 		PlaybackChannels 2
 		JackControl "DP0 Jack"
 	}
@@ -152,7 +151,6 @@ SectionDevice."HDMI1" {
 	Value {
 		PlaybackPriority 200
 		PlaybackPCM "hw:${CardId},5"
-		JackControl "DP1 Jack"
 		PlaybackChannels 2
 		JackControl "DP1 Jack"
 	}
@@ -181,7 +179,6 @@ SectionDevice."HDMI2" {
 	Value {
 		PlaybackPriority 200
 		PlaybackPCM "hw:${CardId},6"
-		JackControl "DP2 Jack"
 		PlaybackChannels 2
 		JackControl "DP2 Jack"
 	}

--- a/ucm2/Qualcomm/x1e80100/T14s-HiFi.conf
+++ b/ucm2/Qualcomm/x1e80100/T14s-HiFi.conf
@@ -3,13 +3,13 @@
 
 SectionVerb {
 	EnableSequence [
-		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia1' 0"
-		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia1' 0"
-		cset "name='DISPLAY_PORT_RX_2 Audio Mixer MultiMedia1' 0"
 		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia1' 1"
 		cset "name='WSA_CODEC_DMA_RX_0 Audio Mixer MultiMedia2' 1"
 		cset "name='MultiMedia3 Mixer TX_CODEC_DMA_TX_3' 1"
 		cset "name='MultiMedia4 Mixer VA_CODEC_DMA_TX_0' 1"
+		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia5' 1"
+		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia6' 1"
+		cset "name='DISPLAY_PORT_RX_2 Audio Mixer MultiMedia7' 1"
 	]
 
 	Include.wsae.File "/codecs/wsa884x/two-speakers/DefaultEnableSeq.conf"
@@ -52,9 +52,9 @@ SectionDevice."Headphones" {
 
 	EnableSequence [
 		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia1' 1"
-		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia1' 0"
-		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia1' 0"
-		cset "name='DISPLAY_PORT_RX_2 Audio Mixer MultiMedia1' 0"
+		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia5' 0"
+		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia6' 0"
+		cset "name='DISPLAY_PORT_RX_2 Audio Mixer MultiMedia7' 0"
 	]
 
 	DisableSequence [
@@ -111,18 +111,20 @@ SectionDevice."HDMI0" {
 
 	EnableSequence [
 		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia1' 0"
-		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia1' 1"
-		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia1' 0"
-		cset "name='DISPLAY_PORT_RX_2 Audio Mixer MultiMedia1' 0"
+		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia5' 1"
+		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia6' 0"
+		cset "name='DISPLAY_PORT_RX_2 Audio Mixer MultiMedia7' 0"
 	]
 
 	DisableSequence [
-		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia1' 0"
+		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia5' 0"
 	]
 
 	Value {
 		PlaybackPriority 200
-		PlaybackPCM "hw:${CardId},0"
+		PlaybackPCM "hw:${CardId},4"
+		JackControl "DP0 Jack"
+		PlaybackChannels 2
 		JackControl "DP0 Jack"
 	}
 }
@@ -138,18 +140,20 @@ SectionDevice."HDMI1" {
 
 	EnableSequence [
 		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia1' 0"
-		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia1' 0"
-		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia1' 1"
-		cset "name='DISPLAY_PORT_RX_2 Audio Mixer MultiMedia1' 0"
+		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia5' 0"
+		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia6' 1"
+		cset "name='DISPLAY_PORT_RX_2 Audio Mixer MultiMedia7' 0"
 	]
 
 	DisableSequence [
-		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia1' 0"
+		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia6' 0"
 	]
 
 	Value {
 		PlaybackPriority 200
-		PlaybackPCM "hw:${CardId},0"
+		PlaybackPCM "hw:${CardId},5"
+		JackControl "DP1 Jack"
+		PlaybackChannels 2
 		JackControl "DP1 Jack"
 	}
 }
@@ -165,18 +169,20 @@ SectionDevice."HDMI2" {
 
 	EnableSequence [
 		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia1' 0"
-		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia1' 0"
-		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia1' 0"
-		cset "name='DISPLAY_PORT_RX_2 Audio Mixer MultiMedia1' 1"
+		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia5' 0"
+		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia6' 0"
+		cset "name='DISPLAY_PORT_RX_2 Audio Mixer MultiMedia7' 1"
 	]
 
 	DisableSequence [
-		cset "name='DISPLAY_PORT_RX_2 Audio Mixer MultiMedia1' 0"
+		cset "name='DISPLAY_PORT_RX_2 Audio Mixer MultiMedia7' 0"
 	]
 
 	Value {
 		PlaybackPriority 200
-		PlaybackPCM "hw:${CardId},0"
+		PlaybackPCM "hw:${CardId},6"
+		JackControl "DP2 Jack"
+		PlaybackChannels 2
 		JackControl "DP2 Jack"
 	}
 }


### PR DESCRIPTION
Align UCM with the topology change that added dedicated multimedia frontends for DisplayPort (commit c8d6762 "ASoC: qcom: x1e80100-LENOVO-Thinkpad-T14s: add dedicated multimedia frontend for DisplayPort").

- SectionVerb EnableSequence: enable DISPLAY_PORT_RX_0/1/2 on MultiMedia5/6/7 (remove the old MultiMedia1 "0" settings).
- Headphones: disable the DP mixers on the new dedicated streams.
- HDMI0/1/2 devices: route each DISPLAY_PORT_RX_* to its own MultiMedia frontend, use dedicated PlaybackPCM "hw:${CardId},4/5/6", add explicit PlaybackChannels 2, and keep the existing JackControl.

This gives independent DP audio streams and matches the [new topology](https://github.com/linux-msm/audioreach-topology/pull/59).

Tested on T14s G6 and ThinkBook 16 G7 QOY.