### PR TITLE
Sound over Display support for Microsoft Windows Dev Kit 2023 (Blackrock)

### DIFF
--- a/ucm2/Qualcomm/sc8280xp/Blackrock-HiFi.conf
+++ b/ucm2/Qualcomm/sc8280xp/Blackrock-HiFi.conf
@@ -1,0 +1,93 @@
+# Use case configuration for Microsoft Blackrock.
+# Author: Jens Glathe <jens.glathe@oldschoolsolutions.biz>
+# Original Author: Srinivas Kandagatla <srinivas.kandagatla@linaro.org>
+
+SectionVerb {
+	EnableSequence [
+		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia1' 1"
+		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia2' 1"
+		cset "name='DISPLAY_PORT_RX_2 Audio Mixer MultiMedia3' 1"
+	]
+
+	Value {
+		TQ "HiFi"
+	}
+}
+
+SectionDevice."HDMI0" {
+	Comment "USB/DisplayPort 0 playback"
+
+	ConflictingDevice [
+		"HDMI1"
+		"HDMI2"
+	]
+
+	EnableSequence [
+		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia1' 1"
+		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia2' 0"
+		cset "name='DISPLAY_PORT_RX_2 Audio Mixer MultiMedia3' 0"
+	]
+
+	DisableSequence [
+		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia1' 0"
+	]
+
+	Value {
+		PlaybackPriority 200
+		PlaybackPCM "hw:${CardId},0"
+		PlaybackChannels 2
+		JackControl "DP0 Jack"
+	}
+}
+
+SectionDevice."HDMI1" {
+	Comment "USB/DisplayPort 1 playback"
+
+	ConflictingDevice [
+		"HDMI0"
+		"HDMI2"
+	]
+
+	EnableSequence [
+		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia1' 0"
+		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia2' 1"
+		cset "name='DISPLAY_PORT_RX_2 Audio Mixer MultiMedia3' 0"
+	]
+
+	DisableSequence [
+		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia2' 0"
+	]
+
+	Value {
+		PlaybackPriority 200
+		PlaybackPCM "hw:${CardId},1"
+		PlaybackChannels 2
+		JackControl "DP1 Jack"
+	}
+}
+
+SectionDevice."HDMI2" {
+	Comment "miniDP playback"
+
+	ConflictingDevice [
+		"HDMI0"
+		"HDMI1"
+	]
+
+	EnableSequence [
+		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia1' 0"
+		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia2' 0"
+		cset "name='DISPLAY_PORT_RX_2 Audio Mixer MultiMedia3' 1"
+	]
+
+	DisableSequence [
+		cset "name='DISPLAY_PORT_RX_2 Audio Mixer MultiMedia3' 0"
+	]
+
+	Value {
+		PlaybackPriority 200
+		PlaybackPCM "hw:${CardId},2"
+		PlaybackChannels 2
+		JackControl "DP2 Jack"
+	}
+}

--- a/ucm2/Qualcomm/sc8280xp/LENOVO-X13s.conf
+++ b/ucm2/Qualcomm/sc8280xp/LENOVO-X13s.conf
@@ -1,7 +1,7 @@
 Syntax 4
 
 SectionUseCase."HiFi" {
-	File "/Qualcomm/sc8280xp/HiFi.conf"
+	File "/Qualcomm/sc8280xp/X13s-HiFi.conf"
 	Comment "HiFi quality Music."
 }
 

--- a/ucm2/Qualcomm/sc8280xp/X13s-HiFi.conf
+++ b/ucm2/Qualcomm/sc8280xp/X13s-HiFi.conf
@@ -1,0 +1,83 @@
+# Use case configuration for LenovoX13s.
+# Author: Srinivas Kandagatla <srinivas.kandagatla@linaro.org>
+
+SectionVerb {
+	EnableSequence [
+		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia1' 1"
+		cset "name='WSA_CODEC_DMA_RX_0 Audio Mixer MultiMedia2' 1"
+		cset "name='MultiMedia4 Mixer VA_CODEC_DMA_TX_0' 1"
+		cset "name='MultiMedia3 Mixer TX_CODEC_DMA_TX_3' 1"
+	]
+
+	Include.wsae.File "/codecs/wsa883x/DefaultEnableSeq.conf"
+
+	Value {
+		TQ "HiFi"
+	}
+}
+
+SectionDevice."Speaker" {
+	Comment "Speaker playback"
+
+	Include.wsamspke.File "/codecs/qcom-lpass/wsa-macro/SpeakerEnableSeq.conf"
+	Include.wsamspkd.File "/codecs/qcom-lpass/wsa-macro/SpeakerDisableSeq.conf"
+	Include.wsaspke.File "/codecs/wsa883x/SpeakerEnableSeq.conf"
+	Include.wsaspkd.File "/codecs/wsa883x/SpeakerDisableSeq.conf"
+
+	Value {
+		PlaybackPriority 100
+		PlaybackPCM "hw:${CardId},1"
+		PlaybackMixer "default:${CardId}"
+		PlaybackMixerElem "Speakers"
+	}
+}
+
+SectionDevice."Headphones" {
+	Comment "Headphones playback"
+
+	Include.wcdhpe.File "/codecs/wcd938x/HeadphoneABEnableSeq.conf"
+	Include.wcdhpd.File "/codecs/wcd938x/HeadphoneDisableSeq.conf"
+	Include.rxmhpe.File "/codecs/qcom-lpass/rx-macro/HeadphoneEnableSeq.conf"
+	Include.rxmhpd.File "/codecs/qcom-lpass/rx-macro/HeadphoneDisableSeq.conf"
+
+	Value {
+		PlaybackPriority 200
+		PlaybackPCM "hw:${CardId},0"
+		PlaybackMixer "default:${CardId}"
+		PlaybackMixerElem "HP"
+		JackControl "Headphone Jack"
+		JackHWMute "Speaker"
+	}
+}
+
+SectionDevice."Headset" {
+	Comment "Headset microphone"
+
+	Include.wcdmice.File "/codecs/wcd938x/HeadphoneMicEnableSeq.conf"
+	Include.wcdmicd.File "/codecs/wcd938x/HeadphoneMicDisableSeq.conf"
+	Include.txmhpe.File "/codecs/qcom-lpass/tx-macro/HeadphoneMicEnableSeq.conf"
+	Include.txmhpd.File "/codecs/qcom-lpass/tx-macro/HeadphoneMicDisableSeq.conf"
+
+	Value {
+		CapturePriority 100
+		CapturePCM "hw:${CardId},2"
+		CaptureMixerElem "ADC2"
+		JackControl "Mic Jack"
+		JackHWMute "Mic"
+	}
+}
+
+SectionDevice."Mic" {
+	Comment "Internal microphones"
+
+	Include.vadm0e.File "/codecs/qcom-lpass/va-macro/DMIC0EnableSeq.conf"
+	Include.vadm0d.File "/codecs/qcom-lpass/va-macro/DMIC0DisableSeq.conf"
+	Include.vadm1e.File "/codecs/qcom-lpass/va-macro/DMIC1EnableSeq.conf"
+	Include.vadm1d.File "/codecs/qcom-lpass/va-macro/DMIC1DisableSeq.conf"
+
+
+	Value {
+		CapturePriority 100
+		CapturePCM "hw:${CardId},3"
+	}
+}

--- a/ucm2/Qualcomm/sc8280xp/microsoft-blackrock.conf
+++ b/ucm2/Qualcomm/sc8280xp/microsoft-blackrock.conf
@@ -1,0 +1,9 @@
+Syntax 4
+
+SectionUseCase."HiFi" {
+	File "/Qualcomm/sc8280xp/Blackrock-HiFi.conf"
+	Comment "HiFi quality Music."
+}
+
+Include.card-init.File "/lib/card-init.conf"
+Include.ctl-remap.File "/lib/ctl-remap.conf"

--- a/ucm2/Qualcomm/sc8280xp/sc8280xp.conf
+++ b/ucm2/Qualcomm/sc8280xp/sc8280xp.conf
@@ -7,5 +7,13 @@ If.LENOVOX13s {
 		Regex "LENOVO.*ThinkPad X13s.*"
 	}
 	True.Include.x13s.File "/Qualcomm/sc8280xp/LENOVO-X13s.conf"
-	False.Error "SC8280XP - ${sys:devices/virtual/dmi/id/board_vendor}-${sys:devices/virtual/dmi/id/product_family} model not supported"
+}
+
+If.microsoftblackrock {
+	Condition {
+		Type RegexMatch
+		String "${sys:devices/virtual/dmi/id/board_vendor}-${sys:devices/virtual/dmi/id/board_name}"
+		Regex "Microsoft Corporation.*Windows Dev Kit 2023.*"
+	}
+	True.Include.blackrock.File "/Qualcomm/sc8280xp/microsoft-blackrock.conf"
 }


### PR DESCRIPTION
Introduce a device profile for the Microsoft Windows Dev Kit 2023. It has a miniDP out and 2 Type-C connectors capable of DP Altmode, and no other (easily) accessible othe audion input/outputs. To use it you also need the corresponding topology, will be a [PR in audioreach-topology](https://github.com/jglathe/audioreach-topology/tree/jg/blackrock).
I also tried to integrate it with the existing Lenovo Thinkpad X13s profile to get automatic detection (works here). 