### PR TITLE
Add support for ASUS Pro ET900N G3 front panel audio

### DIFF
--- a/ucm2/USB-Audio/Realtek/ALC4080-HiFi.conf
+++ b/ucm2/USB-Audio/Realtek/ALC4080-HiFi.conf
@@ -200,6 +200,26 @@ If.asus-rog-strix {
 	}
 }
 
+If.nvidia-dgx-station {
+	Condition {
+		Type RegexMatch
+		String "${CardComponents}"
+		Regex "USB(0955:cf0a)"
+	}
+	True.Define {
+		HeadphonesName "Front Line Out"
+		Mic1Name "Front Microphone"
+		Mic1Mindex "1"
+		Mic1Jack "name='Mic - Input Jack',index=1"
+		Mic2Name "Rear Microphone"
+		Mic2Mixer "Mic"
+		Mic2Jack "Mic - Input Jack"
+		Mic2PCM "0"
+		Line1Name "Rear Line Input"
+		SpdifName ""
+	}
+}
+
 SectionVerb {
 	EnableSequence [
 		disdevall ""

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -126,7 +126,8 @@ Macro.alc4080.RegexMatch {
 	# 26ce:0a06 ASRock X670E/Z790 Taichi
 	# 26ce:0a08 ASRock Z790 PG-ITX/TB4, X870 Steel Legend
 	# 26ce:0a0b ASRock X870E Taichi
-	Id "((0414:a0(0e|1[0124]))|(0b05:(19(84|9[69]|ac)|1a(16|2[07]|5[23c]|7a|97|f1)|1b(7c|9b|e1)))|(0db0:(005a|0b58|1(24b|51f|9a2|feb)|3130|36e7|4(19c|22d|240|88c|c84)|543d|62a4|6c[0c]9|70d3|7696|82c[47]|8af7|9(5bb|61e|e6d)|a(073|228|47c|74b)|b202|c(c78|d0e)|d(1d7|4fa|6e7)|e1f8))|(26ce:0a0[68b]))"
+	# 0955:cf0a NVIDIA USB Audio
+	Id "((0414:a0(0e|1[0124]))|(0b05:(19(84|9[69]|ac)|1a(16|2[07]|5[23c]|7a|97|f1)|1b(7c|9b|e1)))|(0db0:(005a|0b58|1(24b|51f|9a2|feb)|3130|36e7|4(19c|22d|240|88c|c84)|543d|62a4|6c[0c]9|70d3|7696|82c[47]|8af7|9(5bb|61e|e6d)|a(073|228|47c|74b)|b202|c(c78|d0e)|d(1d7|4fa|6e7)|e1f8))|(26ce:0a0[68b])|(0955:cf0a))"
 	Profile "Realtek/ALC4080"
 }
 


### PR DESCRIPTION
This PR adds UCM configuration support for ASUS Pro ET900N G3 - Station GB300 :
- Front panel line out
- Front panel mic in
- Rear line in


Tested on local DGX system, all inputs/outputs working correctly.

Signed-off-by: Kenny4 <Kenny4_Lin@asus.com>