### PR TITLE
ucm2/conf.d: add sof_sdw symlink for sof-soundwire driver rename

### DIFF
--- a/ucm2/conf.d/sof_sdw/sof_sdw.conf
+++ b/ucm2/conf.d/sof_sdw/sof_sdw.conf
@@ -1,0 +1,1 @@
+../sof-soundwire/sof-soundwire.conf


### PR DESCRIPTION
## Summary

The kernel ASoC machine driver for SoundWire-based SOF systems was historically named `sof-soundwire` and is now named `sof_sdw`. UCM lookup uses `\${var:Driver}` from `/sys/class/sound/cardN/device/driver`, so on current kernels the existing `conf.d/sof-soundwire/` directory is never matched and UCM is not loaded.

This adds a symlink under `conf.d/sof_sdw/` pointing at the existing `conf.d/sof-soundwire/sof-soundwire.conf`, mirroring the precedent set by PR #428 for the `apq8096` / `DB820c` rename.

## Why

Without UCM, PipeWire ACP falls back to the `pro-audio` profile which exposes channels as `AUX0`/`AUX1` instead of `FL`/`FR`, so stereo content is downmixed to one speaker and the GNOME Sound panel does not show separate Speaker/Headphones/HDMI options.

With this symlink, UCM detects the `HiFi` profile, alsa-card-profile creates proper sinks/sources, jack auto-routing works, and the GNOME Sound panel exposes the right output choices.

## Affected hardware (verified)

- Lenovo Yoga Slim 7 14ILL10 (cs42l43) — issue #645
- LG Gram Pro 2026 (16Z90U-KU7BK, RT713 + RT1320), Ubuntu 26.04, kernel 7.0.0-15

## Test plan

- [x] `alsaucm -c hw:0 list _verbs` returns `HiFi` (previously empty / no UCM)
- [x] PipeWire HiFi profile auto-activates with proper `front-left,front-right` channel mapping
- [x] Speakers play stereo correctly
- [x] Headphone jack auto-routes on plug
- [x] HDMI / built-in mic / headset mic all expose proper sinks/sources
- [x] No regressions on cards still using `sof-soundwire` driver name (symlink, not rename)