### PR TITLE
HDA/HiFi-analog.conf: skip Line2 ConflictingDevice when loctl is empty

### DIFF
--- a/ucm2/HDA/HiFi-analog.conf
+++ b/ucm2/HDA/HiFi-analog.conf
@@ -283,9 +283,15 @@ If.linefront {
 	True.SectionDevice."Line2" {
 		Comment "Second Line Output"
 
-		ConflictingDevice [
-			"Line${var:LineDevice}"
-		]
+		If.line1exists {
+			Condition {
+				Type String
+				Empty "${var:loctl}"
+			}
+			False.ConflictingDevice [
+				"Line${var:LineDevice}"
+			]
+		}
 
 		EnableSequence [
 			cset "name='Front Playback Switch' on"


### PR DESCRIPTION
When `Front Playback Switch` exists but `Line Playback Switch` does not (`loctl=""`), the `Line2` SectionDevice is created but `Line1` is not. The unconditional `ConflictingDevice ["Line${var:LineDevice}"]` in `Line2` then causes the entire HiFi verb to fail:

```
ucm: unable to find device 'Line1'
ucm: device management error in verb 'HiFi'
```

WirePlumber falls back to `stereo-fallback` profile as a result, hiding the DMIC from PipeWire entirely.

Fix by making the `ConflictingDevice` conditional on `loctl` being non-empty — i.e. only declare the conflict when `Line1` was actually created.

Tested on: Acer Predator PH16-73 (Arrow Lake-HX, ALC245, PCI SSID 1025:1826)

Closes #763