### PR TITLE
ucm2: MediaTek: mt8366-evk: Add alsa-ucm support

### DIFF
--- a/ucm2/MediaTek/mt8366-evk/HiFi.conf
+++ b/ucm2/MediaTek/mt8366-evk/HiFi.conf
@@ -1,0 +1,199 @@
+SectionDevice."Speaker" {
+	Comment "Lineout speaker"
+
+	ConflictingDevice [
+		"Headphones"
+	]
+
+	EnableSequence [
+		cset "name='LOL Mux' Playback"
+	]
+
+	DisableSequence [
+		cset "name='LOL Mux' Open"
+	]
+
+	Value {
+		PlaybackPriority 300
+		PlaybackChannels 1
+		PlaybackPCM "hw:${CardId},${var:PlayDevN}"
+	}
+}
+
+SectionDevice."Headphones" {
+	Comment "Earphone speaker"
+
+	ConflictingDevice [
+		"Speaker"
+	]
+
+	EnableSequence [
+		cset "name='HPL Mux' Audio Playback"
+	]
+
+	DisableSequence [
+		cset "name='HPL Mux' Open"
+	]
+
+	Value {
+		PlaybackPriority 400
+		PlaybackChannels 2
+		PlaybackPCM "hw:${CardId},${var:PlayDevN}"
+		JackControl "Headphone Jack"
+	}
+}
+
+SectionDevice."Headset" {
+	Comment "Earphone microphone"
+
+	ConflictingDevice [
+		"Mic1"
+	]
+
+	EnableSequence [
+		cset "name='ADC L Mux' Left Preamplifier"
+		cset "name='PGA L Mux' AIN1"
+	]
+
+	DisableSequence [
+		cset "name='ADC L Mux' Idle"
+		cset "name='PGA L Mux' None"
+	]
+
+	Value {
+		CapturePriority 500
+		CaptureChannels "${var:CapChanN}"
+		CapturePCM "hw:${CardId},${var:CapDevN}"
+		JackControl "Headset Mic Jack"
+	}
+}
+
+SectionDevice."Mic1" {
+	Comment "Analog microphone"
+
+	ConflictingDevice [
+		"Headset"
+	]
+
+	EnableSequence [
+		cset "name='ADC L Mux' Left Preamplifier"
+		cset "name='ADC R Mux' Right Preamplifier"
+		cset "name='PGA L Mux' AIN0"
+		cset "name='PGA R Mux' AIN2"
+	]
+
+	DisableSequence [
+		cset "name='ADC L Mux' Idle"
+		cset "name='ADC R Mux' Idle"
+		cset "name='PGA L Mux' None"
+		cset "name='PGA R Mux' None"
+	]
+
+	Value {
+		CapturePriority 400
+		CaptureChannels 2
+		CapturePCM "hw:${CardId},${var:CapDevN}"
+	}
+}
+
+SectionDevice."Mic2" {
+	Comment "Digital microphone"
+
+	Value {
+		CapturePriority 300
+		CaptureChannels 2
+		CapturePCM "hw:${CardId},11"
+	}
+}
+
+SectionDevice."Line1" {
+	Comment "PCM input"
+
+	ConflictingDevice [
+		"Line3"
+	]
+
+	EnableSequence [
+		cset "name='UL1_CH1 I2SIN5_CH1' off"
+		cset "name='UL1_CH2 I2SIN5_CH2' off"
+		cset "name='UL1_CH1 PCM_0_CAP_CH1' on"
+		cset "name='UL1_CH2 PCM_0_CAP_CH2' on"
+	]
+
+	DisableSequence [
+		cset "name='UL1_CH1 PCM_0_CAP_CH1' off"
+		cset "name='UL1_CH2 PCM_0_CAP_CH2' off"
+	]
+
+	Value {
+		CapturePriority 200
+		CaptureChannels 2
+		CapturePCM "hw:${CardId},12"
+	}
+}
+
+SectionDevice."Line2" {
+	Comment "PCM output"
+
+	Value {
+		PlaybackPriority 200
+		PlaybackChannels 2
+		PlaybackPCM "hw:${CardId},2"
+	}
+}
+
+SectionDevice."Line3" {
+	Comment "I2S5 input"
+
+	ConflictingDevice [
+		"Line1"
+	]
+
+	EnableSequence [
+		cset "name='UL1_CH1 PCM_0_CAP_CH1' off"
+		cset "name='UL1_CH2 PCM_0_CAP_CH2' off"
+		cset "name='UL1_CH1 I2SIN5_CH1' on"
+		cset "name='UL1_CH2 I2SIN5_CH2' on"
+	]
+
+	DisableSequence [
+		cset "name='UL1_CH1 I2SIN5_CH1' off"
+		cset "name='UL1_CH2 I2SIN5_CH2' off"
+	]
+
+	Value {
+		CapturePriority 100
+		CaptureChannels 2
+		CapturePCM "hw:${CardId},12"
+	}
+}
+
+SectionDevice."Line4" {
+	Comment "I2S5 output"
+
+	Value {
+		PlaybackPriority 100
+		PlaybackChannels 8
+		PlaybackPCM "hw:${CardId},8"
+	}
+}
+
+SectionDevice."Line5" {
+	Comment "I2S6 input"
+
+	Value {
+		CapturePriority 100
+		CaptureChannels 2
+		CapturePCM "hw:${CardId},13"
+	}
+}
+
+SectionDevice."Line6" {
+	Comment "I2S6 output"
+
+	Value {
+		PlaybackPriority 100
+		PlaybackChannels 2
+		PlaybackPCM "hw:${CardId},3"
+	}
+}

--- a/ucm2/MediaTek/mt8366-evk/init.conf
+++ b/ucm2/MediaTek/mt8366-evk/init.conf
@@ -1,0 +1,41 @@
+Syntax 4
+
+SectionUseCase."HiFi" {
+	File "/MediaTek/mt8366-evk/HiFi.conf"
+	Comment "Play high quality music"
+}
+
+BootSequence [
+	cset "name='ADDA_DL_CH1 DL0_CH1' on"
+	cset "name='ADDA_DL_CH2 DL0_CH2' on"
+	cset "name='UL0_CH1 ADDA_UL_CH1' on"
+	cset "name='UL0_CH2 ADDA_UL_CH2' on"
+	cset "name='UL2_CH1 AP_DMIC_UL_CH1' on"
+	cset "name='UL2_CH2 AP_DMIC_UL_CH2' on"
+	cset "name='PCM_0_PB_CH1 DL2_CH1' on"
+	cset "name='PCM_0_PB_CH2 DL2_CH2' on"
+	cset "name='UL1_CH1 PCM_0_CAP_CH1' on"
+	cset "name='UL1_CH2 PCM_0_CAP_CH2' on"
+	cset "name='I2SOUT5_CH1 DL_24CH_CH1' on"
+	cset "name='I2SOUT5_CH2 DL_24CH_CH2' on"
+	cset "name='I2SOUT5_CH3 DL_24CH_CH3' on"
+	cset "name='I2SOUT5_CH4 DL_24CH_CH4' on"
+	cset "name='I2SOUT5_CH5 DL_24CH_CH5' on"
+	cset "name='I2SOUT5_CH6 DL_24CH_CH6' on"
+	cset "name='I2SOUT5_CH7 DL_24CH_CH7' on"
+	cset "name='I2SOUT5_CH8 DL_24CH_CH8' on"
+	cset "name='I2SOUT5_CH_NUM' 8CH"
+	cset "name='UL1_CH1 I2SIN5_CH1' on"
+	cset "name='UL1_CH2 I2SIN5_CH2' on"
+	cset "name='I2S_OUT5_Mux' Dummy_Widget"
+	cset "name='I2S_IN5_Mux' Dummy_Widget"
+	cset "name='I2SOUT6_CH1 DL3_CH1' on"
+	cset "name='I2SOUT6_CH2 DL3_CH2' on"
+	cset "name='UL3_CH1 I2SIN6_CH1' on"
+	cset "name='UL3_CH2 I2SIN6_CH2' on"
+	cset "name='I2S_OUT6_Mux' Dummy_Widget"
+	cset "name='I2S_IN6_Mux' Dummy_Widget"
+	cset "name='I2SIN6_CLK_SOURCE' APLL"
+	cset "name='I2SIN6_RELATCH_DOMAIN' APLL"
+	cset "name='Mic Type Mux' ACC"
+]

--- a/ucm2/MediaTek/mt8366-evk/mt8366-evk.conf
+++ b/ucm2/MediaTek/mt8366-evk/mt8366-evk.conf
@@ -1,0 +1,9 @@
+Syntax 4
+
+Define {
+	PlayDevN "0"
+	CapDevN "10"
+	CapChanN "1"
+}
+
+Include.init.File "/MediaTek/mt8366-evk/init.conf"

--- a/ucm2/conf.d/mt8366-evk/mt8366-evk.conf
+++ b/ucm2/conf.d/mt8366-evk/mt8366-evk.conf
@@ -1,0 +1,1 @@
+../../MediaTek/mt8366-evk/mt8366-evk.conf


### PR DESCRIPTION
Add alsa-ucm support for the MediaTek mt8366-evk platform.