### PR TITLE
ucm2: Qualcomm: fix device ids for surface pro 12in

### DIFF
--- a/ucm2/Qualcomm/x1e80100/Surface12in-HiFi.conf
+++ b/ucm2/Qualcomm/x1e80100/Surface12in-HiFi.conf
@@ -3,8 +3,8 @@
 
 SectionVerb {
 	EnableSequence [
-		cset "name='WSA_CODEC_DMA_RX_0 Audio Mixer MultiMedia2' 1"
-		cset "name='MultiMedia4 Mixer VA_CODEC_DMA_TX_0' 1"
+		cset "name='WSA_CODEC_DMA_RX_0 Audio Mixer MultiMedia1' 1"
+		cset "name='MultiMedia2 Mixer VA_CODEC_DMA_TX_0' 1"
 	]
 
 	Include.wsae.File "/codecs/wsa884x/two-speakers/DefaultEnableSeq.conf"
@@ -25,7 +25,7 @@ SectionDevice."Speaker" {
 	Value {
 		PlaybackChannels 2
 		PlaybackPriority 100
-		PlaybackPCM "hw:${CardId},1"
+		PlaybackPCM "hw:${CardId},0"
 		PlaybackMixer "default:${CardId}"
 		PlaybackMixerElem "Speakers"
 	}
@@ -41,6 +41,6 @@ SectionDevice."Mic" {
 
 	Value {
 		CapturePriority 100
-		CapturePCM "hw:${CardId},3"
+		CapturePCM "hw:${CardId},1"
 	}
 }


### PR DESCRIPTION
Updated device ids to match updated device values in https://github.com/linux-msm/audioreach-topology/pull/32