### PR TITLE
Jg/revert t14s full mm setup

### DIFF
--- a/ucm2/Qualcomm/x1e80100/T14s-HiFi.conf
+++ b/ucm2/Qualcomm/x1e80100/T14s-HiFi.conf
@@ -123,6 +123,7 @@ SectionDevice."HDMI0" {
 	Value {
 		PlaybackPriority 200
 		PlaybackPCM "hw:${CardId},4"
+		JackControl "DP0 Jack"
 		PlaybackChannels 2
 		JackControl "DP0 Jack"
 	}
@@ -151,6 +152,7 @@ SectionDevice."HDMI1" {
 	Value {
 		PlaybackPriority 200
 		PlaybackPCM "hw:${CardId},5"
+		JackControl "DP1 Jack"
 		PlaybackChannels 2
 		JackControl "DP1 Jack"
 	}
@@ -179,6 +181,7 @@ SectionDevice."HDMI2" {
 	Value {
 		PlaybackPriority 200
 		PlaybackPCM "hw:${CardId},6"
+		JackControl "DP2 Jack"
 		PlaybackChannels 2
 		JackControl "DP2 Jack"
 	}

--- a/ucm2/Qualcomm/x1e80100/T14s-HiFi.conf
+++ b/ucm2/Qualcomm/x1e80100/T14s-HiFi.conf
@@ -3,13 +3,13 @@
 
 SectionVerb {
 	EnableSequence [
+		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia1' 0"
+		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia1' 0"
+		cset "name='DISPLAY_PORT_RX_2 Audio Mixer MultiMedia1' 0"
 		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia1' 1"
 		cset "name='WSA_CODEC_DMA_RX_0 Audio Mixer MultiMedia2' 1"
 		cset "name='MultiMedia3 Mixer TX_CODEC_DMA_TX_3' 1"
 		cset "name='MultiMedia4 Mixer VA_CODEC_DMA_TX_0' 1"
-		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia5' 1"
-		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia6' 1"
-		cset "name='DISPLAY_PORT_RX_2 Audio Mixer MultiMedia7' 1"
 	]
 
 	Include.wsae.File "/codecs/wsa884x/two-speakers/DefaultEnableSeq.conf"
@@ -52,9 +52,9 @@ SectionDevice."Headphones" {
 
 	EnableSequence [
 		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia1' 1"
-		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia5' 0"
-		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia6' 0"
-		cset "name='DISPLAY_PORT_RX_2 Audio Mixer MultiMedia7' 0"
+		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia1' 0"
+		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia1' 0"
+		cset "name='DISPLAY_PORT_RX_2 Audio Mixer MultiMedia1' 0"
 	]
 
 	DisableSequence [
@@ -111,20 +111,18 @@ SectionDevice."HDMI0" {
 
 	EnableSequence [
 		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia1' 0"
-		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia5' 1"
-		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia6' 0"
-		cset "name='DISPLAY_PORT_RX_2 Audio Mixer MultiMedia7' 0"
+		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia1' 1"
+		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia1' 0"
+		cset "name='DISPLAY_PORT_RX_2 Audio Mixer MultiMedia1' 0"
 	]
 
 	DisableSequence [
-		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia5' 0"
+		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia1' 0"
 	]
 
 	Value {
 		PlaybackPriority 200
-		PlaybackPCM "hw:${CardId},4"
-		JackControl "DP0 Jack"
-		PlaybackChannels 2
+		PlaybackPCM "hw:${CardId},0"
 		JackControl "DP0 Jack"
 	}
 }
@@ -140,20 +138,18 @@ SectionDevice."HDMI1" {
 
 	EnableSequence [
 		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia1' 0"
-		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia5' 0"
-		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia6' 1"
-		cset "name='DISPLAY_PORT_RX_2 Audio Mixer MultiMedia7' 0"
+		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia1' 0"
+		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia1' 1"
+		cset "name='DISPLAY_PORT_RX_2 Audio Mixer MultiMedia1' 0"
 	]
 
 	DisableSequence [
-		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia6' 0"
+		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia1' 0"
 	]
 
 	Value {
 		PlaybackPriority 200
-		PlaybackPCM "hw:${CardId},5"
-		JackControl "DP1 Jack"
-		PlaybackChannels 2
+		PlaybackPCM "hw:${CardId},0"
 		JackControl "DP1 Jack"
 	}
 }
@@ -169,20 +165,18 @@ SectionDevice."HDMI2" {
 
 	EnableSequence [
 		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia1' 0"
-		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia5' 0"
-		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia6' 0"
-		cset "name='DISPLAY_PORT_RX_2 Audio Mixer MultiMedia7' 1"
+		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia1' 0"
+		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia1' 0"
+		cset "name='DISPLAY_PORT_RX_2 Audio Mixer MultiMedia1' 1"
 	]
 
 	DisableSequence [
-		cset "name='DISPLAY_PORT_RX_2 Audio Mixer MultiMedia7' 0"
+		cset "name='DISPLAY_PORT_RX_2 Audio Mixer MultiMedia1' 0"
 	]
 
 	Value {
 		PlaybackPriority 200
-		PlaybackPCM "hw:${CardId},6"
-		JackControl "DP2 Jack"
-		PlaybackChannels 2
+		PlaybackPCM "hw:${CardId},0"
 		JackControl "DP2 Jack"
 	}
 }


### PR DESCRIPTION
Unfortunately (or thank god, your choice) [the required topology change](https://github.com/linux-msm/audioreach-topology/pull/59) was declined in Audioreach, with very valid reasons. So, although this works really great on my boxes, it shouldn't be the default ucm config for T14s and same-config laptops. Therefore revert to the previous version that matches what you get from Audioreach.