### PR TITLE
Fixes for cs42l43/cs35l56 bridge speaker amp configs

### DIFF
--- a/ucm2/sof-soundwire/cs35l56-bridge.conf
+++ b/ucm2/sof-soundwire/cs35l56-bridge.conf
@@ -23,8 +23,8 @@ SectionDevice."Speaker" {
 	EnableSequence [
 		cset "name='cs42l43 Speaker L Input 1' 'ASPRX1'"
 		cset "name='cs42l43 Speaker R Input 1' 'ASPRX2'"
-		cset "name='cs42l43 ASPTX1 Input' 'DP5RX1'"
-		cset "name='cs42l43 ASPTX2 Input' 'DP5RX2'"
+		cset "name='cs42l43 ASPTX1 Input' 'DP6RX1'"
+		cset "name='cs42l43 ASPTX2 Input' 'DP6RX2'"
 
 		cset "name='AMPL ASP1 TX1 Source' 'DSP1TX1'"
 		cset "name='AMPL ASP1 TX2 Source' 'None'"
@@ -54,7 +54,7 @@ SectionDevice."Speaker" {
 
 	Value {
 		PlaybackPriority 100
-		PlaybackPCM "hw:${CardId},0"
+		PlaybackPCM "hw:${CardId},2"
 		PlaybackMixer "default:${CardId}"
 		PlaybackMixerElem "Speaker"
 	}

--- a/ucm2/sof-soundwire/cs35l56-bridge.conf
+++ b/ucm2/sof-soundwire/cs35l56-bridge.conf
@@ -16,9 +16,16 @@ LibraryConfig.remap.Config {
 SectionDevice."Speaker" {
 	Comment "Speaker"
 
-	ConflictingDevice [
-		"Headphones"
-	]
+	If.hs_present {
+		Condition {
+			Type String
+			Haystack "${var:HeadsetCodec1}"
+			Needle "cs42l43"
+		}
+		True.ConflictingDevice [
+			"Headphones"
+		]
+	}
 
 	EnableSequence [
 		cset "name='cs42l43 Speaker L Input 1' 'ASPRX1'"


### PR DESCRIPTION
Update a couple of issues with systems where the speaker amps are connected through the codec and the headphone output is not being used on the codec.