### PR TITLE
USB-Audio: M-Audio Fast Track Ultra pcm split fix

### DIFF
--- a/ucm2/USB-Audio/M-Audio/Fast-Track-Ultra-HiFi.conf
+++ b/ucm2/USB-Audio/M-Audio/Fast-Track-Ultra-HiFi.conf
@@ -19,7 +19,7 @@ Macro [
 	}
 	{
 		SplitPCM {
-			Name "fast_track_ultra_mixed_in"
+			Name "fast_track_ultra_mono_in"
 			Direction Capture
 			Channels 1
 			HWChannels 8
@@ -27,6 +27,22 @@ Macro [
 			HWChannelPos1 MONO
 			HWChannelPos2 MONO
 			HWChannelPos3 MONO
+			HWChannelPos4 MONO
+			HWChannelPos5 MONO
+			HWChannelPos6 MONO
+			HWChannelPos7 MONO
+		}
+	}
+	{
+		SplitPCM {
+			Name "fast_track_ultra_stereo_in"
+			Direction Capture
+			Channels 2
+			HWChannels 8
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 FL
+			HWChannelPos3 FR
 			HWChannelPos4 FL
 			HWChannelPos5 FR
 			HWChannelPos6 FL
@@ -321,7 +337,7 @@ SectionDevice."Mic:1" {
 	Comment "Input 1"
 
 	Macro.pcm_split.SplitPCMDevice {
-		Name "fast_track_ultra_mixed_in"
+		Name "fast_track_ultra_mono_in"
 		Direction Capture
 		HWChannels 8
 		Channels 1
@@ -334,7 +350,7 @@ SectionDevice."Mic:2" {
 	Comment "Input 2"
 
 	Macro.pcm_split.SplitPCMDevice {
-		Name "fast_track_ultra_mixed_in"
+		Name "fast_track_ultra_mono_in"
 		Direction Capture
 		HWChannels 8
 		Channels 1
@@ -347,7 +363,7 @@ SectionDevice."Mic:3" {
 	Comment "Input 3"
 
 	Macro.pcm_split.SplitPCMDevice {
-		Name "fast_track_ultra_mixed_in"
+		Name "fast_track_ultra_mono_in"
 		Direction Capture
 		HWChannels 8
 		Channels 1
@@ -360,7 +376,7 @@ SectionDevice."Mic:4" {
 	Comment "Input 4"
 
 	Macro.pcm_split.SplitPCMDevice {
-		Name "fast_track_ultra_mixed_in"
+		Name "fast_track_ultra_mono_in"
 		Direction Capture
 		HWChannels 8
 		Channels 1
@@ -373,7 +389,7 @@ SectionDevice."Line:56" {
 	Comment "Input 5/6"
 
 	Macro.pcm_split.SplitPCMDevice {
-		Name "fast_track_ultra_mixed_in"
+		Name "fast_track_ultra_stereo_in"
 		Direction Capture
 		HWChannels 8
 		Channels 2
@@ -388,7 +404,7 @@ SectionDevice."SPDIF:78" {
 	Comment "Input 7/8 (S/PDIF)"
 
 	Macro.pcm_split.SplitPCMDevice {
-		Name "fast_track_ultra_mixed_in"
+		Name "fast_track_ultra_stereo_in"
 		Direction Capture
 		HWChannels 8
 		Channels 2


### PR DESCRIPTION
The defined mono/stereo devices must contain correct number of channels.

Link: https://github.com/alsa-project/alsa-ucm-conf/issues/781
Fixes: 27d3b45 ("Add UCM2 configuration for M-Audio Fast Track Ultra")