### PR TITLE
ucm2: Qualcomm: add Lenovo Yoga Slim7x Gen11 support

### DIFF
--- a/ucm2/Qualcomm/glymur/LENOVO-Slim-7x.conf
+++ b/ucm2/Qualcomm/glymur/LENOVO-Slim-7x.conf
@@ -1,0 +1,11 @@
+Syntax 4
+
+SectionUseCase."HiFi" {
+	File "/Qualcomm/glymur/Slim7x-HiFi.conf"
+	Comment "HiFi quality Music."
+}
+
+Include.card-init.File "/lib/card-init.conf"
+Include.ctl-remap.File "/lib/ctl-remap.conf"
+Include.wsa-init.File "/codecs/wsa884x/four-speakers/init.conf"
+Include.wsam-init.File "/codecs/qcom-lpass/wsa-macro/four-speakers/init.conf"

--- a/ucm2/Qualcomm/glymur/Slim7x-HiFi.conf
+++ b/ucm2/Qualcomm/glymur/Slim7x-HiFi.conf
@@ -1,0 +1,49 @@
+# Use case configuration for X1E80100.
+# Author: Krzysztof Kozlowski <krzysztof.kozlowski@linaro.org>
+
+SectionVerb {
+	EnableSequence [
+		cset "name='WSA_CODEC_DMA_RX_0 Audio Mixer MultiMedia1' 1"
+		cset "name='MultiMedia2 Mixer VA_CODEC_DMA_TX_0' 1"
+	]
+
+	Include.wsae.File "/codecs/wsa884x/four-speakers/DefaultEnableSeq.conf"
+	Include.wsm1e.File "/codecs/qcom-lpass/wsa-macro/Wsa1SpeakerEnableSeq.conf"
+	Include.wsm2e.File "/codecs/qcom-lpass/wsa-macro/Wsa2SpeakerEnableSeq.conf"
+
+	Value {
+		TQ "HiFi"
+	}
+}
+
+SectionDevice."Speaker" {
+	Comment "Speaker playback"
+
+	Include.wsmspk1e.File "/codecs/qcom-lpass/wsa-macro/Wsa1SpeakerEnableSeq.conf"
+	Include.wsmspk2e.File "/codecs/qcom-lpass/wsa-macro/Wsa2SpeakerEnableSeq.conf"
+	Include.wsmspk1d.File "/codecs/qcom-lpass/wsa-macro/Wsa1SpeakerDisableSeq.conf"
+	Include.wsmspk2d.File "/codecs/qcom-lpass/wsa-macro/Wsa2SpeakerDisableSeq.conf"
+	Include.wsaspk.File "/codecs/wsa884x/four-speakers/SpeakerSeq.conf"
+
+	Value {
+		PlaybackChannels 4
+		PlaybackPriority 100
+		PlaybackPCM "hw:${CardId},0"
+		PlaybackMixer "default:${CardId}"
+		PlaybackMixerElem "Speakers"
+	}
+}
+
+SectionDevice."Mic" {
+	Comment "Internal microphones"
+
+	Include.vadm0e.File "/codecs/qcom-lpass/va-macro/DMIC0EnableSeq.conf"
+	Include.vadm0d.File "/codecs/qcom-lpass/va-macro/DMIC0DisableSeq.conf"
+	Include.vadm1e.File "/codecs/qcom-lpass/va-macro/DMIC1EnableSeq.conf"
+	Include.vadm1d.File "/codecs/qcom-lpass/va-macro/DMIC1DisableSeq.conf"
+
+	Value {
+		CapturePriority 100
+		CapturePCM "hw:${CardId},1"
+	}
+}

--- a/ucm2/Qualcomm/glymur/glymur.conf
+++ b/ucm2/Qualcomm/glymur/glymur.conf
@@ -1,0 +1,13 @@
+Syntax 4
+
+Define.DMI_info "${sys:devices/virtual/dmi/id/board_vendor}-${sys:devices/virtual/dmi/id/product_family}-${sys:devices/virtual/dmi/id/board_name}"
+
+# 4x WSA Speakers | 4x Microphones | 3x DP/HDMI
+If.LENOVOSlim7x {
+	Condition {
+		Type RegexMatch
+		String "${var:DMI_info}"
+		Regex "LENOVO.*(Yoga Slim 7).*"
+	}
+	True.Include.7x.File "/Qualcomm/glymur/LENOVO-Slim-7x.conf"
+}

--- a/ucm2/conf.d/glymur/glymur.conf
+++ b/ucm2/conf.d/glymur/glymur.conf
@@ -1,0 +1,1 @@
+../../Qualcomm/glymur/glymur.conf


### PR DESCRIPTION
Yoga Slim 7x Gen 11 supports:
	- 4 speakers
	- 4 dmics
	- Display ports

This patch adds support to Speaker and DMIC's for now, Display ports are not enabled yet.