### PR TITLE
HDA: Fix internal mic availability for HDA codecs with phantom jack

### DIFF
--- a/ucm2/HDA/HiFi-mic.conf
+++ b/ucm2/HDA/HiFi-mic.conf
@@ -388,6 +388,13 @@ DefineMacro.HDACaptureDevice.SectionDevice."${var:__DevName}" {
 	}
 }
 
+If.phantomjackoverride {
+	Condition {
+		Type ControlExists
+		Control "iface=CARD,name='Internal Mic Phantom Jack'"
+	}
+	True.Define.DeviceMicJack "Internal Mic Phantom Jack"
+}
 If.mic1 {
 	Condition {
 		Type String


### PR DESCRIPTION
## Problem

On HDA codecs that have both a `Mic Jack` (external, unplugged) and an 
`Internal Mic Phantom Jack` (fixed, always-on) control, the internal 
microphone gets assigned `Mic Jack` as its JackControl. PipeWire monitors 
this control for availability and marks the internal mic as "not available" 
since the external jack is unplugged, making it invisible to browsers and 
applications.

Confirmed on: Lenovo IdeaPad Slim 5 16AKP10 with Conexant SN6140 codec 
(PCI SSID 17aa:38b6).

## Fix

Add a block immediately before the `HDACaptureDevice` macro call that 
overrides `DeviceMicJack` to use `Internal Mic Phantom Jack` when that 
control exists. Since phantom jacks always report as connected, PipeWire 
correctly marks the internal mic as available.

The condition is safe for other hardware — if no `Internal Mic Phantom Jack` 
control exists, the block has no effect.

## Known limitation

This fix requires UCM to be loaded for the card. On non-ACP HDA cards, 
`HDA-Intel.conf` does not currently activate UCM, requiring a 
machine-specific workaround. A companion fix to `HDA-Intel.conf` is needed 
but has not been tested broadly enough to include here — input from 
maintainers on the right approach would be welcome.

## Related

A companion kernel patch adding a pin config quirk for the SN6140 on this 
hardware has been submitted to alsa-devel@alsa-project.org.