### PR TITLE
ucm2: Qualcomm: x1e80100: add HDMI/DisplayPort playback

### DIFF
--- a/ucm2/Qualcomm/x1e80100/HiFi.conf
+++ b/ucm2/Qualcomm/x1e80100/HiFi.conf
@@ -7,6 +7,8 @@ SectionVerb {
 		cset "name='WSA_CODEC_DMA_RX_0 Audio Mixer MultiMedia2' 1"
 		cset "name='MultiMedia3 Mixer TX_CODEC_DMA_TX_3' 1"
 		cset "name='MultiMedia4 Mixer VA_CODEC_DMA_TX_0' 1"
+		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia5' 1"
+		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia6' 1"
 	]
 
 	Include.wsae.File "/codecs/wsa884x/four-speakers/DefaultEnableSeq.conf"
@@ -51,6 +53,42 @@ SectionDevice."Headphones" {
 		PlaybackMixerElem "HP"
 		JackControl "Headphone Jack"
 		JackHWMute "Speaker"
+	}
+}
+
+SectionDevice."HDMI0" {
+	Comment "USB/DisplayPort 0 playback"
+
+	EnableSequence [
+		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia5' 1"
+	]
+
+	DisableSequence [
+		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia5' 0"
+	]
+
+	Value {
+		PlaybackPriority 100
+		PlaybackPCM "hw:${CardId},4"
+		JackControl "DP0 Jack"
+	}
+}
+
+SectionDevice."HDMI1" {
+	Comment "USB/DisplayPort 1 playback"
+
+	EnableSequence [
+		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia6' 1"
+	]
+
+	DisableSequence [
+		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia6' 0"
+	]
+
+	Value {
+		PlaybackPriority 200
+		PlaybackPCM "hw:${CardId},5"
+		JackControl "DP1 Jack"
 	}
 }
 


### PR DESCRIPTION
Add two DisplayPort playback devices using different frontends MultiMedia5 and MultiMedia6.