### PR TITLE
rt721: enable capture switches by default

### DIFF
--- a/ucm2/codecs/rt721/init.conf
+++ b/ucm2/codecs/rt721/init.conf
@@ -6,9 +6,11 @@ BootSequence [
 	cset "name='rt721 ADC 10 R Mux' 'DMIC2 FE'"
 	cset "name='rt721 ADC 10 L Mux' 'DMIC2 RE'"
 	cset "name='rt721 ADC 09 Mux' 'MIC2'"
+	cset "name='rt721 FU0F Capture Switch' 1"
+	cset "name='rt721 FU0F Capture Volume' 63"
+	cset "name='rt721 FU1E Capture Switch' 1"
 	cset "name='rt721 FU1E Capture Volume' 63"
 	cset "name='rt721 FU06 Playback Volume' 87"
 	cset "name='rt721 FU05 Playback Volume' 87"
-	cset "name='rt721 FU0F Capture Volume' 63"
 	cset "name='rt721 FU33 Boost Volume' 1"
 ]


### PR DESCRIPTION
Enable FU0F and FU1E capture switches in the RT721 init sequence.
Without these, DMIC and headset microphone capture is muted by default.

This matches the behavior of rt712 and rt713 codecs which both enable
their capture switches in init.conf.

**Hardware tested:**
- ASUS ProArt PX13 HN7306EAC
- AMD ACP70 SoundWire
- RT721 codec
- Card components: `cfg-amp:2 mic:acp-dmic cfg-mics:1 hs:rt721`

**System:**
- Fedora 44
- Kernel 7.0.13-200.fc44.x86_64
- alsa-ucm 1.2.16.1-1.fc44

**Before:** Microphone records silence; `amixer` shows:
- `rt721 FU0F Capture Switch`: off,off
- `rt721 FU1E Capture Switch`: off,off,off,off

**After:** Microphone works; switches enabled by default.

Fixes: #805