### PR TITLE
ucm2: USB-Audio: Add RODECaster Duo

### DIFF
--- a/ucm2/USB-Audio/RODE/RODECaster-Duo-Multitrack-Capture.conf
+++ b/ucm2/USB-Audio/RODE/RODECaster-Duo-Multitrack-Capture.conf
@@ -1,0 +1,238 @@
+Include.pcm_split.File "/common/pcm/split.conf"
+
+Macro.playback.SplitPCM {
+	Name "rodecaster_duo_stereo_in"
+	Direction Capture
+	Channels 2
+	HWChannels 20
+	Device 1
+
+	HWChannelPos0 FL	# Main Mix Left
+	HWChannelPos1 FR	# Main Mix Right
+
+	HWChannelPos2 FL	# Fader 1 Left
+	HWChannelPos3 FR	# Fader 1 Right
+
+	HWChannelPos4 FL	# Fader 2 Left
+	HWChannelPos5 FR	# Fader 2 Right
+
+	HWChannelPos6 FL	# Fader 3 Left
+	HWChannelPos7 FR	# Fader 3 Right
+
+	HWChannelPos8 FL	# Fader 4 Left
+	HWChannelPos9 FR	# Fader 4 Right
+
+	HWChannelPos10 FL	# Virtual Fader 1 Left
+	HWChannelPos11 FR	# Virtual Fader 1 Right
+
+	HWChannelPos12 FL	# Virtual Fader 2 Left
+	HWChannelPos13 FR	# Virtual Fader 2 Right
+
+	HWChannelPos14 FL	# Virtual Fader 3 Left
+	HWChannelPos15 FR	# Virtual Fader 3 Right
+
+	HWChannelPos16 FL	# Virtual Fader 4 Left
+	HWChannelPos17 FR	# Virtual Fader 4 Right
+
+	HWChannelPos18 FL	# Virtual Fader 5 Left
+	HWChannelPos19 FR	# Virtual Fader 5 Right
+}
+
+SectionDevice."Mic" {
+	Comment "Microphone"
+
+	Value {
+		CapturePriority 100
+		CapturePCM "hw:${CardId},0"
+	}
+}
+
+SectionDevice."Line:main" {
+	Comment "Main"
+
+	Value {
+		CapturePriority 110
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "rodecaster_duo_stereo_in"
+		Direction Capture
+		Device 1
+		HWChannels 20
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line:fader_1" {
+	Comment "Fader 1"
+
+	Value {
+		CapturePriority 120
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "rodecaster_duo_stereo_in"
+		Direction Capture
+		Device 1
+		HWChannels 20
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line:fader_2" {
+	Comment "Fader 2"
+
+	Value {
+		CapturePriority 130
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "rodecaster_duo_stereo_in"
+		Direction Capture
+		Device 1
+		HWChannels 20
+		Channels 2
+		Channel0 4
+		Channel1 5
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line:fader_3" {
+	Comment "Fader 3"
+
+	Value {
+		CapturePriority 140
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "rodecaster_duo_stereo_in"
+		Direction Capture
+		Device 1
+		HWChannels 20
+		Channels 2
+		Channel0 6
+		Channel1 7
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line:fader_4" {
+	Comment "Fader 4"
+
+	Value {
+		CapturePriority 150
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "rodecaster_duo_stereo_in"
+		Direction Capture
+		Device 1
+		HWChannels 20
+		Channels 2
+		Channel0 8
+		Channel1 9
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line:fader_virtual_1" {
+	Comment "Virtual Fader 1"
+
+	Value {
+		CapturePriority 160
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "rodecaster_duo_stereo_in"
+		Direction Capture
+		Device 1
+		HWChannels 20
+		Channels 2
+		Channel0 10
+		Channel1 11
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line:fader_virtual_2" {
+	Comment "Virtual Fader 2"
+
+	Value {
+		CapturePriority 170
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "rodecaster_duo_stereo_in"
+		Direction Capture
+		Device 1
+		HWChannels 20
+		Channels 2
+		Channel0 12
+		Channel1 13
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line:fader_virtual_3" {
+	Comment "Virtual Fader 3"
+
+	Value {
+		CapturePriority 180
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "rodecaster_duo_stereo_in"
+		Direction Capture
+		Device 1
+		HWChannels 20
+		Channels 2
+		Channel0 14
+		Channel1 15
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line:fader_virtual_4" {
+	Comment "Virtual Fader 4"
+
+	Value {
+		CapturePriority 190
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "rodecaster_duo_stereo_in"
+		Direction Capture
+		Device 1
+		HWChannels 20
+		Channels 2
+		Channel0 16
+		Channel1 17
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line:fader_virtual_5" {
+	Comment "Virtual Fader 5"
+
+	Value {
+		CapturePriority 200
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "rodecaster_duo_stereo_in"
+		Direction Capture
+		Device 1
+		HWChannels 20
+		Channels 2
+		Channel0 18
+		Channel1 19
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}

--- a/ucm2/USB-Audio/RODE/RODECaster-Duo-Multitrack-Playback.conf
+++ b/ucm2/USB-Audio/RODE/RODECaster-Duo-Multitrack-Playback.conf
@@ -1,0 +1,128 @@
+Include.pcm_split.File "/common/pcm/split.conf"
+
+Macro.playback.SplitPCM {
+	Name "rodecaster_duo_stereo_out"
+	Direction Playback
+	Channels 2
+	HWChannels 10
+	Device 1
+
+	HWChannelPos0 FL	# System Left
+	HWChannelPos1 FR	# System Right
+
+	HWChannelPos2 FL	# Game Left
+	HWChannelPos3 FR	# Game Right
+
+	HWChannelPos4 FL	# Music Left
+	HWChannelPos5 FR	# Music Right
+
+	HWChannelPos6 FL	# Virtual A Left
+	HWChannelPos7 FR	# Virtual A Right
+
+	HWChannelPos8 FL	# Virtual B Left
+	HWChannelPos9 FR	# Virtual B Right
+}
+
+SectionDevice."Speaker" {
+	Comment "System"
+
+	Value {
+		PlaybackPriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "rodecaster_duo_stereo_out"
+		Direction Playback
+		Device 1
+		HWChannels 10
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line:chat" {
+	Comment "Chat"
+
+	Value {
+		PlaybackPCM "hw:${CardId},0"
+		PlaybackPriority 110
+	}
+}
+
+SectionDevice."Line:game" {
+	Comment "Game"
+
+	Value {
+		PlaybackPriority 120
+	}
+	Macro.pcm_split.SplitPCMDevice {
+	Name "rodecaster_duo_stereo_out"
+		Direction Playback
+		Device 1
+		HWChannels 10
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line:music" {
+	Comment "Music"
+
+	Value {
+		PlaybackPriority 130
+	}
+	Macro.pcm_split.SplitPCMDevice {
+	Name "rodecaster_duo_stereo_out"
+		Direction Playback
+		Device 1
+		HWChannels 10
+		Channels 2
+		Channel0 4
+		Channel1 5
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line:virtual_a" {
+	Comment "Virtual A"
+
+	Value {
+		PlaybackPriority 140
+	}
+	Macro.pcm_split.SplitPCMDevice {
+	Name "rodecaster_duo_stereo_out"
+		Direction Playback
+		Device 1
+		HWChannels 10
+		Channels 2
+		Channel0 6
+		Channel1 7
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line:virtual_b" {
+	Comment "Virtual B"
+
+	Value {
+		PlaybackPriority 150
+	}
+	Macro.pcm_split.SplitPCMDevice {
+	Name "rodecaster_duo_stereo_out"
+		Direction Playback
+		Device 1
+		HWChannels 10
+		Channels 2
+		Channel0 8
+		Channel1 9
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}

--- a/ucm2/USB-Audio/RODE/RODECaster-Duo.conf
+++ b/ucm2/USB-Audio/RODE/RODECaster-Duo.conf
@@ -1,0 +1,155 @@
+# The RODECaster Duo has two USB ports.
+# USB1 supports multitrack capture and playback. The PID of USB1 changes depending on the device configuration.
+# USB2 acts as a simple stereo device and has its own PID.
+# The configuration below supports devices running on firmware 1.7.3+.
+
+Comment "RODECaster Duo USB"
+If.usb1 {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB19f7:0050"
+	}
+	True {
+		# Multitrack disabled
+		SectionUseCase."HiFi" {
+			Comment "RODECaster Duo"
+			Config {
+				SectionDevice."Speaker" {
+					Comment "System"
+					Value {
+						PlaybackPCM "hw:${CardId},1"
+						PlaybackPriority 100
+					}
+				}
+				SectionDevice."Line:chat" {
+					Comment "Chat"
+					Value {
+						PlaybackPCM "hw:${CardId},0"
+						PlaybackPriority 110
+					}
+				}
+				SectionDevice."Mic" {
+					Comment "Microphone"
+					Value {
+						CapturePCM "hw:${CardId},0"
+						CapturePriority 100
+					}
+				}
+				SectionDevice."Line:main" {
+					Comment "Main"
+					Value {
+						CapturePCM "hw:${CardId},1"
+						CapturePriority 110
+					}
+				}
+			}
+		}
+	}
+}
+If.usb1_multitrack {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB19f7:0095"
+	}
+	True {
+		# Multitrack Capture and Playback
+		SectionUseCase."HiFi" {
+			Comment "RODECaster Duo"
+			Config {
+				Include.playback.File "/USB-Audio/RODE/RODECaster-Duo-Multitrack-Playback.conf"
+				Include.capture.File "/USB-Audio/RODE/RODECaster-Duo-Multitrack-Capture.conf"
+			}
+		}
+	}
+}
+If.usb1_multitrack_playback {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB19f7:0079"
+	}
+	True {
+		# Multitrack Playback Only
+		SectionUseCase."HiFi" {
+			Comment "RODECaster Duo"
+			Config {
+				Include.playback.File "/USB-Audio/RODE/RODECaster-Duo-Multitrack-Playback.conf"
+				SectionDevice."Mic" {
+					Comment "Microphone"
+					Value {
+						CapturePCM "hw:${CardId},0"
+						CapturePriority 100
+					}
+				}
+				SectionDevice."Line:main" {
+					Comment "Main"
+					Value {
+						CapturePCM "hw:${CardId},1"
+						CapturePriority 110
+					}
+				}
+			}
+		}
+	}
+}
+If.usb1_multitrack_capture {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB19f7:0093"
+	}
+	True {
+		# Multitrack Capture Only
+		SectionUseCase."HiFi" {
+			Comment "RODECaster Duo"
+			Config {
+				Include.capture.File "/USB-Audio/RODE/RODECaster-Duo-Multitrack-Capture.conf"
+				SectionDevice."Speaker" {
+					Comment "System"
+					Value {
+						PlaybackPCM "hw:${CardId},1"
+						PlaybackPriority 100
+					}
+				}
+				SectionDevice."Line:chat" {
+					Comment "Chat"
+					Value {
+						PlaybackPCM "hw:${CardId},0"
+						PlaybackPriority 110
+					}
+				}
+			}
+		}
+	}
+}
+
+If.usb2 {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB19f7:004e"
+	}
+	True {
+		SectionUseCase."HiFi" {
+			Comment "RODECaster Duo"
+			Config {
+				SectionDevice."Speaker" {
+					Comment "Secondary"
+
+					Value {
+						PlaybackPCM "hw:${CardId},0"
+					}
+				}
+				SectionDevice."Mic" {
+					Comment "Secondary"
+
+					Value {
+						CapturePCM "hw:${CardId},0"
+					}
+				}
+			}
+		}
+	}
+}

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -157,6 +157,12 @@ Macro.rode-rodecaster-pro-2.RegexMatch {
 	Id "19f7:00(37|72|78|30|26|92|94)"
 	Profile "RODE/RODECaster-Pro-II"
 }
+Macro.rode-rodecaster-duo.RegexMatch {
+	# RODECaster Duo USB1: 19f7:0050, 19f7:0079, 19f7:0093, 19f7:0095
+	# RODECaster Duo USB2: 19f7:004e
+	Id "19f7:00(50|79|93|95|4e)"
+	Profile "RODE/RODECaster-Duo"
+}
 
 Macro.roland-quadcapture.StringMatch	"Id='0582:012f' Profile='Roland/Quad-Capture'"
 Macro.roland-bridgecast.StringMatch	"Id='0582:02b7' Profile='Roland/BridgeCast'"


### PR DESCRIPTION
This PR adds support for the RODECaster Duo Split PCM configuration.

The RODECaster Duo is technically very similar to the RODECaster Pro II, they even share the same firmware, although channel mappings are sightly different.

This profile has been successfully tested by @csanthiago in [parzival-space/rodecaster-pro-2-virtual-devices-pipewire #7](https://github.com/parzival-space/rodecaster-pro-2-virtual-devices-pipewire/issues/7).