### PR TITLE
USB-Audio: ALC4080: Update NVIDIA DGX front mic jack name

### DIFF
--- a/ucm2/USB-Audio/Realtek/ALC4080-HiFi.conf
+++ b/ucm2/USB-Audio/Realtek/ALC4080-HiFi.conf
@@ -206,17 +206,31 @@ If.nvidia-dgx-station {
 		String "${CardComponents}"
 		Regex "USB(0955:cf0a)"
 	}
-	True.Define {
-		HeadphonesName "Front Line Out"
-		Mic1Name "Front Microphone"
-		Mic1Mindex "1"
-		Mic1Jack "name='Mic - Input Jack',index=1"
-		Mic2Name "Rear Microphone"
-		Mic2Mixer "Mic"
-		Mic2Jack "Mic - Input Jack"
-		Mic2PCM "0"
-		Line1Name "Rear Line Input"
-		SpdifName ""
+	True {
+		Define {
+			HeadphonesName "Front Line Out"
+			Mic1Name "Front Microphone"
+			Mic1Mindex "1"
+			Mic1Jack "name='Mic - Input Jack',index=1"
+			Mic2Name "Rear Microphone"
+			Mic2Mixer "Mic"
+			Mic2Jack "Mic - Input Jack"
+			Mic2PCM "0"
+			Line1Name "Rear Line Input"
+			SpdifName ""
+		}
+
+		If.front_mic_jack {
+			Condition {
+				Type ControlExists
+				Control "iface=CARD,name='Front Mic - Input Jack'"
+			}
+			True.Define {
+				Mic1Mixer "Front Mic"
+				Mic1Mindex "0"
+				Mic1Jack "Front Mic - Input Jack"
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
The ALC4080 codec in NVIDIA DGX exposes the front microphone as the dedicated "Front Mic - Input Jack" terminal. Use this terminal instead of the indexed "Mic - Input Jack",index=1 control, which PipeWire rejects and therefore cannot use to track front-mic availability.

This patch redefines Mic1 according to the codec firmware with the front mic's terminal name.