### PR TITLE
ucm2: Qualcomm: x1e80100: T14s: add Microphone Mute LED

### DIFF
--- a/ucm2/Qualcomm/x1e80100/LENOVO-T14s.conf
+++ b/ucm2/Qualcomm/x1e80100/LENOVO-T14s.conf
@@ -1,4 +1,4 @@
-Syntax 4
+Syntax 6
 
 SectionUseCase."HiFi" {
 	File "/Qualcomm/x1e80100/T14s-HiFi.conf"
@@ -9,6 +9,12 @@ BootSequence [
 	cset "name='HPHL Volume' 20"
 	cset "name='HPHR Volume' 20"
 	cset "name='ADC2 Volume' 10"
+]
+
+Include.led.File "/common/ctl/led.conf"
+Macro [
+	{ CtlNew { Arg="name='Mic LED Capture Switch' type=bool,count=1 off" } }
+	{ SetLED { LED="mic" Action="attach" CtlId="Mic LED Capture Switch" } }
 ]
 
 Include.card-init.File "/lib/card-init.conf"

--- a/ucm2/Qualcomm/x1e80100/T14s-HiFi.conf
+++ b/ucm2/Qualcomm/x1e80100/T14s-HiFi.conf
@@ -97,6 +97,8 @@ SectionDevice."Mic" {
 	Value {
 		CapturePriority 100
 		CapturePCM "hw:${CardId},3"
+		CaptureMixerElem "Mic LED"
+		CaptureSwitch "Mic LED Capture Switch"
 	}
 }
 

--- a/ucm2/Qualcomm/x1e80100/x1e80100.conf
+++ b/ucm2/Qualcomm/x1e80100/x1e80100.conf
@@ -1,4 +1,4 @@
-Syntax 4
+Syntax 6
 
 Define.DMI_info "${sys:devices/virtual/dmi/id/board_vendor}-${sys:devices/virtual/dmi/id/product_family}-${sys:devices/virtual/dmi/id/board_name}"
 


### PR DESCRIPTION
Add support for the Microphone Mute LED in the Keyboard's MicMute Key, which is exposed by the lenovo-thinkpad-t14s EC driver that landed in the 6.18 kernel and uses the "audio-micmute" trigger by default. This works by creating a virtual capture switch and binding the LED to it.

Something similar should be done for the speaker mute LED, but I'm not sure how that is supposed to look like. The Speaker Mute LED automatically toggles when the Speaker Mute Key is pressed, so it seems to work without explicit handling. But it can get out-of-sync, if the mute status is modified in software without using the key.