### PR TITLE
ucm2: USB-Audio: add Topping M62 configuration

### DIFF
--- a/ucm2/USB-Audio/Topping/M62-HiFi.conf
+++ b/ucm2/USB-Audio/Topping/M62-HiFi.conf
@@ -1,0 +1,620 @@
+# Topping M62 (USB 152a:875c), Live Streaming and Pro Audio modes.
+#
+# The card has three operating modes, switched from its own panel, and
+# it encodes the mode in the high byte of bcdDevice: 01xx Mobile, 02xx
+# Live Streaming, 03xx Pro Audio. Mobile Mode is a plain stereo device
+# that declares an honest FL FR channel map, so it gets no profile at
+# all; this file describes the other two, which differ from each other
+# only in the rates they offer.
+#
+# The card exposes ONE ten-channel playback PCM. Those ten channels are
+# not a surround layout: they are five independent STEREO buses that the
+# card's own mixer sums into its outputs (Playback 1/2 ... 9/10 in the
+# manual).
+#
+# The descriptor declares no channel POSITIONS at all -- bmChannelConfig
+# is 0x00000000 on both the ten-channel and the sixteen-channel terminal
+# -- and the card exposes no ALSA channel map either, neither a kcontrol
+# nor a /proc entry. Without a profile the host therefore invents one:
+# PipeWire fills ten unnamed channels with its default surround layout,
+# so the desktop believes in a centre, an LFE and a rear that the
+# hardware does not have, or else hands out AUX0..AUX9. Both readings
+# break more than cosmetics -- the balance control and the speaker test
+# have nothing to work with.
+#
+# It does declare channel NAMES. iChannelNames on the playback terminal
+# points at "Playback 1" and on the capture terminal at "Analogue 1",
+# each the first of a consecutive run of string descriptors, and that is
+# where every name in this file comes from.
+#
+# Each bus is therefore published as its own stereo device, split out of
+# the single PCM. Nothing here is exclusive: the five may play at once,
+# which is the point of the five buses.
+#
+# The card carries all ten playback channels in ONE mixer element and
+# all sixteen capture columns in another, so per-bus volume comes from a
+# control remap: each pair gets its own stereo element cut out of the
+# card's element by channel index, and the mic gets a mono one. This is
+# the same shape the Behringer UMC204HD profile uses.
+#
+# Capture: the card offers a SIXTEEN channel PCM with no channel map at
+# all -- but it does name its channels. Its USB string descriptors read
+# Analogue 1, Analogue 2, AUX 1, AUX 2, BT 1, BT 2, Mobile 1, Mobile 2
+# and Loopback 1 to 8, in that order, and macOS displays exactly those
+# because Core Audio reads iChannelNames from the Input Terminal
+# descriptor. Linux surfaces none of it: ALSA carries channel POSITIONS
+# through chmap and has no notion of a channel NAME, so the host sees
+# an anonymous sixteen. The names below are the card's own, read out of
+# the device.
+#
+# The naming was also confirmed by measurement, one column at a time:
+# feeding the microphone input lights column 0, and a headphone-to-AUX
+# loop lights columns 2 and 3.
+#
+# The two microphone columns are published as two mono devices, and NOT
+# additionally as one stereo device covering both. A stereo pair would
+# be useful -- a balanced source arrives on both at once -- but it can
+# only be declared as conflicting with the two halves, and alsa-lib
+# treats a conflict list as a group of mutually exclusive devices: it
+# closes the relation transitively, so a stereo device conflicting with
+# each half makes the two halves conflict with each other. Two
+# microphones that work perfectly well at the same time would then be
+# offered only one at a time, which is the worse loss. Expressing it
+# the other way round, as SupportedDevice, fails for the same reason:
+# the closure fills the lists until nothing excludes anything, and all
+# three end up coexisting and fighting over the preamps they share.
+#
+# Columns 0 to 7 -- Analogue, AUX, Bluetooth and Mobile -- all carry
+# audio, and all four inputs record at once: a sixteen column recording
+# with a phone on Bluetooth and another on OTG shows signal on 0, 2, 3,
+# 4, 5, 6 and 7 simultaneously. All four are therefore declared.
+#
+# Columns 8 to 15 are the eight loopback returns, and the card brings
+# them up MUTED: Mic Capture Switch carries one value per column and
+# reads on for the first eight and off for the rest, so those columns
+# deliver digital silence until something turns them on. The verb's
+# EnableSequence turns all sixteen on, after which the returns carry
+# audio like the rest and are declared here as four stereo devices.
+#
+# Their level is the digital trim, as it is for every input on this
+# card; the vendor's own loopback gain lives behind the control panel
+# and is not visible to ALSA.
+#
+# The inputs are ordered by priority the way the card's own control
+# application lists them -- IN 1, IN 2, IN 1 + 2, AUX, BT, OTG IN --
+# because that order is the manufacturer's own idea of the device and
+# a person who has used the card already knows it.
+#
+# The two microphone channels are named IN 1 and IN 2, as the card's own
+# panel and control application name them, and NOT after jacks: IN 1 is
+# switched on the card between its 6.3 mm jack, its 3.5 mm jack and the
+# headset jack. The switch lives in the card's panel, Linux can neither
+# read it nor set it, so a name like "Mic 3.5" would be a claim the
+# driver cannot back. Which jack fed a recording is the operator's
+# knowledge. The pair is also offered together as IN 1 + 2, for a
+# balanced stereo source that arrives on both at once.
+
+Include.pcm_split.File "/common/pcm/split.conf"
+
+Macro [
+	{
+		SplitPCM {
+			Name "m62_stereo_out"
+			Direction Playback
+			Format S32_LE
+			Channels 2
+			HWChannels 10
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 FL
+			HWChannelPos3 FR
+			HWChannelPos4 FL
+			HWChannelPos5 FR
+			HWChannelPos6 FL
+			HWChannelPos7 FR
+			HWChannelPos8 FL
+			HWChannelPos9 FR
+		}
+	}
+	{
+		SplitPCM {
+			Name "m62_mono_in"
+			Direction Capture
+			Format S32_LE
+			Channels 1
+			HWChannels 16
+			HWChannelPos0 MONO
+			HWChannelPos1 MONO
+			HWChannelPos2 MONO
+			HWChannelPos3 MONO
+			HWChannelPos4 MONO
+			HWChannelPos5 MONO
+			HWChannelPos6 MONO
+			HWChannelPos7 MONO
+			HWChannelPos8 MONO
+			HWChannelPos9 MONO
+			HWChannelPos10 MONO
+			HWChannelPos11 MONO
+			HWChannelPos12 MONO
+			HWChannelPos13 MONO
+			HWChannelPos14 MONO
+			HWChannelPos15 MONO
+		}
+	}
+	{
+		SplitPCM {
+			Name "m62_stereo_in12"
+			Direction Capture
+			Format S32_LE
+			Channels 2
+			HWChannels 16
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 MONO
+			HWChannelPos3 MONO
+			HWChannelPos4 MONO
+			HWChannelPos5 MONO
+			HWChannelPos6 MONO
+			HWChannelPos7 MONO
+			HWChannelPos8 MONO
+			HWChannelPos9 MONO
+			HWChannelPos10 MONO
+			HWChannelPos11 MONO
+			HWChannelPos12 MONO
+			HWChannelPos13 MONO
+			HWChannelPos14 MONO
+			HWChannelPos15 MONO
+		}
+	}
+	{
+		SplitPCM {
+			Name "m62_stereo_in"
+			Direction Capture
+			Format S32_LE
+			Channels 2
+			HWChannels 16
+			HWChannelPos0 MONO
+			HWChannelPos1 MONO
+			HWChannelPos2 FL
+			HWChannelPos3 FR
+			HWChannelPos4 MONO
+			HWChannelPos5 MONO
+			HWChannelPos6 MONO
+			HWChannelPos7 MONO
+			HWChannelPos8 MONO
+			HWChannelPos9 MONO
+			HWChannelPos10 MONO
+			HWChannelPos11 MONO
+			HWChannelPos12 MONO
+			HWChannelPos13 MONO
+			HWChannelPos14 MONO
+			HWChannelPos15 MONO
+		}
+	}
+]
+
+Include.ctl_remap.File "/common/ctl/remap.conf"
+
+# EVERY CAPTURE COLUMN ON. The eight loopback returns arrive muted --
+# see the note on columns 8 to 15 above -- and nothing else on the
+# system turns them on, so without this the card looks as though its
+# loopbacks do not reach USB at all.
+SectionVerb {
+	EnableSequence [
+		cset "name='Mic Capture Switch' 1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1"
+		cset "name='Mic Capture Switch',index=1 1"
+	]
+}
+
+If.macro {
+	Condition { Type AlwaysTrue }
+	True.Macro [
+		{
+			CtlRemapStereoVolSw {
+				Dst "Out 1-2 Playback"
+				Src "M62 Playback"
+				Index0 0
+				Index1 1
+			}
+		}
+		{
+			CtlRemapStereoVolSw {
+				Dst "Out 3-4 Playback"
+				Src "M62 Playback"
+				Index0 2
+				Index1 3
+			}
+		}
+		{
+			CtlRemapStereoVolSw {
+				Dst "Out 5-6 Playback"
+				Src "M62 Playback"
+				Index0 4
+				Index1 5
+			}
+		}
+		{
+			CtlRemapStereoVolSw {
+				Dst "Out 7-8 Playback"
+				Src "M62 Playback"
+				Index0 6
+				Index1 7
+			}
+		}
+		{
+			CtlRemapStereoVolSw {
+				Dst "Out 9-10 Playback"
+				Src "M62 Playback"
+				Index0 8
+				Index1 9
+			}
+		}
+		{
+			CtlRemapMonoVolSw {
+				Dst "Mic1 Capture"
+				Src "Mic Capture"
+				Index 0
+			}
+		}
+		{
+			CtlRemapMonoVolSw {
+				Dst "Mic2 Capture"
+				Src "Mic Capture"
+				Index 1
+			}
+		}
+		{
+			CtlRemapStereoVolSw {
+				Dst "In 1-2 Capture"
+				Src "Mic Capture"
+				Index0 0
+				Index1 1
+			}
+		}
+		{
+			CtlRemapStereoVolSw {
+				Dst "Aux Capture"
+				Src "Mic Capture"
+				Index0 2
+				Index1 3
+			}
+		}
+		{
+			CtlRemapStereoVolSw {
+				Dst "BT Capture"
+				Src "Mic Capture"
+				Index0 4
+				Index1 5
+			}
+		}
+		{
+			CtlRemapStereoVolSw {
+				Dst "OTG Capture"
+				Src "Mic Capture"
+				Index0 6
+				Index1 7
+			}
+		}
+		{
+			CtlRemapStereoVolSw {
+				Dst "LB 1-2 Capture"
+				Src "Mic Capture"
+				Index0 8
+				Index1 9
+			}
+		}
+		{
+			CtlRemapStereoVolSw {
+				Dst "LB 3-4 Capture"
+				Src "Mic Capture"
+				Index0 10
+				Index1 11
+			}
+		}
+		{
+			CtlRemapStereoVolSw {
+				Dst "LB 5-6 Capture"
+				Src "Mic Capture"
+				Index0 12
+				Index1 13
+			}
+		}
+		{
+			CtlRemapStereoVolSw {
+				Dst "LB 7-8 Capture"
+				Src "Mic Capture"
+				Index0 14
+				Index1 15
+			}
+		}
+	]
+}
+
+SectionDevice."Line1" {
+	Comment "Playback 1/2"
+
+	Value {
+		PlaybackPriority 500
+		PlaybackMixer "default:${CardId}"
+		PlaybackMixerElem "Out 1-2"
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "m62_stereo_out"
+		Direction Playback
+		HWChannels 10
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line2" {
+	Comment "Playback 3/4"
+
+	Value {
+		PlaybackPriority 400
+		PlaybackMixer "default:${CardId}"
+		PlaybackMixerElem "Out 3-4"
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "m62_stereo_out"
+		Direction Playback
+		HWChannels 10
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line3" {
+	Comment "Playback 5/6"
+
+	Value {
+		PlaybackPriority 300
+		PlaybackMixer "default:${CardId}"
+		PlaybackMixerElem "Out 5-6"
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "m62_stereo_out"
+		Direction Playback
+		HWChannels 10
+		Channels 2
+		Channel0 4
+		Channel1 5
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line4" {
+	Comment "Playback 7/8"
+
+	Value {
+		PlaybackPriority 200
+		PlaybackMixer "default:${CardId}"
+		PlaybackMixerElem "Out 7-8"
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "m62_stereo_out"
+		Direction Playback
+		HWChannels 10
+		Channels 2
+		Channel0 6
+		Channel1 7
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line5" {
+	Comment "Playback 9/10"
+
+	Value {
+		PlaybackPriority 100
+		PlaybackMixer "default:${CardId}"
+		PlaybackMixerElem "Out 9-10"
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "m62_stereo_out"
+		Direction Playback
+		HWChannels 10
+		Channels 2
+		Channel0 8
+		Channel1 9
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."In1" {
+	Comment "IN 1"
+
+	Value {
+		CapturePriority 300
+		CaptureMixer "default:${CardId}"
+		CaptureMixerElem "Mic1"
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "m62_mono_in"
+		Direction Capture
+		HWChannels 16
+		Channels 1
+		Channel0 0
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."In2" {
+	Comment "IN 2"
+
+	Value {
+		CapturePriority 250
+		CaptureMixer "default:${CardId}"
+		CaptureMixerElem "Mic2"
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "m62_mono_in"
+		Direction Capture
+		HWChannels 16
+		Channels 1
+		Channel0 1
+		ChannelPos0 MONO
+	}
+}
+
+
+SectionDevice."Aux" {
+	Comment "AUX"
+
+	Value {
+		CapturePriority 150
+		CaptureMixer "default:${CardId}"
+		CaptureMixerElem "Aux"
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "m62_stereo_in"
+		Direction Capture
+		HWChannels 16
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+# Bluetooth and the mobile (OTG) input. The card names these channels
+# itself -- its USB string descriptors read Analogue 1/2, AUX 1/2,
+# BT 1/2, Mobile 1/2 and Loopback 1..8, and macOS shows exactly those
+# because Core Audio reads iChannelNames from the Input Terminal
+# descriptor. Both pairs carry audio, alongside the analogue inputs and
+# at the same time as them.
+SectionDevice."BT" {
+	Comment "BT"
+
+	Value {
+		CapturePriority 100
+		CaptureMixer "default:${CardId}"
+		CaptureMixerElem "BT"
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "m62_stereo_in"
+		Direction Capture
+		HWChannels 16
+		Channels 2
+		Channel0 4
+		Channel1 5
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."OTG" {
+	Comment "OTG IN"
+
+	Value {
+		CapturePriority 50
+		CaptureMixer "default:${CardId}"
+		CaptureMixerElem "OTG"
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "m62_stereo_in"
+		Direction Capture
+		HWChannels 16
+		Channels 2
+		Channel0 6
+		Channel1 7
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+# The four loopback returns. Each carries whatever the card's own panel
+# has assigned to it -- a playback bus, Bluetooth, the mobile input --
+# summed inside the card and sent back over USB. They sit below the
+# physical inputs in priority because a return is what the card is
+# already playing rather than something arriving from outside.
+
+SectionDevice."LB12" {
+	Comment "Loopback 1/2"
+
+	Value {
+		CapturePriority 40
+		CaptureMixer "default:${CardId}"
+		CaptureMixerElem "LB 1-2"
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "m62_stereo_in"
+		Direction Capture
+		HWChannels 16
+		Channels 2
+		Channel0 8
+		Channel1 9
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."LB34" {
+	Comment "Loopback 3/4"
+
+	Value {
+		CapturePriority 30
+		CaptureMixer "default:${CardId}"
+		CaptureMixerElem "LB 3-4"
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "m62_stereo_in"
+		Direction Capture
+		HWChannels 16
+		Channels 2
+		Channel0 10
+		Channel1 11
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."LB56" {
+	Comment "Loopback 5/6"
+
+	Value {
+		CapturePriority 20
+		CaptureMixer "default:${CardId}"
+		CaptureMixerElem "LB 5-6"
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "m62_stereo_in"
+		Direction Capture
+		HWChannels 16
+		Channels 2
+		Channel0 12
+		Channel1 13
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."LB78" {
+	Comment "Loopback 7/8"
+
+	Value {
+		CapturePriority 10
+		CaptureMixer "default:${CardId}"
+		CaptureMixerElem "LB 7-8"
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "m62_stereo_in"
+		Direction Capture
+		HWChannels 16
+		Channels 2
+		Channel0 14
+		Channel1 15
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}

--- a/ucm2/USB-Audio/Topping/M62.conf
+++ b/ucm2/USB-Audio/Topping/M62.conf
@@ -1,0 +1,19 @@
+Comment "Topping M62"
+
+SectionUseCase."HiFi" {
+	Comment "Default"
+	File "/USB-Audio/Topping/M62-HiFi.conf"
+}
+
+Include.dhw.File "/common/directm.conf"
+
+Macro.0.DirectUseCase { Id="Direct" PlaybackChannels=10 CaptureChannels=16 }
+
+# The raw verb needs the same unmute as HiFi: the card brings its eight
+# loopback returns up muted, and Direct is precisely where someone asks
+# for all sixteen columns, so it is the verb where silence on half of
+# them misleads most.
+If.unmute.Prepend.SectionUseCase."Direct".Config.SectionVerb.EnableSequence [
+	cset "name='Mic Capture Switch' 1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1"
+	cset "name='Mic Capture Switch',index=1 1"
+]

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -247,6 +247,31 @@ Macro.behringer-umc404hd.StringMatch	"Id='1397:0509' Profile='Behringer/UMC404HD
 Macro.behringer-Flow8-str.StringMatch	"Id='1397:050d' Profile='Behringer/Flow8-Streaming'"
 Macro.behringer-Flow8-rec.StringMatch	"Id='1397:050c' Profile='Behringer/Flow8-Recording'"
 Macro.Rane-SL-1.StringMatch		"Id='13e5:0001' Profile='Rane/SL-1'"
+
+# Topping M62. The operating mode is encoded in the high byte of
+# bcdDevice: 01xx Mobile Mode, 02xx Live Streaming Mode, 03xx Pro Audio
+# Mode. Mobile Mode is a plain stereo device that declares an honest
+# FL FR channel map and needs no profile; the other two expose the five
+# stereo buses and the sixteen column capture the profile describes.
+If.topping-m62 {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB152a:875c"
+	}
+	True.If.mode {
+		Condition {
+			Type RegexMatch
+			String "${sys-card:device/../bcdDevice}"
+			Regex "^0[23]"
+		}
+		True.Define {
+			ProfileName "Topping/M62"
+			MixerRemap "yes"
+		}
+	}
+}
+
 Macro.lenovo-p620-rear.StringMatch	"Id='17aa:1046' Profile='Lenovo/ThinkStation-P620-Rear'"
 Macro.lenovo-p620-main.StringMatch	"Id='17aa:104d' Profile='Lenovo/ThinkStation-P620-Main'"
 Macro.kontrolz1.StringMatch		"Id='17cc:1210' Profile='NativeInstruments/Traktor-Kontrol-Z1'"


### PR DESCRIPTION
ucm2: USB-Audio: add Topping M62 configuration
 
The M62 exposes a single ten channel playback PCM and a single sixteen
channel capture PCM. The ten playback channels are not a surround
layout: they are five independent stereo buses that the card's own
mixer sums into its outputs, named Playback 1/2 to Playback 9/10 in the
manual.
 
The descriptor declares no channel positions at all -- bmChannelConfig
is 0x00000000 on both the ten channel and the sixteen channel terminal
-- and the card exposes no ALSA channel map either, neither a kcontrol
nor a /proc entry. Without a profile the host therefore invents one:
PipeWire fills ten unnamed channels with its default surround layout,
so the desktop believes in a centre, an LFE and a rear that the
hardware does not have, or else hands out AUX0..AUX9. Both readings
break more than cosmetics: the balance control and the speaker test
have nothing to work with, and any per device equalisation carries ten
channel keys where two are meant.
 
Each bus is therefore published as its own stereo device, split out of
the one PCM. The five are not marked conflicting: they may play at
once, which is the point of having five.
 
What the card does declare is channel NAMES. iChannelNames points at
"Playback 1" on the playback terminal and at "Analogue 1" on the
capture terminal, each the first of a consecutive run of string
descriptors, and the run reads Analogue 1, Analogue 2, AUX 1, AUX 2,
BT 1, BT 2, Mobile 1, Mobile 2 and Loopback 1 to 8. macOS displays
exactly those because Core Audio follows that field. Every name in
this profile comes from there. Linux surfaces none
of it: ALSA carries channel positions through chmap and has no notion
of a channel name, so the host sees an anonymous sixteen and this
profile is where the names can live. The order was confirmed by
measurement as well, one column at a time -- feeding the microphone
input lights column 0, and a headphone to AUX loop lights columns 2
and 3.
 
The inputs are therefore published under the names the card's own
panel and control application use: IN 1, IN 2, AUX, BT and OTG IN. The
two microphone channels are named after the card's mic channels and not
after jacks, because IN 1 is switched on the card between its own
6.3 mm jack, the 3.5 mm jack and the headset jack; that switch lives in
the card's own panel and is not visible to the driver, so a jack name
would be a claim the configuration cannot back.
 
The two microphone channels are offered as two mono devices and not
additionally as one stereo device covering both. A stereo pair would be
useful, since a balanced source arrives on both at once, but it can only
be declared as conflicting with the two halves, and alsa-lib treats a
conflict list as a group of mutually exclusive devices: it closes the
relation transitively, so a stereo device conflicting with each half
makes the two halves conflict with each other. Two microphones that work
perfectly well at the same time would then be offered only one at a
time, which is the worse loss. Expressing it the other way round, as
SupportedDevice, fails for the same reason: the closure fills the lists
until nothing excludes anything, and all three end up coexisting and
overwriting each other's preamp gain.
 
Bluetooth and Mobile carry audio, and all four inputs record at once: a
sixteen channel recording with a phone on Bluetooth and another on OTG
shows signal on the analogue, AUX, Bluetooth and Mobile columns
simultaneously.
 
The eight loopback returns arrive MUTED. Mic Capture Switch carries one
value per capture column and reads on for the first eight and off for
the rest, so columns 8 to 15 deliver digital silence until something
turns them on. That is why they look as though the loop never reaches
the USB stream, while the vendor's control panel meters it happily and
while the same card delivers those returns to a host whose software
turns the switch on. The verb turns all sixteen on, and the four
returns are then declared as stereo devices, below the physical inputs
in priority because a return is what the card is already playing rather
than something arriving from outside. The Direct verb unmutes them too:
it is where someone asks for all sixteen columns at once, so it is the
verb where silence on half of them misleads most.
 
The card keeps all ten playback channels in one mixer element and all
sixteen capture columns in another, so the per bus and per input
volumes come from a control remap by channel index, in the same shape
the Behringer UMC204HD profile uses.
 
The card has three operating modes, switched from its own panel, and
all three keep the same USB id. Mobile Mode is a plain stereo device
with an honest FL FR channel map on both directions and needs no
profile; applying this one to it would ask a two channel PCM for ten.
The mode is encoded in the high byte of bcdDevice, 01xx Mobile, 02xx
Live Streaming, 03xx Pro Audio, so the profile is selected only for the
latter two. Live Streaming and Pro Audio have identical channel layouts
and differ only in the rates they offer, 44.1 and 48 kHz against those
plus 88.2 and 96 kHz.
 
Tested on Fedora with alsa-lib 1.2.16 and PipeWire in all three modes:
in Live Streaming and Pro Audio the five sinks and the named sources
appear as expected, playback lands on the intended pair, each remapped
element moves only its own channels, and a sixteen column recording
confirms the input columns, the loopback returns among them once the
verb has unmuted them; in Mobile Mode the card is left to the generic
configuration.

Signed-off-by: Mikhail Gavrilov <mikhail.v.gavrilov@gmail.com>

Attached alsa-info from all three modes. The `bcdDevice` value is what the profile keys on:

| Mode | bcdDevice | Playback | Capture | Rates (kHz) | Profile |
| --- | --- | --- | --- | --- | --- |
| [alsa-info-MobileMode.txt](https://github.com/user-attachments/files/30801211/alsa-info-MobileMode.txt) | 0145 | 2ch, FL FR | 2ch, FL FR | 44.1, 48 | not applied |
| [alsa-info-LiveStreamingMode.txt](https://github.com/user-attachments/files/30801208/alsa-info-LiveStreamingMode.txt)| 0248 | 10ch | 16ch | 44.1, 48 | applied |
| [alsa-info-ProAudioMode.txt](https://github.com/user-attachments/files/30801204/alsa-info-ProAudioMode.txt) | 0327 | 10ch | 16ch | 44.1, 48, 88.2, 96 | applied |

In the two ten channel modes the descriptor declares the channel map `FL FR FC LFE RL RR FLC FRC RC SL`, which the hardware does not have: those are five stereo buses. Mobile Mode declares `FL FR` on both directions and is left to the generic configuration.