### PR TITLE
Add Arturia Audiofuse Studio to USB-Audio

### DIFF
--- a/ucm2/USB-Audio/Arturia/Audiofuse-Studio-HiFi.conf
+++ b/ucm2/USB-Audio/Arturia/Audiofuse-Studio-HiFi.conf
@@ -1,0 +1,192 @@
+Include.pcm_split.File "/common/pcm/split.conf"
+
+Define {
+	HasLine3 "y"
+	HasMic1 "y"
+	HasMic2 "y"
+}
+
+If.audiofusestudio {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB1c75:af02"
+	}
+	True.Define {
+		HasLine3 ""
+		HasMic2 ""
+	}
+}
+
+Macro [
+	{
+		SplitPCM {
+			Name "audiofusestudio_stereo_out"
+			Direction Playback
+			Format S32_LE
+			Channels 2
+			HWChannels 4
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 FL
+			HWChannelPos3 FR
+		}
+	}
+	{
+		SplitPCM {
+			Name "audiofusestudio_stereo_in"
+			Direction Capture
+			Format S32_LE
+			Channels 2
+			HWChannels 4
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+			HWChannelPos2 FL
+			HWChannelPos3 FR
+		}
+	}
+	{
+		SplitPCM {
+			Name "audiofusestudio_mono_in"
+			Direction Capture
+			Format S32_LE
+			Channels 1
+			HWChannels 4
+			HWChannelPos0 MONO
+			HWChannelPos1 MONO
+			HWChannelPos2 MONO
+			HWChannelPos3 MONO
+		}
+	}
+]
+
+DefineMacro.ConflictingLine3 {
+	If.0 {
+		Condition {
+			Type String
+			Empty "${var:HasLine3}"
+		}
+		False.ConflictingDevice [
+			"Line3"
+		]
+	}
+}
+
+SectionDevice."Line1" {
+	Comment "Main Output L/R"
+
+	Value {
+		PlaybackPriority 300
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "audiofusestudio_stereo_out"
+		Direction Playback
+		HWChannels 4
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+SectionDevice."Line2" {
+	Comment "Loopback L/R"
+
+	Value {
+		PlaybackPriority 200
+		CapturePriority 200
+	}
+	Macro.pcm_split1.SplitPCMDevice {
+		Name "audiofusestudio_stereo_out"
+		Direction Playback
+		HWChannels 4
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+	Macro.pcm_split2.SplitPCMDevice {
+		Name "audiofusestudio_stereo_in"
+		Direction Capture
+		HWChannels 4
+		Channels 2
+		Channel0 2
+		Channel1 3
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+If.line3 {
+	Condition {
+		Type String
+		Empty "${var:HasLine3}"
+	}
+	False.SectionDevice."Line3" {
+		Comment "Stereo Input 1+2 L/R"
+
+		Value {
+			CapturePriority 100
+		}
+		Macro.pcm_split.SplitPCMDevice {
+			Name "audiofusestudio_stereo_in"
+			Direction Capture
+			HWChannels 4
+			Channels 2
+			Channel0 0
+			Channel1 1
+			ChannelPos0 FL
+			ChannelPos1 FR
+		}
+	}
+}
+
+If.mic1 {
+	Condition {
+		Type String
+		Empty "${var:HasMic1}"
+	}
+	False.SectionDevice."Mic1" {
+		Comment "Mic/Line/Inst 1 (L)"
+
+		Macro.conflict.ConflictingLine3 { }
+
+		Value {
+			CapturePriority 400
+		}
+		Macro.pcm_split2.SplitPCMDevice {
+			Name "audiofusestudiostudio_mono_in"
+			Direction Capture
+			HWChannels 4
+			Channels 1
+			Channel0 0
+			ChannelPos0 MONO
+		}
+	}
+}
+
+If.mic2 {
+	Condition {
+		Type String
+		Empty "${var:HasMic2}"
+	}
+	False.SectionDevice."Mic2" {
+		Comment "Mic/Line/Inst 2 (R)"
+
+		Macro.conflict.ConflictingLine3 { }
+
+		Value {
+			CapturePriority 300
+		}
+		Macro.pcm_split2.SplitPCMDevice {
+			Name "audiofusestudio_mono_in"
+			Direction Capture
+			HWChannels 4
+			Channels 1
+			Channel0 1
+			ChannelPos0 MONO
+		}
+	}
+}

--- a/ucm2/USB-Audio/Arturia/Audiofuse-Studio-HiFi.conf
+++ b/ucm2/USB-Audio/Arturia/Audiofuse-Studio-HiFi.conf
@@ -6,7 +6,7 @@ Define {
 	HasMic2 "y"
 }
 
-If.audiofusestudio {
+If.audiofuse{
 	Condition {
 		Type String
 		Haystack "${CardComponents}"

--- a/ucm2/USB-Audio/Arturia/Audiofuse-Studio.conf
+++ b/ucm2/USB-Audio/Arturia/Audiofuse-Studio.conf
@@ -1,0 +1,10 @@
+Comment "Arturia Audiofuse Studio"
+
+SectionUseCase."HiFi" {
+	Comment "Default Alsa Profile"
+	File "/USB-Audio/Arturia/Audiofuse-Studio-HiFi.conf"
+}
+
+Include.dhw.File "/common/directm.conf"
+
+Macro.0.DirectUseCase { Id="Direct" PlaybackChannels=4 CaptureChannels=4 }


### PR DESCRIPTION
Hi there! This PR adds the Arturia Audiofuse Studio interface to USB-Audio.

I implemented the patch written in this issue:
https://github.com/alsa-project/alsa-ucm-conf/issues/568