### PR TITLE
Add Blue Snowball UCM Mono Profile

### DIFF
--- a/ucm2/USB-Audio/BlueSnowball/BlueSnowball.conf
+++ b/ucm2/USB-Audio/BlueSnowball/BlueSnowball.conf
@@ -1,0 +1,6 @@
+Syntax 3
+
+SectionUseCase."HiFi" {
+    Comment "Blue Snowball"
+    File "BlueSnowball/HiFi.conf"
+}

--- a/ucm2/USB-Audio/BlueSnowball/HiFi.conf
+++ b/ucm2/USB-Audio/BlueSnowball/HiFi.conf
@@ -1,0 +1,26 @@
+Syntax 3
+
+SectionUseCase."HiFi" {
+    Comment "Blue Snowball"
+}
+
+SectionDefaults [
+    cset "name='Mic Capture Volume' 100%"
+    cset "name='Mic Capture Switch' on"
+]
+
+SectionDevice."Mic" {
+    Comment "Microphone"
+    Value {
+        CapturePriority 100
+        CapturePCM "hw:${CardId},0"
+        CaptureChannels "1"
+        CaptureChannelMap "0:0"
+    }
+    EnableSequence [
+        cdev "hw:${CardId}"
+    ]
+    DisableSequence [
+        cdev "hw:${CardId}"
+    ]
+}

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -272,6 +272,16 @@ Macro.ssl2.RegexMatch			"Id='31e9:000[1289]' Profile='SolidStateLabs/SSL2'"
 Macro.beacn-mic.StringMatch		"Id='33ae:0001' Profile='Beacn/Beacn-Mic'"
 Macro.beacn-studio.RegexMatch		"Id='33ae:[04]003' Profile='Beacn/Beacn-Studio'"
 
+# Blue Snowball - C-Media / Blue variants - mono-only, stalls on stereo/48k
+Macro.blue-snowball.RegexMatch {
+        # 0d8c:0005 - Generic C-Media Blue Snowball (your pid_0005)
+        # 1130:4800 - Blue Snowball (Tenx variant)
+        # 0b0e:0410 - Blue Snowball v1
+        # 0b0e:0305 - Blue Snowball v2 / Snowball iCE
+        Id "((0d8c:0005)|(1130:4800)|(0b0e:0410)|(0b0e:0305))"
+        Profile "BlueSnowball/BlueSnowball"
+}
+
 #
 # end of device specific configuration block
 #


### PR DESCRIPTION
This forces the microphone to be detected as a mono input device correctly. This fixes a hardware crash caused by OBS attempting to access two PCM channels in low latency mode at launch. Without this the microphone works in stereo, when OBS isn't running.