### PR TITLE
ucm2: Qualcomm: add Radxa Dragon Q8B support

### DIFF
--- a/ucm2/Qualcomm/sc8280xp/Dragon-Q8B-HiFi.conf
+++ b/ucm2/Qualcomm/sc8280xp/Dragon-Q8B-HiFi.conf
@@ -1,0 +1,127 @@
+SectionVerb {
+	EnableSequence [
+		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia1' 1"
+		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia2' 1"
+		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia3' 1"
+		cset "name='DISPLAY_PORT_RX_2 Audio Mixer MultiMedia4' 1"
+		cset "name='MultiMedia5 Mixer TX_CODEC_DMA_TX_3' 1"
+	]
+
+	DisableSequence [
+		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia2' 0"
+		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia3' 0"
+		cset "name='DISPLAY_PORT_RX_2 Audio Mixer MultiMedia4' 0"
+	]
+
+	Value {
+		TQ "HiFi"
+	}
+}
+
+SectionDevice."HDMI0" {
+	Comment "Type-C / DisplayPort 0 playback"
+
+	ConflictingDevice [
+		"HDMI1"
+		"HDMI2"
+	]
+
+	EnableSequence [
+		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia2' 1"
+	]
+
+	DisableSequence [
+		# Keep DP routes up while the HiFi verb is active. PipeWire opens
+		# the PCM before running the target device EnableSequence when
+		# switching between conflicting HDMI devices.
+	]
+
+	Value {
+		PlaybackPriority 100
+		PlaybackPCM "hw:${CardId},1"
+		JackControl "DP0 Jack"
+	}
+}
+
+SectionDevice."HDMI1" {
+	Comment "Type-C / DisplayPort 1 playback"
+
+	ConflictingDevice [
+		"HDMI0"
+		"HDMI2"
+	]
+
+	EnableSequence [
+		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia3' 1"
+	]
+
+	DisableSequence [
+		# Keep DP routes up while the HiFi verb is active. PipeWire opens
+		# the PCM before running the target device EnableSequence when
+		# switching between conflicting HDMI devices.
+	]
+
+	Value {
+		PlaybackPriority 100
+		PlaybackPCM "hw:${CardId},2"
+		JackControl "DP1 Jack"
+	}
+}
+
+SectionDevice."HDMI2" {
+	Comment "HDMI playback"
+
+	ConflictingDevice [
+		"HDMI0"
+		"HDMI1"
+	]
+
+	EnableSequence [
+		cset "name='DISPLAY_PORT_RX_2 Audio Mixer MultiMedia4' 1"
+	]
+
+	DisableSequence [
+		# Keep DP routes up while the HiFi verb is active. PipeWire opens
+		# the PCM before running the target device EnableSequence when
+		# switching between conflicting HDMI devices.
+	]
+
+	Value {
+		PlaybackPriority 100
+		PlaybackPCM "hw:${CardId},3"
+		JackControl "DP2 Jack"
+	}
+}
+
+SectionDevice."Headphones" {
+	Comment "Headphones playback"
+
+	Include.wcdhpe.File "/codecs/wcd938x/HeadphoneABEnableSeq.conf"
+	Include.wcdhpd.File "/codecs/wcd938x/HeadphoneDisableSeq.conf"
+	Include.rxmhpe.File "/codecs/qcom-lpass/rx-macro/HeadphoneEnableSeq.conf"
+	Include.rxmhpd.File "/codecs/qcom-lpass/rx-macro/HeadphoneDisableSeq.conf"
+
+	Value {
+		PlaybackPriority 200
+		PlaybackPCM "hw:${CardId},0"
+		PlaybackMixer "default:${CardId}"
+		PlaybackMixerElem "HP"
+		JackControl "Headphone Jack"
+	}
+}
+
+SectionDevice."Headset" {
+	Comment "Headset microphone"
+
+	Include.wcdmice.File "/codecs/wcd938x/HeadphoneMicEnableSeq.conf"
+	Include.wcdmicd.File "/codecs/wcd938x/HeadphoneMicDisableSeq.conf"
+	Include.txmhpe.File "/codecs/qcom-lpass/tx-macro/HeadphoneMicEnableSeq.conf"
+	Include.txmhpd.File "/codecs/qcom-lpass/tx-macro/HeadphoneMicDisableSeq.conf"
+
+	Value {
+		CapturePriority 100
+		CapturePCM "hw:${CardId},4"
+		CaptureMixerElem "ADC2"
+		JackControl "Mic Jack"
+	}
+}

--- a/ucm2/Qualcomm/sc8280xp/Radxa-Dragon-Q8B.conf
+++ b/ucm2/Qualcomm/sc8280xp/Radxa-Dragon-Q8B.conf
@@ -1,0 +1,17 @@
+Syntax 4
+
+SectionUseCase."HiFi" {
+	File "/Qualcomm/sc8280xp/Dragon-Q8B-HiFi.conf"
+	Comment "HiFi quality Music."
+}
+
+BootSequence [
+	cset "name='HPHL Volume' 2"
+	cset "name='HPHR Volume' 2"
+	cset "name='ADC2 Volume' 10"
+]
+
+Include.card-init.File "/lib/card-init.conf"
+Include.ctl-remap.File "/lib/ctl-remap.conf"
+Include.wcd-init.File "/codecs/wcd938x/init.conf"
+Include.rxm-init.File "/codecs/qcom-lpass/rx-macro/init.conf"

--- a/ucm2/Qualcomm/sc8280xp/sc8280xp.conf
+++ b/ucm2/Qualcomm/sc8280xp/sc8280xp.conf
@@ -1,5 +1,7 @@
 Syntax 4
 
+Define.DMI_info "${sys:devices/virtual/dmi/id/board_vendor}-${sys:devices/virtual/dmi/id/product_family}-${sys:devices/virtual/dmi/id/product_name}"
+
 If.LENOVOX13s {
 	Condition {
 		Type RegexMatch
@@ -7,5 +9,13 @@ If.LENOVOX13s {
 		Regex "LENOVO.*ThinkPad X13s.*"
 	}
 	True.Include.x13s.File "/Qualcomm/sc8280xp/LENOVO-X13s.conf"
-	False.Error "SC8280XP - ${sys:devices/virtual/dmi/id/board_vendor}-${sys:devices/virtual/dmi/id/product_family} model not supported"
+}
+
+If.RADXA_DRAGON_Q8B {
+	Condition {
+		Type RegexMatch
+		String "${var:DMI_info}"
+		Regex "^Radxa Computer Co\\., Ltd.-Dragon-Radxa Dragon Q8B$"
+	}
+	True.Include.radxaq8b.File "/Qualcomm/sc8280xp/Radxa-Dragon-Q8B.conf"
 }

--- a/ucm2/codecs/wcd938x/HeadphoneABEnableSeq.conf
+++ b/ucm2/codecs/wcd938x/HeadphoneABEnableSeq.conf
@@ -9,5 +9,6 @@ EnableSequence [
 	cset "name='HPHL_COMP Switch' 0"
 	cset "name='CLSH Switch' 1"
 	cset "name='LO Switch' 1"
-	cset "name='RX HPH Mode' CLS_AB_LOHIFI"
+	cset "name='RX_HPH HD2 Mode Switch' 1"
+	cset "name='RX HPH Mode' CLS_AB_HIFI"
 ]


### PR DESCRIPTION
Radxa Dragon Q8B has 1x HDMI (over DP), 2x DP and Headset(Mic and speakers)
connectors.

This PR adds support for audio over these interfaces.