### PR TITLE
ucm2: Qualcomm: sc8280xp: add DisplayPort devices on X13s

### DIFF
--- a/ucm2/Qualcomm/sc8280xp/HiFi.conf
+++ b/ucm2/Qualcomm/sc8280xp/HiFi.conf
@@ -3,6 +3,8 @@
 
 SectionVerb {
 	EnableSequence [
+		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia1' 0"
+		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia1' 0"
 		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia1' 1"
 		cset "name='WSA_CODEC_DMA_RX_0 Audio Mixer MultiMedia2' 1"
 		cset "name='MultiMedia4 Mixer VA_CODEC_DMA_TX_0' 1"
@@ -35,10 +37,25 @@ SectionDevice."Speaker" {
 SectionDevice."Headphones" {
 	Comment "Headphones playback"
 
+	ConflictingDevice [
+		"HDMI0"
+		"HDMI1"
+	]
+
 	Include.wcdhpe.File "/codecs/wcd938x/HeadphoneABEnableSeq.conf"
 	Include.wcdhpd.File "/codecs/wcd938x/HeadphoneDisableSeq.conf"
 	Include.rxmhpe.File "/codecs/qcom-lpass/rx-macro/HeadphoneEnableSeq.conf"
 	Include.rxmhpd.File "/codecs/qcom-lpass/rx-macro/HeadphoneDisableSeq.conf"
+
+	EnableSequence [
+		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia1' 1"
+		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia1' 0"
+		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia1' 0"
+	]
+
+	DisableSequence [
+		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia1' 0"
+	]
 
 	Value {
 		PlaybackPriority 200
@@ -46,7 +63,6 @@ SectionDevice."Headphones" {
 		PlaybackMixer "default:${CardId}"
 		PlaybackMixerElem "HP"
 		JackControl "Headphone Jack"
-		JackHWMute "Speaker"
 	}
 }
 
@@ -59,11 +75,10 @@ SectionDevice."Headset" {
 	Include.txmhpd.File "/codecs/qcom-lpass/tx-macro/HeadphoneMicDisableSeq.conf"
 
 	Value {
-		CapturePriority 100
+		CapturePriority 200
 		CapturePCM "hw:${CardId},2"
 		CaptureMixerElem "ADC2"
 		JackControl "Mic Jack"
-		JackHWMute "Mic"
 	}
 }
 
@@ -75,9 +90,58 @@ SectionDevice."Mic" {
 	Include.vadm1e.File "/codecs/qcom-lpass/va-macro/DMIC1EnableSeq.conf"
 	Include.vadm1d.File "/codecs/qcom-lpass/va-macro/DMIC1DisableSeq.conf"
 
-
 	Value {
 		CapturePriority 100
 		CapturePCM "hw:${CardId},3"
+	}
+}
+
+SectionDevice."HDMI0" {
+	Comment "USB/DisplayPort 0 playback"
+
+	ConflictingDevice [
+		"Headphones"
+		"HDMI1"
+	]
+
+	EnableSequence [
+		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia1' 0"
+		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia1' 1"
+		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia1' 0"
+	]
+
+	DisableSequence [
+		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia1' 0"
+	]
+
+	Value {
+		PlaybackPriority 200
+		PlaybackPCM "hw:${CardId},0"
+		JackControl "DP0 Jack"
+	}
+}
+
+SectionDevice."HDMI1" {
+	Comment "USB/DisplayPort 1 playback"
+
+	ConflictingDevice [
+		"Headphones"
+		"HDMI0"
+	]
+
+	EnableSequence [
+		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia1' 0"
+		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia1' 0"
+		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia1' 1"
+	]
+
+	DisableSequence [
+		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia1' 0"
+	]
+
+	Value {
+		PlaybackPriority 200
+		PlaybackPCM "hw:${CardId},0"
+		JackControl "DP1 Jack"
 	}
 }


### PR DESCRIPTION
Model HDMI0/HDMI1 after the T14s HiFi layout: same MultiMedia1 frontend as Headphones, explicit RX_CODEC vs DISPLAY_PORT mixer sequences, and ConflictingDevice between Headphones and each DP sink.

Speakers stay on MultiMedia2 and are not part of that conflict, so the WSA path remains in the ACP profile across DP plug/unplug. JackControl is "DP0 Jack" / "DP1 Jack". No JackHWMute on playback; headset vs internal mic is priority-only (200 vs 100).

Compatible with the existing SC8280XP-LENOVO-X13S topology.

Assisted-by: Grok 4.5 (xAI)