### PR TITLE
ucm2: Qualcomm: add Lenovo IdeaCentre Mini 01Q8X10 support

### DIFF
--- a/ucm2/Qualcomm/x1e80100/IdeaCentre-HiFi.conf
+++ b/ucm2/Qualcomm/x1e80100/IdeaCentre-HiFi.conf
@@ -1,0 +1,132 @@
+# Use case configuration for X1E80100.
+# Author: Srinivas Kandagatla <srinivas.kandagatla@linaro.org>
+
+SectionVerb {
+	EnableSequence [
+		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia1' 1"
+		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia5' 1"
+		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia6' 1"
+		cset "name='DISPLAY_PORT_RX_2 Audio Mixer MultiMedia7' 1"
+		cset "name='MultiMedia3 Mixer TX_CODEC_DMA_TX_3' 1"
+	]
+
+	Value {
+		TQ "HiFi"
+	}
+}
+
+SectionDevice."Headphones" {
+	Comment "Headphones playback"
+
+	Include.wcdhpe.File "/codecs/wcd938x/HeadphoneABEnableSeq.conf"
+	Include.wcdhpd.File "/codecs/wcd938x/HeadphoneDisableSeq.conf"
+	Include.rxmhpe.File "/codecs/qcom-lpass/rx-macro/HeadphoneEnableSeq.conf"
+	Include.rxmhpd.File "/codecs/qcom-lpass/rx-macro/HeadphoneDisableSeq.conf"
+
+	EnableSequence [
+		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia1' 1"
+	]
+
+	DisableSequence [
+		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia1' 0"
+	]
+
+	Value {
+		PlaybackPriority 300
+		PlaybackPCM "hw:${CardId},0"
+		PlaybackMixer "default:${CardId}"
+		PlaybackMixerElem "HP"
+		JackControl "Headphone Jack"
+	}
+}
+
+SectionDevice."Headset" {
+	Comment "Headset microphone"
+
+	Include.wcdmice.File "/codecs/wcd938x/HeadphoneMicEnableSeq.conf"
+	Include.wcdmicd.File "/codecs/wcd938x/HeadphoneMicDisableSeq.conf"
+	Include.txmhpe.File "/codecs/qcom-lpass/tx-macro/SoundwireMic1EnableSeq.conf"
+	Include.txmhpd.File "/codecs/qcom-lpass/tx-macro/SoundwireMicDisableSeq.conf"
+
+	Value {
+		CapturePriority 300
+		CapturePCM "hw:${CardId},2"
+		CaptureMixerElem "ADC2"
+		JackControl "Mic Jack"
+	}
+}
+
+SectionDevice."HDMI0" {
+	Comment "USB/DisplayPort 0 playback"
+
+	ConflictingDevice [
+		"HDMI1"
+		"HDMI2"
+	]
+
+	EnableSequence [
+		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia5' 1"
+		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia6' 0"
+		cset "name='DISPLAY_PORT_RX_2 Audio Mixer MultiMedia7' 0"
+	]
+
+	DisableSequence [
+		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia5' 0"
+	]
+
+	Value {
+		PlaybackPriority 200
+		PlaybackPCM "hw:${CardId},4"
+		JackControl "DP0 Jack"
+	}
+}
+
+SectionDevice."HDMI1" {
+	Comment "USB/DisplayPort 1 playback"
+
+	ConflictingDevice [
+		"HDMI0"
+		"HDMI2"
+	]
+
+	EnableSequence [
+		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia5' 0"
+		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia6' 1"
+		cset "name='DISPLAY_PORT_RX_2 Audio Mixer MultiMedia7' 0"
+	]
+
+	DisableSequence [
+		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia6' 0"
+	]
+
+	Value {
+		PlaybackPriority 150
+		PlaybackPCM "hw:${CardId},5"
+		JackControl "DP1 Jack"
+	}
+}
+
+SectionDevice."HDMI2" {
+	Comment "HDMI playback"
+
+	ConflictingDevice [
+		"HDMI0"
+		"HDMI1"
+	]
+
+	EnableSequence [
+		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia5' 0"
+		cset "name='DISPLAY_PORT_RX_1 Audio Mixer MultiMedia6' 0"
+		cset "name='DISPLAY_PORT_RX_2 Audio Mixer MultiMedia7' 1"
+	]
+
+	DisableSequence [
+		cset "name='DISPLAY_PORT_RX_2 Audio Mixer MultiMedia7' 0"
+	]
+
+	Value {
+		PlaybackPriority 100
+		PlaybackPCM "hw:${CardId},6"
+		JackControl "DP2 Jack"
+	}
+}

--- a/ucm2/Qualcomm/x1e80100/LENOVO-IdeaCentre-mini.conf
+++ b/ucm2/Qualcomm/x1e80100/LENOVO-IdeaCentre-mini.conf
@@ -1,0 +1,17 @@
+Syntax 4
+
+SectionUseCase."HiFi" {
+	File "/Qualcomm/x1e80100/IdeaCentre-HiFi.conf"
+	Comment "HiFi quality Music."
+}
+
+BootSequence [
+	cset "name='HPHL Volume' 20"
+	cset "name='HPHR Volume' 20"
+	cset "name='ADC2 Volume' 10"
+]
+
+Include.card-init.File "/lib/card-init.conf"
+Include.ctl-remap.File "/lib/ctl-remap.conf"
+Include.wcd-init.File "/codecs/wcd938x/init.conf"
+Include.rxm-init.File "/codecs/qcom-lpass/rx-macro/init.conf"

--- a/ucm2/Qualcomm/x1e80100/x1e80100.conf
+++ b/ucm2/Qualcomm/x1e80100/x1e80100.conf
@@ -61,3 +61,13 @@ If.HONORMagicBookArt  {
 	}
 	True.Include.magicbook.File "/Qualcomm/x1e80100/X1E80100-CRD.conf"
 }
+
+# 0x WSA Speakers | 0x Microphones | 3x DP/HDMI | 1x WCD Headset
+If.LENOVOMiniX {
+	Condition {
+		Type RegexMatch
+		String "${var:DMI_info}"
+		Regex "IdeaCentre.*Mini.*01Q8X10.*"
+	}
+	True.Include.t14s.File "/Qualcomm/x1e80100/LENOVO-IdeaCentre-mini.conf"
+}


### PR DESCRIPTION
Add UCM for the Lenovo IdeaCentre Mini 01Q8X10 (X1E80100, board 91B6). Hardware present on this card:

  - WCD938x headphones + headset mic
  - three DisplayPort backends
  - no WSA speakers, no built-in mics

Match DMI with IdeaCentre.*Mini.*01Q8X10 and load
LENOVO-IdeaCentre-mini.conf / IdeaCentre-HiFi.conf. Card init only includes WCD and RX-macro; WSA / WSA-macro init is omitted because those codecs are not on the board.

Playback / capture mapping, aligned with the matching AudioReach topology:

  Headphones   hw:${CardId},0   MM1  RX_CODEC_DMA_RX_0
  Headset mic  hw:${CardId},2   MM3  TX_CODEC_DMA_TX_3
  HDMI0        hw:${CardId},4   MM5  DISPLAY_PORT_RX_0   DP0 Jack
  HDMI1        hw:${CardId},5   MM6  DISPLAY_PORT_RX_1   DP1 Jack
  HDMI2        hw:${CardId},6   MM7  DISPLAY_PORT_RX_2   DP2 Jack

Independent MM streams are a workaround for how ALSA UCM and PipeWire / WirePlumber cooperate today. If headset and all three DP ports share one frontend PCM (the T14s-style MM1 mixer switch):

  - UCM must list them as ConflictingDevice
  - WirePlumber instantiates one node per PCM, not per UCM device
  - enabling a DP port tears down the headset path on that PCM
  - jack events become profile switches rather than sink appear / disappear
  - concurrent playback to headset and a monitor is impossible

Giving each DP port its own frontend (MM5/6/7) makes each port a real PCM. PipeWire can then create one sink per port, jack-gated by DP0/DP1/DP2 Jack, while headphones stay on hw:*,0. The verb EnableSequence arms all three DP mixers so unused ports still show up as available sinks when their jack asserts.

Headphones do not conflict with the HDMI devices. HDMI0/1/2 are still marked conflicting with each other only where a single userspace stream must pick one monitor.

Priorities: Headphones/Headset 300, HDMI0 200, HDMI1 150, HDMI2 100, so a plugged headset wins over the first DP port.

Depends on the X1E80100-LENOVO-IdeaCentre-Mini topology change in audioreach-topology. [1]

[1]: https://github.com/linux-msm/audioreach-topology/pull/74

Assisted-by: Grok 4.5 (xAI)