### PR TITLE
ucm2: Qualcomm: Add support for HP OmniBook 5

### DIFF
--- a/ucm2/Qualcomm/x1e80100/x1e80100.conf
+++ b/ucm2/Qualcomm/x1e80100/x1e80100.conf
@@ -7,7 +7,7 @@ If.LENOVOT14s {
 	Condition {
 		Type RegexMatch
 		String "${var:DMI_info}"
-		Regex "LENOVO.*(Think(Pad T14s Gen 6.*|Book 16 G7 QOY)|Ideapad.*5.*)|(HP.*Omnibook X.*)|ASUSTeK COMPUTER.*ASUS (Zenbook A14|Vivobook S 15|Vivobook 16|Vivobook 14)|(Microsoft Corporation.*Surface.*Microsoft Surface Laptop, 7th Edition)"
+		Regex "LENOVO.*(Think(Pad T14s Gen 6.*|Book 16 G7 QOY)|Ideapad.*5.*)|(HP.*Omni(book X|Book 5).*)|ASUSTeK COMPUTER.*ASUS (Zenbook A14|Vivobook S 15|Vivobook 16|Vivobook 14)|(Microsoft Corporation.*Surface.*Microsoft Surface Laptop, 7th Edition)"
 	}
 	True.Include.t14s.File "/Qualcomm/x1e80100/LENOVO-T14s.conf"
 }


### PR DESCRIPTION
Add DMI match for the Purwa-based HP OmniBook 5 Laptop 14-he0xxx. Setup is identical to the existing Omnibook X14 (WCD938x codec, 2x WSA speakers), which is matched in the Lenovo T14s block.